### PR TITLE
Change the Way Width is Determined

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -497,7 +497,7 @@ class Chosen extends AbstractChosen
 
       f_width = @container.outerWidth()
 
-      if( w > f_width - 10 )
+      if( f_width && w > f_width - 10 )
         w = f_width - 10
 
       @search_field.css({'width': w + 'px'})

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -495,7 +495,7 @@ class Chosen extends AbstractChosen
       w = div.width() + 25
       div.remove()
 
-      f_width = @container.outerWidth()
+      f_width = @container[0].offsetWidth
 
       if( f_width && w > f_width - 10 )
         w = f_width - 10

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -494,7 +494,7 @@ class @Chosen extends AbstractChosen
 
       f_width = @container.getWidth()
 
-      if( w > f_width-10 )
+      if( f_width && w > f_width-10 )
         w = f_width - 10
 
       @search_field.setStyle({'width': w + 'px'})

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -492,7 +492,7 @@ class @Chosen extends AbstractChosen
       w = Element.measure(div, 'width') + 25
       div.remove()
 
-      f_width = @container.getWidth()
+      f_width = @container.offsetWidth
 
       if( f_width && w > f_width-10 )
         w = f_width - 10

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -224,9 +224,9 @@ class AbstractChosen
     return @options.width if @options.width?
 
     if jQuery? and $ is jQuery
-      return $(@form_field).css('width') if $(@form_field).css('width')
+      return width if width = $(@form_field).css('width')
     else
-      return @form_field.getStyle('width') if @form_field.getStyle('width')
+      return width if width = @form_field.getStyle('width')
 
     @form_field.offsetWidth
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -221,7 +221,14 @@ class AbstractChosen
       else this.results_search()
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    return @options.width if @options.width?
+
+    if jQuery? and $ is jQuery
+      return $(@form_field).css('width') if $(@form_field).css('width')
+    else
+      return @form_field.getStyle('width') if @form_field.getStyle('width')
+
+    @form_field.offsetWidth
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
@harvesthq/chosen-developers 

This fixes some issues that come when applying Chosen to a `select` that is not visible (when you haven't set `width: n` for whatever reason). Basically, it uses jQuery & Prototypes magic methods for getting width if they're set and falls back to `offsetWidth` if they're not. As always, a width specified in the option object will take precedence.

I went a little crazy testing this. Each of these fiddles demonstrates 4 ways you would apply width to Chosen in both a container that is hidden on page load and a container that is visible on page load. As you can see, with the exception of a hidden select that has no style applied to it, the new version does a wonderful job of matching size:

- [jQuery 1.0 version](http://jsfiddle.net/tTn5a/2/)
- [jQuery fix-hidden-width version](http://jsfiddle.net/geJ7t/1/) 
- [Prototype 1.0 version](http://jsfiddle.net/JUFUE/2/)
- [Prototype fix-hidden-width version](http://jsfiddle.net/gsavJ/1/) 

**Please Note:** This doesn't fix the % width issue (people will still need to specify those via `width: %`. I only mention this because one of these examples uses a percentage width set via a class. If you adjust the width of the output area, Chosen might not match it's original field. The best thing to do is adjust the width of the area and then click "Run" again. (Can you tell I learned this the hard way?)