### PR TITLE
Added events example and descriptions to documentation

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -176,25 +176,25 @@
         <tr>
           <td>change</td>
           <td>
-            <p>Chosen triggers the standard DOM event whenever a selection is made (it also includes a selected or deselected parameter that tells you which option was changed).</p>
+            <p>Chosen triggers the standard DOM event whenever a selection is made (it also sends a <code class="language-javascript">selected</code> or <code class="language-javascript">deselected</code> parameter that tells you which option was changed).</p>
             <p><strong>Note:</strong> in order to use change in the Prototype version, you have to include the <a href="https://github.com/kangax/protolicious/blob/5b56fdafcd7d7662c9d648534225039b2e78e371/event.simulate.js">Event.simulate</a> class. The selected and deselected parameters are not available for Prototype.</p>
           </td>
         </tr>
         <tr>
           <td>liszt:ready</td>
-          <td>after Chosen has been fully instantiated.</td>
+          <td>after Chosen has been fully instantiated (it also sends the <code class="language-javascript">chosen</code> object as a parameter).</td>
         </tr>
         <tr>
           <td>liszt:maxselected</td>
-          <td>triggered if <code class="language-javascript">max_selected_options</code> is set and that total is broken.</td>
+          <td>triggered if <code class="language-javascript">max_selected_options</code> is set and that total is broken. (it also sends the <code class="language-javascript">chosen</code> object as a parameter)</td>
         </tr>
         <tr>
           <td>liszt:showing_dropdown</td>
-          <td>triggered when Chosen's dropdown is opened.</td>
+          <td>triggered when Chosen's dropdown is opened (it also sends the <code class="language-javascript">chosen</code> object as a parameter).</td>
         </tr>
         <tr>
           <td>liszt:hiding_dropdown</td>
-          <td>triggered when Chosen's dropdown is closed.</td>
+          <td>triggered when Chosen's dropdown is closed (it also sends the <code class="language-javascript">chosen</code> object as a parameter).</td>
         </tr>
       </table>
 


### PR DESCRIPTION
@pfiller I just copy/pasted the event descriptions you posted in #227. I added an example for the change event, since that seemed like the most complex one.
