### PR TITLE
IE7 compatibility for prototype.js version of Chosen single select

### DIFF
--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -123,7 +123,7 @@ class Chosen extends AbstractChosen
         @pending_destroy_click = false
 
   container_mouseup: (evt) ->
-    this.results_reset(evt) if evt.target.nodeName is "ABBR" and not @is_disabled
+    this.results_reset(evt) if $(evt.target).nodeName is "ABBR" and not @is_disabled
 
   blur_test: (evt) ->
     this.close_field() if not @active_field and @container.hasClassName("chzn-container-active")
@@ -149,7 +149,7 @@ class Chosen extends AbstractChosen
     @search_field.focus()
 
   test_active_click: (evt) ->
-    if evt.target.up('#' + @container_id)
+    if $(evt.target).up('#' + @container_id)
       @active_field = true
     else
       this.close_field()
@@ -259,23 +259,23 @@ class Chosen extends AbstractChosen
       @search_field.removeClassName "default"
 
   search_results_mouseup: (evt) ->
-    target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
+    target = if $(evt.target).hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     if target
       @result_highlight = target
       this.result_select(evt)
       @search_field.focus()
 
   search_results_mouseover: (evt) ->
-    target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
+    target = if $(evt.target).hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     this.result_do_highlight( target ) if target
 
   search_results_mouseout: (evt) ->
-    this.result_clear_highlight() if evt.target.hasClassName('active-result') or evt.target.up('.active-result')
+    this.result_clear_highlight() if $(evt.target).hasClassName('active-result') or evt.target.up('.active-result')
 
 
   choices_click: (evt) ->
     evt.preventDefault()
-    if( @active_field and not(evt.target.hasClassName('search-choice') or evt.target.up('.search-choice')) and not @results_showing )
+    if( @active_field and not($(evt.target).hasClassName('search-choice') or evt.target.up('.search-choice')) and not @results_showing )
       this.results_show()
 
   choice_build: (item) ->
@@ -297,7 +297,7 @@ class Chosen extends AbstractChosen
     evt.preventDefault()
     if not @is_disabled
       @pending_destroy_click = true
-      this.choice_destroy evt.target
+      this.choice_destroy $(evt.target)
 
   choice_destroy: (link) ->
     if this.result_deselect link.readAttribute("rel")


### PR DESCRIPTION
When using prototype.js version of Chosen in single select mode, evt.target is not always an extended object in container_mousedown. To achieve IE7 compatibility, the attached patch is required. Otherwise the expand arrow of the single select can not be used for that browser. See attached screenshot.

![Ska rmavbild 2012-12-19 kl 10 32 07](https://f.cloud.github.com/assets/2294247/21614/9de17734-49c0-11e2-8245-6f59d1224270.png)
