### PR TITLE
rtl fix on index did completely hide search on example page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
   <link rel="stylesheet" href="chosen.css">
   <style type="text/css" media="all">
     /* fix rtl for demo */
-    .chzn-rtl .chzn-search { left: -9000px; }
     .chzn-rtl .chzn-drop { left: -9000px; }
   </style>
 </head>


### PR DESCRIPTION
Removing the `left: -9000px` positioning does fix this.
