### PR TITLE
Fix reselecting option doesn't trigger 'change' event.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -322,6 +322,7 @@ class Chosen extends AbstractChosen
 
   results_reset: ->
     @form_field.options[0].selected = true
+    @current_value = @form_field_jq.val()
     @selected_item.find("span").text @default_text
     @selected_item.addClass("chzn-default") if not @is_multiple
     this.show_search_field_default()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -314,6 +314,7 @@ class Chosen extends AbstractChosen
 
   results_reset: ->
     @form_field.options[0].selected = true
+    @current_value = @form_field.value
     @selected_item.down("span").update(@default_text)
     @selected_item.addClassName("chzn-default") if not @is_multiple
     this.show_search_field_default()


### PR DESCRIPTION
This fixes a bug where the 'change' event isn't triggered if you reselect the same option after clearing it.

Reproduce the bug:
1. Have an instance with {allow_single_deselect: true} set.
2. Have some JS listening for the 'change' event on the <select>
3. Select an option. (change event triggers)
4. Click the 'x' to clear selection. (change event triggers)
5. Select the same option again. (change event doesn't trigger)
