### PR TITLE
fix funny disco video broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,7 @@
                 Create a new instance of Chosen: <code>new Chosen(some_form_element);</code></li>
               </ul>
             </ul>
-            <li><a href="http://youtu.be/pS-RsIzb78U?t=57s">Disco</a>.</li>
+            <li><a href="http://www.youtube.com/watch?feature=player_detailpage&v=UkSPUDpe0U8#t=11s">Disco</a>.</li>
           </ol>
           
           <h2>Notable Forks</h2>


### PR DESCRIPTION
fix funny disco video broken link

The linked youtube video is no longer available.  Updated with
 a new funny disco video.
