### PR TITLE
 Use the placeholder attribute as default text when it is availabe

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -33,7 +33,9 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
 
   set_default_text: ->
-    if @form_field.getAttribute("data-placeholder")
+    if @form_field.getAttribute("placeholder")
+      @default_text = @form_field.getAttribute("placeholder")
+    else if @form_field.getAttribute("data-placeholder")
       @default_text = @form_field.getAttribute("data-placeholder")
     else if @is_multiple
       @default_text = @options.placeholder_text_multiple || @options.placeholder_text || AbstractChosen.default_multiple_text


### PR DESCRIPTION
I'm not sure why you chose to use @data-placeholder in the first place but there is nothing wrong with @placeholder. This attribute is now supported in most major browser.

I suggest to also check that attribute to find the default text of the select. My patch is backward compatible with @data-placeholder, of course.
