### PR TITLE
Performance improvement on winnow_results

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -459,10 +459,9 @@
       _ref = this.results_data;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         option = _ref[_i];
-        if (searchText == "") {
+        if (searchText === "") {
           found = true;
-        }
-        else {
+        } else {
           if (!option.disabled && !option.empty) {
             if (option.group) {
               $('#' + option.dom_id).hide();

--- a/chosen/chosen.proto.js
+++ b/chosen/chosen.proto.js
@@ -455,23 +455,27 @@
       _ref = this.results_data;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         option = _ref[_i];
-        if (!option.disabled && !option.empty) {
-          if (option.group) {
-            $(option.dom_id).hide();
-          } else if (!(this.is_multiple && option.selected)) {
-            found = false;
-            result_id = option.dom_id;
-            if (regex.test(option.text)) {
-              found = true;
-              results += 1;
-            } else if (option.text.indexOf(" ") >= 0 || option.text.indexOf("[") === 0) {
-              parts = option.text.replace(/\[|\]/g, "").split(" ");
-              if (parts.length) {
-                for (_j = 0, _len2 = parts.length; _j < _len2; _j++) {
-                  part = parts[_j];
-                  if (regex.test(part)) {
-                    found = true;
-                    results += 1;
+        if (searchText === "") {
+          found = true;
+        } else {
+          if (!option.disabled && !option.empty) {
+            if (option.group) {
+              $(option.dom_id).hide();
+            } else if (!(this.is_multiple && option.selected)) {
+              found = false;
+              result_id = option.dom_id;
+              if (regex.test(option.text)) {
+                found = true;
+                results += 1;
+              } else if (option.text.indexOf(" ") >= 0 || option.text.indexOf("[") === 0) {
+                parts = option.text.replace(/\[|\]/g, "").split(" ");
+                if (parts.length) {
+                  for (_j = 0, _len2 = parts.length; _j < _len2; _j++) {
+                    part = parts[_j];
+                    if (regex.test(part)) {
+                      found = true;
+                      results += 1;
+                    }
                   }
                 }
               }

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -406,24 +406,27 @@ class Chosen
     zregex = new RegExp(searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i')
 
     for option in @results_data
-      if not option.disabled and not option.empty
-        if option.group
-          $('#' + option.dom_id).hide()
-        else if not (@is_multiple and option.selected)
-          found = false
-          result_id = option.dom_id
+      if searchText == ""
+        found = true
+      else
+        if not option.disabled and not option.empty
+          if option.group
+            $('#' + option.dom_id).hide()
+          else if not (@is_multiple and option.selected)
+            found = false
+            result_id = option.dom_id
           
-          if regex.test option.text
-            found = true
-            results += 1
-          else if option.text.indexOf(" ") >= 0 or option.text.indexOf("[") == 0
-            #TODO: replace this substitution of /\[\]/ with a list of characters to skip.
-            parts = option.text.replace(/\[|\]/g, "").split(" ")
-            if parts.length
-              for part in parts
-                if regex.test part
-                  found = true
-                  results += 1
+            if regex.test option.text
+              found = true
+              results += 1
+            else if option.text.indexOf(" ") >= 0 or option.text.indexOf("[") == 0
+              #TODO: replace this substitution of /\[\]/ with a list of characters to skip.
+              parts = option.text.replace(/\[|\]/g, "").split(" ")
+              if parts.length
+                for part in parts
+                  if regex.test part
+                    found = true
+                    results += 1
 
           if found
             if searchText.length

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -397,24 +397,27 @@ class Chosen
     zregex = new RegExp(searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i')
 
     for option in @results_data
-      if not option.disabled and not option.empty
-        if option.group
-          $(option.dom_id).hide()
-        else if not (@is_multiple and option.selected)
-          found = false
-          result_id = option.dom_id
+      if searchText == ""
+        found = true
+      else
+        if not option.disabled and not option.empty
+          if option.group
+            $(option.dom_id).hide()
+          else if not (@is_multiple and option.selected)
+            found = false
+            result_id = option.dom_id
           
-          if regex.test option.text
-            found = true
-            results += 1
-          else if option.text.indexOf(" ") >= 0 or option.text.indexOf("[") == 0
-            #TODO: replace this substitution of /\[\]/ with a list of characters to skip.
-            parts = option.text.replace(/\[|\]/g, "").split(" ")
-            if parts.length
-              for part in parts
-                if regex.test part
-                  found = true
-                  results += 1
+            if regex.test option.text
+              found = true
+              results += 1
+            else if option.text.indexOf(" ") >= 0 or option.text.indexOf("[") == 0
+              #TODO: replace this substitution of /\[\]/ with a list of characters to skip.
+              parts = option.text.replace(/\[|\]/g, "").split(" ")
+              if parts.length
+                for part in parts
+                  if regex.test part
+                    found = true
+                    results += 1
 
           if found
             if searchText.length


### PR DESCRIPTION
Hi there,

I’m using chosen on a select box of 700+ options. With so much data the first click on the chosen select box is really slow (it takes 3-4 seconds only to display the chosen select box).

I dug into `winnow_results` and I noticed `searchText` is being tested against a regex in a `for` loop, even if `searchText` is blank. This regex test is fairly expensive when looping against many options.

This commit skips the regex test when `searchText` is blank, which makes for faster loading time on first click.
