### PR TITLE
Stop IE 8 from calling onbeforeunload when clicking on a chosen field

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -159,6 +159,7 @@ class Chosen extends AbstractChosen
 
 
   test_active_click: (evt) ->
+    evt.preventDefault()
     if $(evt.target).parents('#' + @container_id).length
       @active_field = true
     else


### PR DESCRIPTION
I came across an issue which may affect others in the future.

When executing the test_active_click callback, the event should be canceled of default browser behavior with evt.preventDefault();

The reason being that if you are using onbeforeunload for something in IE 8 clicking on a chosen field counts as a link click for some reason and executes the onbeforeunload callback even though you are not leaving the page.
