### PR TITLE
Only attempt to hide the dropdown if it's showing

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -245,10 +245,11 @@ class Chosen extends AbstractChosen
     this.winnow_results()
 
   results_hide: ->
-    this.result_clear_highlight()
+    if @results_showing
+      this.result_clear_highlight()
 
-    @container.removeClass "chzn-with-drop"
-    @form_field_jq.trigger("liszt:hiding_dropdown", {chosen: this})
+      @container.removeClass "chzn-with-drop"
+      @form_field_jq.trigger("liszt:hiding_dropdown", {chosen: this})
 
     @results_showing = false
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -232,10 +232,11 @@ class Chosen extends AbstractChosen
     this.winnow_results()
 
   results_hide: ->
-    this.result_clear_highlight()
+    if @results_showing
+      this.result_clear_highlight()
 
-    @container.removeClassName "chzn-with-drop"
-    @form_field.fire("liszt:hiding_dropdown", {chosen: this})
+      @container.removeClassName "chzn-with-drop"
+      @form_field.fire("liszt:hiding_dropdown", {chosen: this})
 
     @results_showing = false
 


### PR DESCRIPTION
There are multiple events that trigger the `results_hide` function.
1. **Expand a dropdown and close it again.** This triggers `results_hide` through the `results_toggle` function. Note that the dropdown is still highlighted.
2. **Focus on another element**. This triggers `results_hide` through the `close_field` function.

Suppose we have two Chosen dropdowns.

Expanding the first dropdown sets `@results_showing` to `true`. Closing it sets the flag to `false`. However, expanding the second dropdown will first toggle the flag to `true` but then toggle it back to `false` when `results_hide` is called as a result of `close_field`.

An example of this behavior can be seen at http://www.getharvest.com/platform.
