### PR TITLE
Emberjs <script> wrappers break chosen search

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -805,7 +805,7 @@ Copyright (c) 2011 by Harvest
             found = false;
             result_id = option.dom_id;
             result = $("#" + result_id);
-            if (regex.test(option.html)) {
+            if (regex.test(option.html) || regex.test(option.text)) {
               found = true;
               results += 1;
             } else if (option.html.indexOf(" ") >= 0 || option.html.indexOf("[") === 0) {

--- a/chosen/chosen.proto.js
+++ b/chosen/chosen.proto.js
@@ -795,7 +795,7 @@ Copyright (c) 2011 by Harvest
           } else if (!(this.is_multiple && option.selected)) {
             found = false;
             result_id = option.dom_id;
-            if (regex.test(option.html)) {
+            if (regex.test(option.html) || regex.test(option.text)) {
               found = true;
               results += 1;
             } else if (option.html.indexOf(" ") >= 0 || option.html.indexOf("[") === 0) {

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -413,7 +413,7 @@ class Chosen extends AbstractChosen
           result_id = option.dom_id
           result = $("#" + result_id)
 
-          if regex.test option.html
+          if regex.test option.html or regex.test option.text
             found = true
             results += 1
           else if option.html.indexOf(" ") >= 0 or option.html.indexOf("[") == 0

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -398,7 +398,7 @@ class Chosen extends AbstractChosen
           found = false
           result_id = option.dom_id
           
-          if regex.test option.html
+          if regex.test option.html or regex.test option.text
             found = true
             results += 1
           else if option.html.indexOf(" ") >= 0 or option.html.indexOf("[") == 0


### PR DESCRIPTION
Emberjs wraps bindable dom elements with script tag and chosen search regex seems unable to match html content with script in it.

I made a quick 'n dirty patch to make it work. Let me know if there's a smarter way to fix it.
