### PR TITLE
Data value attribute for search result items

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -71,7 +71,7 @@ class AbstractChosen
 
       style = if option.style.cssText != "" then " style=\"#{option.style}\"" else ""
 
-      '<li id="' + option.dom_id + '" class="' + classes.join(' ') + '"'+style+'>' + option.html + '</li>'
+      '<li id="' + option.dom_id + '" data-value="' + option.value + '" class="' + classes.join(' ') + '"'+style+'>' + option.html + '</li>'
     else
       ""
 


### PR DESCRIPTION
There is times when you need to highlight some of the options, for example major cities in huge list.

Easiest way to do that will be something like this:

```
.chzn-results li[data-value='1'] {
    color: red !important;
}
```
