### PR TITLE
Rebuild Search Results After liszt:updated

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -99,7 +99,7 @@ class AbstractChosen
     this.result_clear_highlight()
     @result_single_selected = null
     this.results_build()
-    this.winnow_results()
+    this.winnow_results() if @results_showing
 
   results_toggle: ->
     if @results_showing


### PR DESCRIPTION
@kenearley @stof @koenpunt @elkelk

This is a slight modification of #947 which adds a call to `winnow_results` after triggering a `liszt:updated`. This is useful for people who are modifying the contents of the underlying select while mid-search (think ajaxy). I've added a conditional that ensures it only happens when results are showing.

I believe this fixes things like #1221 and #510.
