### PR TITLE
[WIP] Add result on mouseup only after a mousedown event was captured

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -71,7 +71,8 @@ class Chosen extends AbstractChosen
     @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
     @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
 
-    @search_results.bind 'click.chosen', (evt) => this.search_results_click(evt); return
+    @search_results.bind 'mousedown.chosen', (evt) => this.search_results_mousedown(evt); return
+    @search_results.bind 'mouseup.chosen', (evt) => this.search_results_mouseup(evt); return
     @search_results.bind 'mouseover.chosen', (evt) => this.search_results_mouseover(evt); return
     @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
     @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
@@ -268,7 +269,12 @@ class Chosen extends AbstractChosen
       @search_field.val("")
       @search_field.removeClass "default"
 
-  search_results_click: (evt) ->
+  search_results_mousedown: (evt) ->
+    @click_started = true
+
+  search_results_mouseup: (evt) ->
+    return unless @click_started
+    @click_started = false
     target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
     if target.length
       @result_highlight = target

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -71,7 +71,7 @@ class Chosen extends AbstractChosen
     @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
     @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
 
-    @search_results.bind 'mouseup.chosen', (evt) => this.search_results_mouseup(evt); return
+    @search_results.bind 'click.chosen', (evt) => this.search_results_click(evt); return
     @search_results.bind 'mouseover.chosen', (evt) => this.search_results_mouseover(evt); return
     @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
     @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
@@ -268,7 +268,7 @@ class Chosen extends AbstractChosen
       @search_field.val("")
       @search_field.removeClass "default"
 
-  search_results_mouseup: (evt) ->
+  search_results_click: (evt) ->
     target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
     if target.length
       @result_highlight = target

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -54,7 +54,7 @@ class @Chosen extends AbstractChosen
     @container.observe "mouseenter", (evt) => this.mouse_enter(evt)
     @container.observe "mouseleave", (evt) => this.mouse_leave(evt)
 
-    @search_results.observe "mouseup", (evt) => this.search_results_mouseup(evt)
+    @search_results.observe "click", (evt) => this.search_results_click(evt)
     @search_results.observe "mouseover", (evt) => this.search_results_mouseover(evt)
     @search_results.observe "mouseout", (evt) => this.search_results_mouseout(evt)
     @search_results.observe "mousewheel", (evt) => this.search_results_mousewheel(evt)
@@ -262,7 +262,7 @@ class @Chosen extends AbstractChosen
       @search_field.value = ""
       @search_field.removeClassName "default"
 
-  search_results_mouseup: (evt) ->
+  search_results_click: (evt) ->
     target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     if target
       @result_highlight = target

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -54,7 +54,8 @@ class @Chosen extends AbstractChosen
     @container.observe "mouseenter", (evt) => this.mouse_enter(evt)
     @container.observe "mouseleave", (evt) => this.mouse_leave(evt)
 
-    @search_results.observe "click", (evt) => this.search_results_click(evt)
+    @search_results.observe "mousedown", (evt) => this.search_results_mousedown(evt)
+    @search_results.observe "mouseup", (evt) => this.search_results_mouseup(evt)
     @search_results.observe "mouseover", (evt) => this.search_results_mouseover(evt)
     @search_results.observe "mouseout", (evt) => this.search_results_mouseout(evt)
     @search_results.observe "mousewheel", (evt) => this.search_results_mousewheel(evt)
@@ -262,7 +263,12 @@ class @Chosen extends AbstractChosen
       @search_field.value = ""
       @search_field.removeClassName "default"
 
-  search_results_click: (evt) ->
+  search_results_mousedown: (evt) ->
+    @click_started = true
+
+  search_results_mouseup: (evt) ->
+    return unless @click_started
+    @click_started = false
     target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     if target
       @result_highlight = target

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -239,7 +239,7 @@ class AbstractChosen
     this.search_results_mouseout(evt)
 
   search_results_touchend: (evt) ->
-    this.search_results_click(evt) if @touch_started
+    this.search_results_mouseup(evt) if @touch_started
 
   outerHTML: (element) ->
     return element.outerHTML if element.outerHTML

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -239,7 +239,7 @@ class AbstractChosen
     this.search_results_mouseout(evt)
 
   search_results_touchend: (evt) ->
-    this.search_results_mouseup(evt) if @touch_started
+    this.search_results_click(evt) if @touch_started
 
   outerHTML: (element) ->
     return element.outerHTML if element.outerHTML


### PR DESCRIPTION
This is a fix for #1386.

When starting a scroll with a Wacom pen I have to press a secondary button and then drag the list, this doesn't trigger a `mousedown` event. But when I release to extend my scroll, the `mouseup` event is triggered, and thus the list is closed. Changing the result adding on click fixes this as a `click` event is only triggered when there has been a `mousedown` and `mouseup` event.

*WIP as there are still some issues in combination with mousedown/touchstart mouseup/touchend on iPad*