### PR TITLE
Implement handling of options that are both disabled AND selected

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -198,6 +198,19 @@
   position: relative;
   cursor: default;
 }
+.chzn-container-multi .chzn-choices .search-choice.search-choice-disabled {
+  background-color: #e4e4e4;
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f4f4f4', endColorstr='#eeeeee', GradientType=0 );
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(20%, #f4f4f4), color-stop(50%, #f0f0f0), color-stop(52%, #e8e8e8), color-stop(100%, #eeeeee));
+  background-image: -webkit-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+  background-image: -moz-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+  background-image: -o-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+  background-image: -ms-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+  background-image: linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+  color: #666;
+  border: 1px solid #cccccc;
+  padding-right: 5px;
+}
 .chzn-container-multi .chzn-choices .search-choice-focus {
   background: #d4d4d4;
 }

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -298,13 +298,18 @@ class Chosen extends AbstractChosen
       return false # fire event
     choice_id = @container_id + "_c_" + item.array_index
     @choices += 1
-    @search_container.before  '<li class="search-choice" id="' + choice_id + '"><span>' + item.html + '</span><a href="javascript:void(0)" class="search-choice-close" rel="' + item.array_index + '"></a></li>'
+    if item.disabled
+      html = '<li class="search-choice search-choice-disabled" id="' + choice_id + '"><span>' + item.html + '</span></li>'
+    else
+      html = '<li class="search-choice" id="' + choice_id + '"><span>' + item.html + '</span><a href="javascript:void(0)" class="search-choice-close" rel="' + item.array_index + '"></a></li>'
+    @search_container.before  html
     link = $('#' + choice_id).find("a").first()
     link.click (evt) => this.choice_destroy_link_click(evt)
 
   choice_destroy_link_click: (evt) ->
     evt.preventDefault()
-    if not @is_disabled
+    result_data = @results_data[$(evt.target).attr "rel"]
+    if not @is_disabled and not result_data.disabled
       @pending_destroy_click = true
       this.choice_destroy $(evt.target)
     else
@@ -492,7 +497,7 @@ class Chosen extends AbstractChosen
       this.choice_destroy @pending_backstroke.find("a").first()
       this.clear_backstroke()
     else
-      @pending_backstroke = @search_container.siblings("li.search-choice").last()
+      @pending_backstroke = @search_container.siblings("li.search-choice:not(.search-choice-disabled)").last()
       @pending_backstroke.addClass "search-choice-focus"
 
   clear_backstroke: ->

--- a/example.jquery.html
+++ b/example.jquery.html
@@ -1203,6 +1203,24 @@
       </div>
     </div>
 
+    <div class="side-by-side clearfix">
+      <p>It is also possible to prevent selected options being deselected by also making them disabled.</p>
+      <div>
+        <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chzn-select" id="test_me_paddington" name="test_me_form" tabindex="8">
+          <option value=""></option>
+          <option>American Black Bear</option>
+          <option>Asiatic Black Bear</option>
+          <option>Brown Bear</option>
+          <option>Giant Panda</option>
+          <option selected>Sloth Bear</option>
+          <option disabled>Sun Bear</option>
+          <option selected disabled>Paddington Bear</option>
+          <option selected>Polar Bear</option>
+          <option disabled>Spectacled Bear</option>
+        </select>
+      </div>
+    </div>
+
     <h2>Default Text Support</h2>
     <div class="side-by-side clearfix">
       <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select Some Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>

--- a/example.proto.html
+++ b/example.proto.html
@@ -1202,6 +1202,24 @@
       </div>
     </div>
 
+    <div class="side-by-side clearfix">
+      <p>It is also possible to prevent selected options being deselected by also making them disabled.</p>
+      <div>
+        <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chzn-select" id="test_me_paddington" name="test_me_form" tabindex="8">
+          <option value=""></option>
+          <option>American Black Bear</option>
+          <option>Asiatic Black Bear</option>
+          <option>Brown Bear</option>
+          <option>Giant Panda</option>
+          <option selected>Sloth Bear</option>
+          <option disabled>Sun Bear</option>
+          <option selected disabled>Paddington Bear</option>
+          <option selected>Polar Bear</option>
+          <option disabled>Spectacled Bear</option>
+        </select>
+      </div>
+    </div>
+
     <h2>Default Text Support</h2>
     <div class="side-by-side clearfix">
       <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select Some Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>


### PR DESCRIPTION
Allows Chosen to deal with items that are both disabled and selected (i.e. should show as selected but should not be deselectable). See also #516 and #586.

These changes include:
- Different class/styling on the disabled item
- Removal of the "x" link on the disabled item
- Tweaks to backspace-handling, to ignore disabled items
- An inadvertent fix for the Prototype code (see below)
- Update to the example files

This change does **not** update the compiled files, as I appear to have a different version of coffeescript (or different options), and didn't want to create needless changeset noise. This can be updated, however.
#### Prototype fix

I noticed that in `keydown_backstroke` (around line 490), it was calling:

```
@pending_backstroke = @search_container.siblings("li.search-choice").last()
```

but Prototype does not accept a selector argument to `siblings()`, so this was doing nothing. In order to replicate the functionality from jQuery, it would have to be something like:

```
@pending_backstroke = @search_container.siblings().accept( (x) -> x.x.hasClassName("search-choice") ).last()
```

with an additional tag name check. In any event, I updated the code to use:

```
@pending_backstroke = @search_container.siblings().reject( (x) -> x.hasClassName("search-choice-disabled") ).last()
```

as I needed to exclude disabled items, and it appeared to be doing the right thing anyway.
