### PR TITLE
fix for optgroups

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -599,8 +599,8 @@ class OptionsParser
       position: @group_index
       children: 0
       disabled: group.disabled
-    this.add_option( option, group_id, group.disabled ) for option in group.childNodes
     @group_index += 1
+    this.add_option( option, group_id, group.disabled ) for option in group.childNodes
 
   add_option: (option, group_id, group_disabled) ->
     if option.nodeName is "OPTION"


### PR DESCRIPTION
It appears that when dealing with optgroups,  the _<index> suffix for element ids isn't being incremented properly and thus lookups in the @results_data variable are failing.

This patch should fix things, let me know what you think.  Thanks for the awesome widget!
