### PR TITLE
Add Gemfile for compass dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'compass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chunky_png (1.2.8)
+    compass (0.12.2)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.1)
+    fssm (0.2.10)
+    sass (3.2.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  compass


### PR DESCRIPTION
@kenearley There's a dev dependency on Compass -- this adds a Gemfile to hopefully convey that, but at least to codify it.  Couldn't `grunt build` without it.
