### PR TITLE
Ignore leading whitespace in option.html when winnowing results

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -679,7 +679,7 @@
       this.no_results_clear();
       results = 0;
       searchText = this.search_field.val() === this.default_text ? "" : $('<div/>').text($.trim(this.search_field.val())).html();
-      regex = new RegExp('^' + searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i');
+      regex = new RegExp('^\\s*' + searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i');
       zregex = new RegExp(searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i');
       _ref = this.results_data;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -377,7 +377,7 @@ class Chosen extends AbstractChosen
     results = 0
 
     searchText = if @search_field.val() is @default_text then "" else $('<div/>').text($.trim(@search_field.val())).html()
-    regex = new RegExp('^' + searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i')
+    regex = new RegExp('^\\s*' + searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i')
     zregex = new RegExp(searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'i')
 
     for option in @results_data


### PR DESCRIPTION
This change tells Chosen to ignore leading whitespace in option.html when winnowing results.  This fixes broken search behavior for HTML like the following, where the text within the `<option>` nodes is formatted for readability:

```
    <select name="state" multiple="multiple">
      <option value="AL">
        Alabama
      </option>
      <option value="AK">
        Alaska
      </option>
    </select>
```

Currently, Chosen will return zero or unexpected results when the user types "a" into the search box, because the search regex `/^a/i` does not match against the HTML `\n      Alabama\n`.  With this change, the regex becomes `/^\s*a/i` which does match.

Since the behavior of HTML renderers is to ignore leading whitespace like in the above, I think Chosen should do the same.
