### PR TITLE
Results of dropdowns should be forced to 1 line.

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -244,6 +244,8 @@
   padding: 0;
 }
 .chzn-container .chzn-results li {
+  float: left; 
+  clear: left;
   display: none;
   line-height: 15px;
   padding: 5px 6px;


### PR DESCRIPTION
An example of what i've come across is below...

Desired results (of a dropdown): 

January 1
February 1
March 1
April 1
May 1
June 1
July 1
August 1
September 1
October 1
November 1
December 1

Actual Results: 

January 1
February 1
March 1 
April 1 May 1 <----
June 1
July 1
August 1
September 1
October 1
November 1
December 1

Since the width is being set by the largest element, if there are smaller ones in the list, they are wrapping incorrectly (in all browsers). Adding float: left; clear: left; is forcing every item to be on its own line. Confirmed to work in IE8+, IE7 falls back to the default selects anyway.
