### PR TITLE
Fixed Tab Behavior for Mulitselect

### DIFF
--- a/chosen/chosen.jquery.js
+++ b/chosen/chosen.jquery.js
@@ -318,7 +318,11 @@ Copyright (c) 2011 by Harvest
       if (this.options.width != null) {
         return this.options.width;
       } else {
-        return "" + this.form_field.offsetWidth + "px";
+          var width = this.form_field.offsetWidth;
+          if (width == 0) {
+              width = window.getComputedStyle != null ? parseFloat(window.getComputedStyle(this.form_field).getPropertyValue('width')) : (typeof jQuery !== "undefined" && jQuery !== null) && (this.form_field_jq != null) ? this.form_field_jq.outerWidth() : this.form_field.getWidth();
+          }
+          return width + "px";
       }
     };
 


### PR DESCRIPTION
Fixes issue 841 where tab can be used to select an option that has been found by typing in a select that allows multiple inputs.
