### PR TITLE
Add -webkit-overflow-scrolling: touch for iOS5

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -227,6 +227,7 @@
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .chzn-container-multi .chzn-results {
   margin: -1px 0 0;


### PR DESCRIPTION
This enables native scrolling and makes scrolling much smoother in iOS5 Mobile Safari.

I've tested it with iPad / iOS 5.1
