### PR TITLE
fix so it doesn't explode on empty selects with allow_single_deselects

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -113,7 +113,7 @@
       this.results_showing = false;
       this.result_highlighted = null;
       this.result_single_selected = null;
-      this.allow_single_deselect = (this.options.allow_single_deselect != null) && this.form_field.options[0] && this.form_field.options[0].text === "" ? this.options.allow_single_deselect : false;
+      this.allow_single_deselect = (this.options.allow_single_deselect != null) && this.form_field.options[0].text === "" ? this.options.allow_single_deselect : false;
       this.disable_search_threshold = this.options.disable_search_threshold || 0;
       this.choices = 0;
       return this.results_none_found = this.options.no_results_text || "No results match";


### PR DESCRIPTION
right now if you enable allow_single_deselects it will error out if there is a select with no options, this fixes it
