### PR TITLE
Keep javascript:void links from triggering onbeforeunload in IE

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -72,9 +72,6 @@
         container_div.html('<ul class="chzn-choices"><li class="search-field"><input type="text" value="' + this.default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chzn-drop" style="left:-9000px;"><ul class="chzn-results"></ul></div>');
       } else {
         container_div.html('<a href="javascript:void(0)" class="chzn-single"><span>' + this.default_text + '</span><div><b></b></div></a><div class="chzn-drop" style="left:-9000px;"><div class="chzn-search"><input type="text" autocomplete="off" /></div><ul class="chzn-results"></ul></div>');
-        $('a', container_div).click(function (evt) {
-          evt.preventDefault();
-        });
       }
       this.form_field_jq.hide().after(container_div);
       this.container = $('#' + this.container_id);

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -60,6 +60,8 @@ class Chosen
       container_div.html '<ul class="chzn-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chzn-drop" style="left:-9000px;"><ul class="chzn-results"></ul></div>'
     else
       container_div.html '<a href="javascript:void(0)" class="chzn-single"><span>' + @default_text + '</span><div><b></b></div></a><div class="chzn-drop" style="left:-9000px;"><div class="chzn-search"><input type="text" autocomplete="off" /></div><ul class="chzn-results"></ul></div>'
+      $("a", container_div).click (evt) ->
+        evt.preventDefault()
 
     @form_field_jq.hide().after container_div
     @container = ($ '#' + @container_id)


### PR DESCRIPTION
Hi, and thanks for making chosen!

If you use some kind of dirtyforms plugin, clicking on Chosen UI elements will cause the "leave page" handling code to be called.

This is because, apparently, links to javascript:void will trigger the onbeforeunload event in at least IE 6, 7 and 8.

I'm not sure what the Microsoft rationale is for this behavior :) but here's a quick fix (for jquery, doesn't break anything).

btw here's yeat another pretty example of the chosen forms:  http://spendet.org/losgehts.html

Carlo
