### PR TITLE
Include docsupport contents in zip

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -84,7 +84,7 @@ module.exports = (grunt) ->
     zip:
       chosen:
         cwd: 'public/'
-        src: ['public/*']
+        src: ['public/**/*']
         dest: 'chosen.zip'
 
     s3:


### PR DESCRIPTION
The generated zip does not contain the style for the demo page. 
