### PR TITLE
Fixing bug related to choice destroy click.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -300,6 +300,8 @@ class Chosen extends AbstractChosen
     if not @is_disabled
       @pending_destroy_click = true
       this.choice_destroy $(evt.target)
+      this.input_blur(evt)
+      @pending_destroy_click = false
     else
       evt.stopPropagation
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -24,6 +24,7 @@ class AbstractChosen
     @activate_action = (evt) => this.activate_field(evt)
     @active_field = false
     @mouse_on_container = false
+    @pending_destroy_click = false
     @results_showing = false
     @result_highlighted = null
     @result_single_selected = null
@@ -40,7 +41,7 @@ class AbstractChosen
     setTimeout (=> this.container_mousedown()), 50 unless @active_field
   
   input_blur: (evt) ->
-    if not @mouse_on_container
+    if not @mouse_on_container or @pending_destroy_click
       @active_field = false
       setTimeout (=> this.blur_test()), 100
 


### PR DESCRIPTION
This particular issue was tricky to debug, but essentially there was
an issue with clicking to destroy a choice in the multi select.

The current bug can be reproduced by following the steps here:
https://github.com/harvesthq/chosen/issues/346

I tried to solve it by forcing the field to blur after the choice
delete link was clicked.  However, there was a race condition
involving @pending_destroy_click, container's mouseup event, and the
destroy link's click event.
