### PR TITLE
Makes it easier to tab through the form fields. By capturing the focusin 

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -88,6 +88,7 @@ class Chosen
 
   register_observers: ->
     @container.click (evt) => this.container_click(evt)
+    @container.focusin (evt) => this.container_click(evt) 
     @container.mouseenter (evt) => this.mouse_enter(evt)
     @container.mouseleave (evt) => this.mouse_leave(evt)
   


### PR DESCRIPTION
Makes it easier to tab through the form fields. By capturing the focusin event and treating like a click, user no longer has to switch to the mouse to activate the dropdown menu.
