### PR TITLE
Chosen search breaks (uses option.html instead of option.text)

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -859,7 +859,6 @@ Copyright (c) 2011 by Harvest
             found = false;
             result_id = option.dom_id;
             result = $("#" + result_id);
-            console.log(regex, zregex, option.text, regex.test(option.text));
             if (regex.test(option.text)) {
               found = true;
               results += 1;


### PR DESCRIPTION
Just changed references of option.html to option.text. This allows for searching of entities (<, >, & etc) as well as allowing leading spaces to be dropped from the search text.

p.s. sorry I didn't have time to install coffeescript.
