### PR TITLE
Edge case chrome bug fixed by 'clearfixing' the search container.

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -97,6 +97,7 @@
   margin: 0;
   white-space: nowrap;
   z-index: 1010;
+  overflow: hidden;
 }
 .chzn-container-single .chzn-search input {
   background: #fff url('chosen-sprite.png') no-repeat 100% -20px;


### PR DESCRIPTION
Fixes an edge case bug in Chrome 26 where in some situations the results `<ul>` can end up floating to the right of the search box, causing them to become hidden.

Screenshot before fix:

![Screen Shot 2013-04-12 at 23 28 20](https://f.cloud.github.com/assets/149426/375508/a2da3ab4-a3c0-11e2-8201-194562dc2416.png)
