### PR TITLE
Define box-sizing in Chosen scope to prevent conflicts

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -18,6 +18,9 @@
   box-shadow        : 0 4px 5px rgba(0,0,0,.15);
   z-index: 1010;
 }
+.chzn-container * {
+    box-sizing: content-box;
+}
 /* @end */
 
 /* @group Single Chosen */


### PR DESCRIPTION
Chosen is entirely built on the premise that the current box-sizing model used is the default `content-box`. This is not a problem in itself, but more and more people start to use things like:

``` css
* {
  box-sizing: border-box;
}
```

...wich, as of now, completely breaks Chosen because all the width/height/padding/border calculations are based on a `content-box` model.

Using the `border-box` box-sizing is especially useful when dealing with responsive designs.

We can prevent Chosen from breaking simply by defining the box-sizing to use in the Chosen scope, wich only requires 1 line of code (3 in this pull request to stay coherent with the current code style).
