### PR TITLE
Fix for multiple elements with the same ID

### DIFF
--- a/chosen/chosen.proto.js
+++ b/chosen/chosen.proto.js
@@ -298,7 +298,8 @@ Copyright (c) 2011 by Harvest
 (function() {
   var Chosen, get_side_border_padding, root,
     __hasProp = {}.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    __count = 0;
 
   root = this;
 
@@ -330,7 +331,7 @@ Copyright (c) 2011 by Harvest
 
     Chosen.prototype.set_up_html = function() {
       var base_template, container_classes, container_props, dd_top, dd_width, sf_width;
-      this.container_id = this.form_field.identify().replace(/[^\w]/g, '_') + "_chzn";
+      this.container_id = this.form_field.identify().replace(/[^\w]/g, '_') + "_chzn_" + __count++;
       container_classes = ["chzn-container"];
       container_classes.push("chzn-container-" + (this.is_multiple ? "multi" : "single"));
       if (this.inherit_select_classes && this.form_field.className) {


### PR DESCRIPTION
Fixes issue that arises when two elements with the same ID on a page both have Chosen initialised on them, by adding a count to the ID for each chosen container element. 
