### PR TITLE
StackOverflow policy

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -20,8 +20,10 @@ preferred channel for [bug reports](#bugs), [features requests](#features)
 and [submitting pull requests](#pull-requests), but please respect the 
 following restrictions:
 
-* Please **do not** use the issue tracker for personal support requests (use
-  [Stack Overflow](http://stackoverflow.com/search?q=chosen)).
+* Support issues or usage question that are not bugs should be posted on 
+[Stack Overflow, using the `chosen.js`](http://stackoverflow.com/questions/tagged/chosen.js) tag
+(related tags: [`jquery-chosen`](http://stackoverflow.com/questions/tagged/jquery-chosen),
+[`prototype-chosen`](http://stackoverflow.com/questions/tagged/prototype-chosen)).
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.


### PR DESCRIPTION
@harvesthq/chosen-developers I got this idea while browsing the [Poltergeist repo](https://github.com/jonleighton/poltergeist/tree/v1.3.0#getting-help). It makes more sense to ask people to use tags when asking questions on StackOverflow. There are already tags created for chosen
- [chosen.js](http://stackoverflow.com/questions/tagged/chosen.js)
- [jquery-chosen](http://stackoverflow.com/questions/tagged/jquery-chosen)
- [prototype-chosen](http://stackoverflow.com/questions/tagged/prototype-chosen)

I kind of like the idea of moving this to a Getting Help section in the README, like it is on the Poltergeist repo. I doubt if people creating Issues ever dig into the Contributing page. Thoughts?

Here's the [contributing.md](https://github.com/harvesthq/chosen/blob/stackoverflow_policy/contributing.md) file for review: 
