### PR TITLE
Dupe examples

### DIFF
--- a/example.html
+++ b/example.html
@@ -288,8 +288,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -537,8 +535,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -789,8 +785,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -1038,8 +1032,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 

--- a/example.jquery.html
+++ b/example.jquery.html
@@ -288,8 +288,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -537,8 +535,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -789,8 +785,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 
@@ -1038,8 +1032,6 @@
           <option value="Uganda">Uganda</option> 
           <option value="Ukraine">Ukraine</option> 
           <option value="United Arab Emirates">United Arab Emirates</option> 
-          <option value="United Kingdom">United Kingdom</option> 
-          <option value="United States">United States</option> 
           <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option> 
           <option value="Uruguay">Uruguay</option> 
           <option value="Uzbekistan">Uzbekistan</option> 


### PR DESCRIPTION
In the examples, United States and United Kingdom appear twice - at the top and alphabetically sorted.
