### PR TITLE
Add middle truncation feature

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -203,6 +203,7 @@ class Chosen extends AbstractChosen
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()
+    this.do_middle_truncate() if @middle_truncate
 
     @search_results.html content
     @parsing = false
@@ -263,6 +264,7 @@ class Chosen extends AbstractChosen
     @form_field_jq.trigger("liszt:hiding_dropdown", {chosen: this})
     @dropdown.css {"left":"-9000px"}
     @results_showing = false
+    this.do_middle_truncate() if @middle_truncate
 
 
   set_tab_index: (el) ->
@@ -552,6 +554,17 @@ class Chosen extends AbstractChosen
       when 40
         this.keydown_arrow()
         break
+
+  do_middle_truncate: ->
+    span = @selected_item.find('span').first()
+    target_width = span.width()
+    text = span.text()
+    span.css({position: 'absolute'}) # Temporarily pull span out of layout, in order to see how big it would be
+    len = text.length
+    while span.width() > target_width
+      span.text( text.substr(0, Math.ceil(len/2)) + '\u2026' + text.substr(text.length - Math.floor(len/2)) )
+      len--
+    span.css({position: ''})
 
   search_field_scale: ->
     if @is_multiple

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -183,6 +183,7 @@ class Chosen extends AbstractChosen
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()
+    this.do_middle_truncate() if @middle_truncate
 
     @search_results.update content
     @parsing = false
@@ -242,6 +243,7 @@ class Chosen extends AbstractChosen
     @form_field.fire("liszt:hiding_dropdown", {chosen: this})
     @dropdown.setStyle({"left":"-9000px"})
     @results_showing = false
+    this.do_middle_truncate() if @middle_truncate
 
 
   set_tab_index: (el) ->
@@ -535,6 +537,17 @@ class Chosen extends AbstractChosen
       when 40
         this.keydown_arrow()
         break
+
+  do_middle_truncate: ->
+    span = @selected_item.down('span')
+    target_width = span.measure('width')
+    text = span.innerHTML
+    span.setStyle({position: 'absolute'}) # Temporarily pull span out of layout, in order to see how big it would be
+    len = text.length
+    while span.measure('width') > target_width
+      span.update( text.substr(0, Math.ceil(len/2)) + '&hellip;' + text.substr(text.length - Math.floor(len/2)) )
+      len--
+    span.setStyle({position: null})
 
   search_field_scale: ->
     if @is_multiple

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -30,6 +30,7 @@ class AbstractChosen
     @disable_search_threshold = @options.disable_search_threshold || 0
     @disable_search = @options.disable_search || false
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
+    @middle_truncate = @options.middle_truncate || false
     @search_contains = @options.search_contains || false
     @choices = 0
     @single_backstroke_delete = @options.single_backstroke_delete || false


### PR DESCRIPTION
This adds a new "middle_truncate" option, which if set to true will cause the displayed text for single-selects to be truncated in the center, Mac-style.

Couple of notes:

This was done against v0.9.8, since that is the version I am using.  (Newer versions seem not to work for me.)

I only implemented the middle-truncation logic for jQuery, since I do not use prototype.js.

Has not been tested in IE.
