### PR TITLE
Inherit classes from original element

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -275,9 +275,10 @@
       this.container_id += "_chzn";
       this.f_width = this.form_field_jq.outerWidth();
       this.default_text = this.form_field_jq.data('placeholder') ? this.form_field_jq.data('placeholder') : this.default_text_default;
+      this.container_classes = this.form_field_jq.attr('class');
       container_div = $("<div />", {
         id: this.container_id,
-        "class": "chzn-container" + (this.is_rtl ? ' chzn-rtl' : ''),
+        "class": "chzn-container " + this.container_classes + (this.is_rtl ? ' chzn-rtl' : ''),
         style: 'width: ' + this.f_width + 'px;'
       });
       if (this.is_multiple) {


### PR DESCRIPTION
As requested in this issue: https://github.com/harvesthq/chosen/issues/209 this commit makes the chosen container inherit the classes from the original select element.

This is done in the jQuery version only, sorry. Prototype isn't my strong suit.. =) 

Also, I wan't sure which minification algorithm so I didn't..
