### PR TITLE
a small layout fix

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -19,6 +19,10 @@
   box-shadow        : 0 4px 5px rgba(0,0,0,.15);
   z-index: 1010;
 }
+
+.chzn-container .chzn-drop.chzn-hidden {
+    display: none;
+}
 /* @end */
 
 /* @group Single Chosen */

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -40,7 +40,7 @@ class Chosen extends AbstractChosen
     if @is_multiple
       container_div.html '<ul class="chzn-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chzn-drop" style="left:-9000px;"><ul class="chzn-results"></ul></div>'
     else
-      container_div.html '<a href="javascript:void(0)" class="chzn-single chzn-default"><span>' + @default_text + '</span><div><b></b></div></a><div class="chzn-drop" style="left:-9000px;"><div class="chzn-search"><input type="text" autocomplete="off" /></div><ul class="chzn-results"></ul></div>'
+      container_div.html '<a href="javascript:void(0)" class="chzn-single chzn-default"><span>' + @default_text + '</span><div><b></b></div></a><div class="chzn-drop chzn-hidden" style="left:-9000px;"><div class="chzn-search"><input type="text" autocomplete="off" /></div><ul class="chzn-results"></ul></div>'
 
     @form_field_jq.hide().after container_div
     @container = ($ '#' + @container_id)
@@ -240,6 +240,7 @@ class Chosen extends AbstractChosen
     dd_top = if @is_multiple then @container.height() else (@container.height() - 1)
     @form_field_jq.trigger("liszt:showing_dropdown", {chosen: this})
     @dropdown.css {"top":  dd_top + "px", "left":0}
+    @dropdown.removeClass "chzn-hidden"
     @results_showing = true
 
     @search_field.focus()
@@ -252,6 +253,7 @@ class Chosen extends AbstractChosen
     this.result_clear_highlight()
     @form_field_jq.trigger("liszt:hiding_dropdown", {chosen: this})
     @dropdown.css {"left":"-9000px"}
+    @dropdown.addClass "chzn-hidden"
     @results_showing = false
 
 


### PR DESCRIPTION
Even if drop part is not visible it still is a part of layout and causes unnecessary scrollbars.

When using css sticky footer layout, `#main` element has `overflow: auto;` and having a semi-long chosen causes `#main` to show scrollbar for no "apparent" reason
