### PR TITLE
Error in Safari when using chosen.jquery

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -151,14 +151,22 @@
       return this.mouse_on_container = false;
     };
     Chosen.prototype.input_focus = function(evt) {
+      var binding;
+      binding = this;
       if (!this.active_field) {
-        return setTimeout(this.container_click.bind(this), 50);
+        return setTimeout((function() {
+          return binding.container_click();
+        }), 50);
       }
     };
     Chosen.prototype.input_blur = function(evt) {
+      var binding;
       if (!this.mouse_on_container) {
         this.active_field = false;
-        return setTimeout(this.blur_test.bind(this), 100);
+        binding = this;
+        return setTimeout((function() {
+          return binding.blur_test();
+        }), 100);
       }
     };
     Chosen.prototype.blur_test = function(evt) {

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -129,12 +129,14 @@ class Chosen
   mouse_leave: -> @mouse_on_container = false
 
   input_focus: (evt) ->
-    setTimeout this.container_click.bind(this), 50 unless @active_field
+    binding = this
+    setTimeout (-> binding.container_click()), 50 unless @active_field
   
   input_blur: (evt) ->
     if not @mouse_on_container
       @active_field = false
-      setTimeout this.blur_test.bind(this), 100
+      binding = this
+      setTimeout (-> binding.blur_test()), 100
 
   blur_test: (evt) ->
     this.close_field() if not @active_field and @container.hasClass "chzn-container-active"


### PR DESCRIPTION
If you open example.jquery.html in Safari when you make a selection in the select box and then click elsewhere on the page and trigger the blur callback you get the following error in the console:

TypeError: Result of expression 'this.blur_test.bind' [undefined] is not a function.

It looks like the jQuery version was using a Prototype.js style function binding in the first argument of the setTimeout, I replaced it with a closure which fixes the error.
