### PR TITLE
Update chosen.css

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -2,7 +2,7 @@
 .chzn-container {
   font-size: 13px;
   position: relative;
-  display: inline-block;
+  display: inline-table;
   zoom: 1;
   *display: inline;
 }


### PR DESCRIPTION
fix when use with bootstrap inline-help or error-validation
text vertical alignment is not middle.
