### PR TITLE
Search matches optgroup

### DIFF
--- a/example.jquery.html
+++ b/example.jquery.html
@@ -9,29 +9,29 @@
     a img {border: none;}
     ol li {list-style: decimal outside;}
     fieldset {border:0;padding:0;}
-    
+
     body { font-family: sans-serif; font-size: 1em; }
-    
+
     div#container { width: 780px; margin: 0 auto; padding: 1em 0;  }
     p { margin: 1em 0; max-width: 700px; }
     h1 + p { margin-top: 0; }
-    
+
     h1, h2 { font-family: Georgia, Times, serif; }
     h1 { font-size: 2em; margin-bottom: .75em; }
     h2 { font-size: 1.5em; margin: 2.5em 0 .5em; border-bottom: 1px solid #999; padding-bottom: 5px; }
     h3 { font-weight: bold; }
-    
+
     ul li { list-style: disc; margin-left: 1em; }
     ol li { margin-left: 1.25em; }
-    
+
     div.side-by-side { width: 100%; margin-bottom: 1em; }
     div.side-by-side > div { float: left; width: 50%; }
     div.side-by-side > div > em { margin-bottom: 10px; display: block; }
-    
+
     a { color: orange; text-decoration: underline; }
-    
+
     .faqs em { display: block; }
-    
+
     .clearfix:after {
       content: "\0020";
       display: block;
@@ -40,7 +40,7 @@
       overflow: hidden;
       visibility: hidden;
     }
-    
+
     footer {
       margin-top: 2em;
       border-top: 1px solid #666;
@@ -54,7 +54,7 @@
   <div id="container">
     <h1>Chosen</h1>
     <p>Chosen is a JavaScript plugin for Prototype and jQuery that makes long, unwieldy select boxes much more user-friendly. For more information (including usage, explanation and faqs), check out the <a href="http://harvesthq.github.com/chosen/">online documentation</a>.</p>
-    
+
     <h2>Standard Select</h2>
     <div class="side-by-side clearfix">
       <div>
@@ -556,7 +556,7 @@
         </select>
       </div>
     </div>
-    
+
     <h2>Multiple Select</h2>
     <div class="side-by-side clearfix">
       <div>
@@ -1057,7 +1057,7 @@
         </select>
       </div>
     </div>
-    
+
     <h2>&lt;optgroup&gt; Support</h2>
     <div class="side-by-side clearfix">
       <div>
@@ -1209,7 +1209,7 @@
       <code>&lt;select <strong>data-placeholder="Choose a country..."</strong> style="width:350px;" multiple class="chzn-select"&gt;</code>
       <p><strong>Note:</strong> on single selects, the first element is assumed to be selected by the browser. To take advantage of the default text support, you will need to include a blank option as the first element of your select list.</p>
     </div>
-    
+
     <h2>No Results Text Support</h2>
     <div class="side-by-side clearfix">
       <p>Setting the "No results" search text is as easy as passing an option when you create Chosen:</p>
@@ -1217,7 +1217,7 @@
         $(".chzn-select").chosen({no_results_text: "No results matched"});
       </code>
     </div>
-    
+
     <h2>Allow Deselect on Single Selects</h2>
     <div class="side-by-side clearfix">
       <p>When a single select box isn't a required field, you can set <code>allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
@@ -1293,10 +1293,10 @@
       <li>Activate the plugin on the select boxes of your choice: <code>$(".chzn-select").chosen()</code></li>
       <li><a href="http://youtu.be/pS-RsIzb78U?t=57s">Disco</a>.</li>
     </ol>
-    
+
   </div>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js" type="text/javascript"></script>
   <script src="chosen/chosen.jquery.js" type="text/javascript"></script>
-  <script type="text/javascript"> $(".chzn-select").chosen(); $(".chzn-select-deselect").chosen({allow_single_deselect:true}); </script>
+  <script type="text/javascript"> $(".chzn-select").chosen({allow_optgroup_search:true}); $(".chzn-select-deselect").chosen({allow_single_deselect:true}); </script>
   </form>
 </body>


### PR DESCRIPTION
This addition will allow to have search/filter match on 'optgroup' as
well. This way if the group label contains characters of search/filter,
show all 'options' in that 'optgroup'.

This is used as an option in the chosen object, by default it should
not search for optgroup. If you want to enable it, use the
allow_optgroup_search flag and set it to true. Example attached as well.
