### PR TITLE
Disable Chosen on iOS devices (iPad, iPod, iPhone)

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -202,10 +202,10 @@ class AbstractChosen
   @browser_is_supported: ->
     if window.navigator.appName == "Microsoft Internet Explorer"
       return document.documentMode >= 8
-    if /iP(od|hone)/.test(window.navigator.userAgent)
+    if /iP(od|hone)/i.test(window.navigator.userAgent)
       return false
     if /Android/i.test(window.navigator.userAgent)
-      return false if /Mobile/.test(window.navigator.userAgent)
+      return false if /Mobile/i.test(window.navigator.userAgent)
     return true
 
   @default_multiple_text: "Select Some Options"


### PR DESCRIPTION
As a solution (until actual support is implemented?) for #27, #382, #1088 and #1233 I've flagged iOS browsers as unsupported.
