### PR TITLE
Placeholder Text Clipping Bug

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -317,6 +317,7 @@ class Chosen extends AbstractChosen
       this.results_hide() if @is_multiple and @choices > 0 and @search_field.val().length < 1
 
       link.parents('li').first().remove()
+      this.search_field_scale()
 
   results_reset: ->
     @form_field.options[0].selected = true


### PR DESCRIPTION
Fix issue where removing all entries from a multiple select can cause the placeholder input text to be clipped.
 - Resize the search field when a choice is destroyed
