### PR TITLE
Bugfix: change is triggered before element is removed

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -322,6 +322,8 @@ class Chosen extends AbstractChosen
 
       link.parents('li').first().remove()
 
+      @form_field_jq.trigger "change", {deselected: @form_field.options[@results_data[pos].options_index].value}
+
       this.search_field_scale()
 
   results_reset: ->
@@ -392,7 +394,6 @@ class Chosen extends AbstractChosen
       this.result_clear_highlight()
       this.winnow_results()
 
-      @form_field_jq.trigger "change", {deselected: @form_field.options[result_data.options_index].value}
       this.search_field_scale()
 
       return true


### PR DESCRIPTION
I've found bug on destroying selected element - after clicking delete 'x' icon, trigger('change') is called, and then that element is removed.

My script was getting selected values from html elements, so when I clicked 'x', change was called when that element, that I wanted to destroy, was in HTML.

In this commit I moved triggering after the process of removing element.

I'm not able to generate js and js.min files - if somebody could do so, I would be grateful.
