### PR TITLE
#402 Created a new min_length option

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -63,7 +63,7 @@ class Chosen extends AbstractChosen
     else
       @search_container = @container.find('div.chzn-search').first()
       @selected_item = @container.find('.chzn-single').first()
-    
+
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
@@ -108,6 +108,8 @@ class Chosen extends AbstractChosen
 
   container_mousedown: (evt) ->
     if !@is_disabled
+
+
       if evt and evt.type is "mousedown" and not @results_showing
         evt.preventDefault()
 
@@ -227,6 +229,10 @@ class Chosen extends AbstractChosen
     @result_highlight = null
 
   results_show: ->
+
+    if @search_field.val().length < @min_length
+      return false
+
     if @result_single_selected?
       this.result_do_highlight @result_single_selected
     else if @is_multiple and @max_selected_options <= @choices
@@ -563,7 +569,7 @@ class Chosen extends AbstractChosen
         w = @f_width - 10
 
       @search_field.css({'width': w + 'px'})
-  
+
   generate_random_id: ->
     string = "sel" + this.generate_random_char() + this.generate_random_char() + this.generate_random_char()
     while $("#" + string).length > 0

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -216,6 +216,10 @@ class Chosen extends AbstractChosen
     @result_highlight = null
 
   results_show: ->
+
+    if @search_field.val().length < @min_length
+      return false
+
     if @result_single_selected?
       this.result_do_highlight @result_single_selected
     else if @is_multiple and @max_selected_options <= @choices

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -36,6 +36,7 @@ class AbstractChosen
     @single_backstroke_delete = @options.single_backstroke_delete || false
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
+    @min_length = @options.min_length || 0
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -55,7 +56,7 @@ class AbstractChosen
       setTimeout (=> this.container_mousedown()), 50 unless @active_field
     else
       @activate_field() unless @active_field
-  
+
   input_blur: (evt) ->
     if not @mouse_on_container
       @active_field = false
@@ -124,7 +125,7 @@ class AbstractChosen
     new_id = this.generate_random_id()
     @form_field.id = new_id
     new_id
-  
+
   generate_random_char: ->
     chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     rand = Math.floor(Math.random() * chars.length)
@@ -142,7 +143,7 @@ class AbstractChosen
 
     width + "px"
 
-  # class methods and variables ============================================================ 
+  # class methods and variables ============================================================
 
   @browser_is_supported: ->
     if window.navigator.appName == "Microsoft Internet Explorer"


### PR DESCRIPTION
The option min_length prevents drop-down from displaying until minimum length criteria is met.

``` js
//Prevents drop-down to show up until two characters are inserted into input textbox.
$(#'my-multiselect').chosen ({
    min_length: 2
});
```
