### PR TITLE
new event: key press

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -599,6 +599,7 @@
       return this.pending_backstroke = null;
     };
     Chosen.prototype.keyup_checker = function(evt) {
+      this.form_field_jq.trigger("keypress");
       var stroke, _ref;
       stroke = (_ref = evt.which) != null ? _ref : evt.keyCode;
       this.search_field_scale();


### PR DESCRIPTION
triggers an event "keypress" which will allow to listen on the event by using:
$("#form_field").chosen().keypress( ... );
