### PR TITLE
Propagation of focus event from the original select to chosen

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -82,6 +82,7 @@ class Chosen extends AbstractChosen
     @search_results.mouseout (evt) => this.search_results_mouseout(evt)
 
     @form_field_jq.bind "liszt:updated", (evt) => this.results_update_field(evt)
+    @form_field_jq.focus (evt) => this.input_focus(evt)
 
     @search_field.blur (evt) => this.input_blur(evt)
     @search_field.keyup (evt) => this.keyup_checker(evt)


### PR DESCRIPTION
This relates to PR #240, but I changed the .coffee file instead of the .js file. I think it's handy to have the focus event from the original select propagate to chosen.

This also prevents a nasty problem I encountered when using HTML5 validation attributes (i.e., required) on a select later turned into a chosen field. If the user tries to submit the form with no value selected in the field, the submit will just silently do nothing, because the browser can't focus the select field as it's hidden.
