### PR TITLE
Clear highlight when no results are found

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -147,6 +147,7 @@ class AbstractChosen
 
     if results < 1 and searchText.length
       this.update_results_content ""
+      this.result_clear_highlight()
       this.no_results searchText
     else
       this.update_results_content this.results_option_build()


### PR DESCRIPTION
While updating my `option_adding` branch I'd notice that when there are no results `@result_highlight` was still set and that caused problems.

Although it isn't a issue in `master`, I think it is incorrect to keep `@result_highlight` set when no results are found.
