### PR TITLE
Don't stop mouse event propagation if results are showing. 

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -106,7 +106,7 @@ class Chosen extends AbstractChosen
   container_mousedown: (evt) ->
     if !@is_disabled
       target_closelink =  if evt? then ($ evt.target).hasClass "search-choice-close" else false
-      if evt and evt.type is "mousedown"
+      if evt and evt.type is "mousedown" and not @results_showing
         evt.stopPropagation()
       if not @pending_destroy_click and not target_closelink
         if not @active_field

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -99,7 +99,7 @@ class Chosen extends AbstractChosen
   container_mousedown: (evt) ->
     if !@is_disabled
       target_closelink =  if evt? then evt.target.hasClassName "search-choice-close" else false
-      if evt and evt.type is "mousedown"
+      if evt and evt.type is "mousedown" and not @results_showing
         evt.stop()
       if not @pending_destroy_click and not target_closelink
         if not @active_field


### PR DESCRIPTION
Otherwise, when you open the chosen dialog, text in the search input cannot be selected with the mouse.
