### PR TITLE
Propagate focus event to focus on the control. could be useful when doing form validation :)

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -82,6 +82,7 @@ class Chosen extends AbstractChosen
     @search_results.mouseout (evt) => this.search_results_mouseout(evt)
 
     @form_field_jq.bind "liszt:updated", (evt) => this.results_update_field(evt)
+    @form_field_jq.focus (evt) => this.input_focus(evt)
 
     @search_field.blur (evt) => this.input_blur(evt)
     @search_field.keyup (evt) => this.keyup_checker(evt)


### PR DESCRIPTION
I've added this before, but on js file, now i have edited the coffe file 
