### PR TITLE
Adding CakePHP plugin reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ If you're interested, you can find the recipes in Cakefile.
 
 - [Chosen for MooTools](https://github.com/julesjanssen/chosen), by Jules Janssen
 - [Chosen Drupal 7 Module](http://drupal.org/project/chosen), by Pol Dell'Aiera, Arshad Chummun, Bart Feenstra, Kálmán Hosszu, etc.
+- [Chosen CakePHP Plugin](https://github.com/paulredmond/chosen-cakephp), by Paul Redmond


### PR DESCRIPTION
Hey Harvest team!

I have a Chosen CakePHP plugin for CakePHP 1.3x and 2.0 that I would love to add to the list of forks. Chosen has been a real treat to add to my dynamic forms in CakePHP. Thanks for such an awesome project!

You can browse the repository here: https://github.com/paulredmond/chosen-cakephp
