### PR TITLE
Prototype implementation uses @results_none_found before it is set

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -7,10 +7,9 @@ root = this
 class AbstractChosen
 
   constructor: (@form_field, @options={}) ->
-    this.set_default_values()
-    
     @is_multiple = @form_field.multiple
     this.set_default_text()
+    this.set_default_values()
 
     this.setup()
 


### PR DESCRIPTION
In the AbstractChosen constructor, set_default_values() is called before set_default_text(). But in the prototype implementation of Chosen, the extended set_default_values() uses @results_none_found, which is set in set_default_text(). Because of this, @results_none_found is undefined when used, and the string 'undefined' is displayed to the end user.
