### PR TITLE
Prevent text selection on Chosen

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -1,5 +1,6 @@
 @import "compass/css3/box-sizing";
 @import "compass/css3/images";
+@import "compass/css3/user-interface";
 
 $chosen-sprite: image-url('chosen-sprite.png');
 $chosen-sprite-retina: image-url('chosen-sprite@2x.png');
@@ -12,6 +13,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png');
   font-size: 13px;
   zoom: 1;
   *display: inline;
+  @include user-select(none);
   .chzn-drop {
     position: absolute;
     top: 100%;


### PR DESCRIPTION
Mostly for @mlettini @starzonmyarmz 

Simple change that stops text selection on chosen. This is especially nice when users click and drag to select.

Fixes #292 

cc/ @kenearley @stof @koenpunt
