### PR TITLE
Add CSS-only shadow-scrolling effect

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -238,6 +238,38 @@
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  /* stolen from http://lea.verou.me/2012/04/background-attachment-local/ */
+  background:
+    -moz-linear-gradient(white 30%, rgba(255,255,255,0)),
+    -moz-linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+    -moz-radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+    -moz-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+  background:
+    -webkit-linear-gradient(white 30%, rgba(255,255,255,0)),
+    -webkit-linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+    -webkit-radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+    -webkit-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+  background:
+    -ms-linear-gradient(white 30%, rgba(255,255,255,0)),
+    -ms-linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+    -ms-radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+    -ms-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+  background:
+    -o-linear-gradient(white 30%, rgba(255,255,255,0)),
+    -o-linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+    -o-radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+    -o-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+  background:
+    linear-gradient(white 30%, rgba(255,255,255,0)),
+    linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+    radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+    radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+  background-repeat: no-repeat;
+  background-color: white;
+  background-size: 100% 40px, 100% 40px, 100% 4px, 100% 4px;
+
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
 }
 .chzn-container-multi .chzn-results {
   margin: -1px 0 0;


### PR DESCRIPTION
Based on @leaverou's [blog post](http://lea.verou.me/2012/04/background-attachment-local/).

Makes nice-looking scrolling shadows, which degrade gracefully:

![While on top](https://img.skitch.com/20120928-bhqkqt2itjwr6t8sre724f7g1j.png) ![While on bottom](https://img.skitch.com/20120928-rkqkxm7w8u4wp8mb34g4khm9u.png)
