### PR TITLE
replaced deprecated grunt-css for grunt-contrib-cssmin

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -106,7 +106,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-watch'
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-clean'
-  grunt.loadNpmTasks 'grunt-css'
+  grunt.loadNpmTasks 'grunt-contrib-cssmin'
   grunt.loadNpmTasks 'grunt-build-gh-pages'
   grunt.loadNpmTasks 'grunt-zip'
   grunt.loadNpmTasks 'grunt-dom-munger'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-watch": "~0.3.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-clean": "~0.4.1",
-    "grunt-css": "~0.5.4",
+    "grunt-contrib-cssmin": "~0.6.1",
     "grunt-build-gh-pages": "0.0.4",
     "grunt-zip": "~0.9.2",
     "grunt-dom-munger": "~2.0.1",


### PR DESCRIPTION
As [mentioned here](https://github.com/jzaefferer/grunt-css), `grunt-css` is deprecated and `grunt-contrib-cssmin` is the suggested package for `cssmin`
