### PR TITLE
Fix IE bug in quirks mode when working with large datasets

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -226,6 +226,8 @@
 .chzn-container .chzn-results {
   margin: 0 4px 4px 0;
   max-height: 240px;
+  /* IE Hack */
+  height: expression(this.scrollHeight > 240 ? "240px" : "auto");
   padding: 0 0 0 4px;
   position: relative;
   overflow-x: hidden;


### PR DESCRIPTION
When a dropdown box contains a lot of items, the browser viewport becomes to large, as max-height is not supported. Added an expression as IE hack.
