### PR TITLE
Remove memoization of search field width.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -487,10 +487,10 @@ class Chosen extends AbstractChosen
       w = div.width() + 25
       div.remove()
 
-      @f_width = @container.outerWidth() unless @f_width
+      f_width = @container.outerWidth()
 
-      if( w > @f_width-10 )
-        w = @f_width - 10
+      if( w > f_width - 10 )
+        w = f_width - 10
 
       @search_field.css({'width': w + 'px'})
   

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -476,10 +476,10 @@ class Chosen extends AbstractChosen
       w = Element.measure(div, 'width') + 25
       div.remove()
 
-      @f_width = @container.getWidth() unless @f_width
+      f_width = @container.getWidth()
 
-      if( w > @f_width-10 )
-        w = @f_width - 10
+      if( w > f_width-10 )
+        w = f_width - 10
 
       @search_field.setStyle({'width': w + 'px'})
 


### PR DESCRIPTION
@kenearley @stof @koenpunt

This addresses #1352 and #1167, but does not entirely fix them. As long as we don't have a window resize method, fields with widths will always run the risk of being behind the actual container size.

Performance of jQuery's outerWidth method was the original reason for adding memoization, but it does't seem to be a big enough problem to keep at all costs.
