### PR TITLE
jQuery 1.9 - $.browser removed

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -9,12 +9,7 @@ $.fn.extend({
   chosen: (options) ->
     ua = navigator.userAgent.toLowerCase();
 
-    match = /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
-      /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
-      /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
-      /(msie) ([\w.]+)/.exec( ua ) ||
-      ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
-      [];
+    match = /(msie) ([\w.]+)/.exec( ua ) || [];
     
     browser =
       name: match[ 1 ] || ""
@@ -22,7 +17,7 @@ $.fn.extend({
       
     # Do no harm and return as soon as possible for unsupported browsers, namely IE6 and IE7
     # Continue on if running IE document type but in compatibility mode
-    return this if browser.name.msie and (browser.version is "6.0" or  (browser.version is "7.0" and document.documentMode is 7 ))
+    return this if browser.name is "msie" and (browser.version is "6.0" or  (browser.version is "7.0" and document.documentMode is 7 ))
     this.each((input_field) ->
       $this = $ this
       $this.data('chosen', new Chosen(this, options)) unless $this.hasClass "chzn-done"


### PR DESCRIPTION
When I tested the latest beta of jQuery the chosen plugin throws an error. Since jQuery 1.9 has removed $.browser I added the user agent sniffing.
