### PR TITLE
Update stackoverflow link to search for chosen posts

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -21,7 +21,7 @@ and [submitting pull requests](#pull-requests), but please respect the
 following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests (use
-  [Stack Overflow](http://stackoverflow.com)).
+  [Stack Overflow](http://stackoverflow.com/search?q=chosen)).
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.


### PR DESCRIPTION
@pfiller @stof @koenpunt 

Now that we are getting more detailed documentation out, we should really try to steer how-to questions to [StackOverflow](http://stackoverflow.com/search?tab=relevance&q=chosen). We should also occasionally review posts there to see where people are confused. This will help us to revise the docs, as needed. Thoughts?
