### PR TITLE
Fixes for gradients and Right to Left support

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -193,8 +193,6 @@
   padding: 3px 20px 3px 5px;
   margin: 3px 0 3px 5px;
   position: relative;
-}
-.chzn-container-multi .chzn-choices .search-choice span {
   cursor: default;
 }
 .chzn-container-multi .chzn-choices .search-choice-focus {


### PR DESCRIPTION
Here are some CSS fixes that mostly fix things in Internet Explorer and Opera.
## Gradient fixes:
- Some of the gradients were configured from top to bottom, and some from bottom to top. I changed so that now all gradients go from top to bottom. I used Colorzilla's "Ultimate CSS Gradient Generator" to reverse the direction of gradients.
- Fixed IE gradient filters that were configured to start with the bottom color instead of top, and did not work correctly in IE. Now filters are in line with other gradients.
## RTL fixes:
- In IE8 there is a bug where left border disappears in elements that have direction: rtl. Fixed this with being more specific on which elements get direction: rtl. Search input still has this bug in IE8 since it has border and has to be rtl.
- Added overflow: visible, so that IE8 does not cut off part of the last character in rtl single select.
- Fixed fallback "background" declaration for rtl
- Fix no results text positioning for rtl in all browsers
## Multiple Select "cursor: default" fix in .search-choice:
- Multiple Select search choices were showing a "text" cursor instead of "default" when hovering over the gap between "x" and the span with text.

I have tested these changes in newest stable versions of IE, Safari, FF, Opera and Chrome, + IE8 and FF 3.6
