### PR TITLE
Properly vertically center elements on the same line as a chosen select in FF/Opera

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -3,6 +3,7 @@
   font-size: 13px;
   position: relative;
   display: inline-block;
+  vertical-align: middle;
   zoom: 1;
   *display: inline;
 }


### PR DESCRIPTION
This fixes harvesthq/chosen#938 without switching to css tables as harvesthq/chosen#1078 does.
