### PR TITLE
Add viewport edge detection to results dropdown

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -232,7 +232,7 @@ class Chosen extends AbstractChosen
     dropdownTop = @container.offset().top + @container.height() - $(window).scrollTop()
     totalHeight = @dropdown.height() + dropdownTop
 
-    @dropdown.toggleClass 'chzn-above', totalHeight > windowHeight
+    @dropdown.add(@container).toggleClass 'chzn-above', totalHeight > windowHeight
 
     @results_showing = true
 
@@ -245,7 +245,7 @@ class Chosen extends AbstractChosen
     if @results_showing
       this.result_clear_highlight()
 
-      @container.removeClass "chzn-with-drop"
+      @container.removeClass "chzn-with-drop chzn-above"
       @form_field_jq.trigger("liszt:hiding_dropdown", {chosen: this})
 
     @results_showing = false

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -228,6 +228,12 @@ class Chosen extends AbstractChosen
     @container.addClass "chzn-with-drop"
     @form_field_jq.trigger("liszt:showing_dropdown", {chosen: this})
 
+    windowHeight = $(window).height()
+    dropdownTop = @container.offset().top + @container.height() - $(window).scrollTop()
+    totalHeight = @dropdown.height() + dropdownTop
+
+    @dropdown.toggleClass 'chzn-above', totalHeight > windowHeight
+
     @results_showing = true
 
     @search_field.focus()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -215,6 +215,15 @@ class Chosen extends AbstractChosen
     @container.addClassName "chzn-with-drop"
     @form_field.fire("liszt:showing_dropdown", {chosen: this})
 
+    windowHeight = document.viewport.getHeight()
+    dropdownTop = @container.cumulativeOffset()[1] + @container.getHeight() - document.viewport.getScrollOffsets().top
+    totalHeight = @dropdown.getHeight() + dropdownTop
+
+    if totalHeight > windowHeight
+      @dropdown.addClassName 'chzn-above'
+    else
+      @dropdown.removeClassName 'chzn-above'
+
     @results_showing = true
 
     @search_field.focus()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -220,8 +220,10 @@ class Chosen extends AbstractChosen
     totalHeight = @dropdown.getHeight() + dropdownTop
 
     if totalHeight > windowHeight
+      @container.addClassName 'chzn-above'
       @dropdown.addClassName 'chzn-above'
     else
+      @container.removeClassName 'chzn-above'
       @dropdown.removeClassName 'chzn-above'
 
     @results_showing = true
@@ -236,6 +238,7 @@ class Chosen extends AbstractChosen
       this.result_clear_highlight()
 
       @container.removeClassName "chzn-with-drop"
+      @container.removeClassName "chzn-above"
       @form_field.fire("liszt:hiding_dropdown", {chosen: this})
 
     @results_showing = false

--- a/public/chosen.css
+++ b/public/chosen.css
@@ -28,7 +28,7 @@
 
 .chzn-container .chzn-drop.chzn-above {
   top:auto;
-  bottom:29px;
+  bottom:100%;
   border:solid #aaa;
   border-width:1px 1px 0 1px;
   -webkit-box-shadow: 0 -4px 5px rgba(0,0,0,.15);
@@ -152,6 +152,11 @@
   -moz-background-clip   : padding;
   -webkit-background-clip: padding-box;
   background-clip        : padding-box;
+}
+.chzn-container-single.chzn-above .chzn-drop {
+  -webkit-border-radius: 4px 4px 0 0;
+  -moz-border-radius   : 4px 4px 0 0;
+  border-radius        : 4px 4px 0 0;
 }
 .chzn-container-single-nosearch .chzn-search {
   position: absolute;
@@ -388,6 +393,22 @@
   -moz-border-radius-bottomright: 0;
   border-bottom-left-radius : 0;
   border-bottom-right-radius: 0;
+}
+.chzn-container-active.chzn-with-drop.chzn-above .chzn-single {
+  border-top-width: 0;
+  padding-top: 1px;
+  -webkit-box-shadow: 0 -1px 0 #fff inset;
+  -moz-box-shadow   : 0 -1px 0 #fff inset;
+  box-shadow        : 0 -1px 0 #fff inset;
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#eeeeee', GradientType=0 );
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(20%, #ffffff), color-stop(50%, #f6f6f6), color-stop(52%, #eeeeee), color-stop(100%, #f4f4f4));
+  background-image: -webkit-linear-gradient(top, #ffffff 20%, #f6f6f6 50%, #eeeeee 52%, #f4f4f4 100%);
+  background-image: -moz-linear-gradient(top, #ffffff 20%, #f6f6f6 50%, #eeeeee 52%, #f4f4f4 100%);
+  background-image: -o-linear-gradient(top, #ffffff 20%, #f6f6f6 50%, #eeeeee 52%, #f4f4f4 100%);
+  background-image: linear-gradient(#ffffff 20%, #f6f6f6 50%, #eeeeee 52%, #f4f4f4 100%);
+  -webkit-border-radius:0 0 4px 4px;
+  -moz-border-radius:0 0 4px 4px;
+  border-radius:0 0 4px 4px;
 }
 .chzn-container-active.chzn-with-drop .chzn-single div {
   background: transparent;

--- a/public/chosen.css
+++ b/public/chosen.css
@@ -26,6 +26,16 @@
   box-sizing        : border-box;
 }
 
+.chzn-container .chzn-drop.chzn-above {
+  top:auto;
+  bottom:29px;
+  border:solid #aaa;
+  border-width:1px 1px 0 1px;
+  -webkit-box-shadow: 0 -4px 5px rgba(0,0,0,.15);
+  -moz-box-shadow   : 0 -4px 5px rgba(0,0,0,.15);
+  box-shadow        : 0 -4px 5px rgba(0,0,0,.15);
+}
+
 .chzn-container.chzn-with-drop .chzn-drop {
   left: 0;
 }


### PR DESCRIPTION
Fixes harvesthq/chosen#155

Ensure dropdowns are always visible in the viewport by checking if they would drop below the window's bottom edge and positioning them above the input if that is the case.
This code is based off the snippets by @coreyworrell

This addition is especially important when a select input is positioned near the bottom of the page where the user can't scroll anymore - without this addition the input is nearly unusable as the list of options is cut off.