### PR TITLE
Properly mark selected value as false when choosing another value.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -319,7 +319,11 @@ class Chosen extends AbstractChosen
       if @is_multiple
         high.removeClass("active-result")
       else
-        @search_results.find(".result-selected").removeClass "result-selected"
+        if @result_single_selected
+          @result_single_selected.removeClass("result-selected")
+          selected_index = @result_single_selected[0].getAttribute('data-option-array-index')
+          @results_data[selected_index].selected = false
+
         @result_single_selected = high
 
       high.addClass "result-selected"

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -306,7 +306,11 @@ class @Chosen extends AbstractChosen
       if @is_multiple
         high.removeClassName("active-result")
       else
-        @search_results.descendants(".result-selected").invoke "removeClassName", "result-selected"
+        if @result_single_selected
+          @result_single_selected.removeClassName("result-selected")
+          selected_index = @result_single_selected.getAttribute('data-option-array-index')
+          @results_data[selected_index].selected = false
+
         @result_single_selected = high
       
       high.addClassName("result-selected")


### PR DESCRIPTION
@harvesthq/chosen-developers 

How's that for a title? This makes sure that we set any current value to false when choosing a result in single select mode. Presently, any value that is selected will retain its `result-selected` class _forever_.

Fixes #1391
