### PR TITLE
Feature: Default options

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -5,6 +5,7 @@ $.fn.extend({
     # Do no harm and return as soon as possible for unsupported browsers, namely IE6 and IE7
     # Continue on if running IE document type but in compatibility mode
     return this unless AbstractChosen.browser_is_supported()
+    options = $.extend({}, AbstractChosen.default_options, $.fn.chosen.defaults, options)
     this.each (input_field) ->
       $this = $ this
       chosen = $this.data('chosen')
@@ -16,6 +17,8 @@ $.fn.extend({
       return
 
 })
+
+$.fn.chosen.defaults = AbstractChosen.default_options
 
 class Chosen extends AbstractChosen
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -15,8 +15,11 @@ class @Chosen extends AbstractChosen
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_options: () ->
-    for option of AbstractChosen.default_options
-      @options[option] = @options[option] || Chosen.default_options[option] || AbstractChosen.default_options[option]
+    options = {}
+    Object.extend(options, AbstractChosen.default_options)
+    Object.extend(options, Chosen.default_options)
+    Object.extend(options, @options)
+    @options = options
 
   set_up_html: ->
     container_classes = ["chosen-container"]

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -5,12 +5,18 @@ class @Chosen extends AbstractChosen
     @is_rtl = @form_field.hasClassName "chosen-rtl"
 
   set_default_values: ->
+    this.set_options()
+
     super()
 
     # HTML Templates
     @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>')
     @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
+
+  set_options: () ->
+    for option of AbstractChosen.default_options
+      @options[option] = @options[option] || Chosen.default_options[option] || AbstractChosen.default_options[option]
 
   set_up_html: ->
     container_classes = ["chosen-container"]

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -266,6 +266,17 @@ class AbstractChosen
       return false if /Mobile/i.test(window.navigator.userAgent)
     return true
 
+  @default_options =
+    allow_single_deselect: false
+    disable_search_threshold: 0
+    disable_search: false
+    enable_split_word_search: false
+    group_search: true
+    search_contains: false
+    single_backstroke_delete: true
+    max_selected_options: Infinity
+    inherit_select_classes: false
+
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"


### PR DESCRIPTION
I took a stab at making default options configurable.

For the jQuery version defaults can be set like:

```javascript
$.fn.chosen.defaults.allow_single_deselect = true;
$('.chzn-select').chosen();

// or

$.fn.chosen.defaults = {allow_single_deselect: true};
$('.chzn-select').chosen();

```

And for the Prototype version:

```javascript
Chosen.default_options.allow_single_deselect = true;
new Chosen($$('.chzn-select')[0]);

// or

Chosen.default_options = {allow_single_deselect: true};
new Chosen($$('.chzn-select')[0]);
```

I'm not quite sure about the merging, because in the jQuery version `$.fn.chosen.defaults` starts as a reference to `AbstractChosen.default_options`, but when `$.fn.chosen.defaults` gets overwritten the actual defaults are lost. So when instantiating I need to merge `AbstractChosen.default_options`, `$.fn.chosen.defaults` and `options` to get the correct options.

@harvesthq/chosen-developers: what are your thoughts on defaults?