### PR TITLE
Fixing Cakefile to not use reserved word 'package'

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -98,9 +98,9 @@ task 'watch', 'watch coffee/ for changes and build Chosen', ->
 task 'package_npm', 'generate the package.json file for npm', package_npm = (cb) ->
   try
     package_file = 'package.json'
-    package = JSON.parse("#{fs.readFileSync package_file}")
-    package['version'] = version()
-    fs.writeFileSync package_file, JSON.stringify(package, null, 2)
+    package_obj = JSON.parse("#{fs.readFileSync package_file}")
+    package_obj['version'] = version()
+    fs.writeFileSync package_file, JSON.stringify(package_obj, null, 2)
     console.log "Wrote #{package_file}"
     cb() if typeof cb is 'function'
   catch e


### PR DESCRIPTION
I don't know when the change occurred, but `package` is now apparently a reserved word in node.js (I have v0.6.15).
