### PR TITLE
No need to expose classes to window context

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -30,6 +30,8 @@ module.exports = (grunt) ->
         dest: "public/chosen.proto.js"
 
     coffee:
+      options:
+        join: true
       compile:
         files:
           'public/chosen.jquery.js': ['coffee/lib/select-parser.coffee', 'coffee/lib/abstract-chosen.coffee', 'coffee/chosen.jquery.coffee']

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -1,4 +1,3 @@
-root = this
 $ = jQuery
 
 $.fn.extend({
@@ -159,7 +158,7 @@ class Chosen extends AbstractChosen
     @parsing = true
     @selected_option_count = null
 
-    @results_data = root.SelectParser.select_to_array @form_field
+    @results_data = SelectParser.select_to_array @form_field
 
     if @is_multiple
       @search_choices.find("li.search-choice").remove()
@@ -482,5 +481,3 @@ class Chosen extends AbstractChosen
         w = f_width - 10
 
       @search_field.css({'width': w + 'px'})
-
-root.Chosen = Chosen

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -1,6 +1,4 @@
-root = this
-
-class Chosen extends AbstractChosen
+class @Chosen extends AbstractChosen
 
   setup: ->
     @current_selectedIndex = @form_field.selectedIndex
@@ -148,7 +146,7 @@ class Chosen extends AbstractChosen
     @parsing = true
     @selected_option_count = null
 
-    @results_data = root.SelectParser.select_to_array @form_field
+    @results_data = SelectParser.select_to_array @form_field
 
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")
@@ -473,5 +471,3 @@ class Chosen extends AbstractChosen
         w = f_width - 10
 
       @search_field.setStyle({'width': w + 'px'})
-
-root.Chosen = Chosen

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -1,5 +1,3 @@
-root = this
-
 class AbstractChosen
 
   constructor: (@form_field, @options={}) ->
@@ -209,5 +207,3 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
-
-root.AbstractChosen = AbstractChosen

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -62,5 +62,3 @@ SelectParser.select_to_array = (select) ->
   parser = new SelectParser()
   parser.add_node( child ) for child in select.childNodes
   parser.parsed
-
-this.SelectParser = SelectParser


### PR DESCRIPTION
Updated the sources that only in the prototype version the `Chosen` class is available in `window` context. The jQuery version only needs those classes internally.

This could only work when there is no separate function wrapper around every classes, which could easily be achieved by joining the coffee sources before compiling. (`join: true` in `Gruntfile.coffee`)

@harvesthq/chosen-developers; Was there a reason in the past that these classes were available in `window` context?
