### PR TITLE
Prevent chosen-drop elem from appearing when empty

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -176,7 +176,10 @@ class Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
     @results_count = @results_data.length
-    @results_all_chosen = false
+    if @results_count > 0 
+      @results_all_chosen = false
+    else 
+      @results_all_chosen = true
 
     if @is_multiple
       @search_choices.find("li.search-choice").remove()

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -175,6 +175,8 @@ class Chosen extends AbstractChosen
     @selected_option_count = null
 
     @results_data = SelectParser.select_to_array @form_field
+    @results_count = @results_data.length
+    @results_all_chosen = false
 
     if @is_multiple
       @search_choices.find("li.search-choice").remove()
@@ -221,6 +223,10 @@ class Chosen extends AbstractChosen
   results_show: ->
     if @is_multiple and @max_selected_options <= this.choices_count()
       @form_field_jq.trigger("chosen:maxselected", {chosen: this})
+      return false
+
+    if @is_multiple and @results_all_chosen
+      @form_field_jq.trigger("chosen:allselected", {chosen: this})
       return false
 
     @container.addClass "chosen-with-drop"
@@ -348,7 +354,12 @@ class Chosen extends AbstractChosen
       item.selected = true
 
       @form_field.options[item.options_index].selected = true
-      @selected_option_count = null
+      @selected_option_count = @selected_option_count + 1
+
+      if @selected_option_count == @results_count 
+        @results_all_chosen = true
+      else 
+        @results_all_chosen = false
 
       if @is_multiple
         this.choice_build item
@@ -379,7 +390,8 @@ class Chosen extends AbstractChosen
       result_data.selected = false
 
       @form_field.options[result_data.options_index].selected = false
-      @selected_option_count = null
+      @selected_option_count = @selected_option_count - 1
+      @results_all_chosen = false
 
       this.result_clear_highlight()
       this.winnow_results() if @results_showing

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -348,7 +348,7 @@ class Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = @selected_option_count + 1
-      @results_all_chosen = @selected_option_count == @results_count
+      @remaining_results = @selected_option_count == @results_count
 
       if @is_multiple
         this.choice_build item

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -176,10 +176,7 @@ class Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
     @results_count = @results_data.length
-    if @results_count > 0 
-      @results_all_chosen = false
-    else 
-      @results_all_chosen = true
+    @remaining_results = @results_count == 0
 
     if @is_multiple
       @search_choices.find("li.search-choice").remove()
@@ -228,7 +225,7 @@ class Chosen extends AbstractChosen
       @form_field_jq.trigger("chosen:maxselected", {chosen: this})
       return false
 
-    if @is_multiple and @results_all_chosen
+    if @is_multiple and @remaining_results
       @form_field_jq.trigger("chosen:allselected", {chosen: this})
       return false
 
@@ -351,11 +348,7 @@ class Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = @selected_option_count + 1
-
-      if @selected_option_count == @results_count 
-        @results_all_chosen = true
-      else 
-        @results_all_chosen = false
+      @results_all_chosen = @selected_option_count == @results_count
 
       if @is_multiple
         this.choice_build item
@@ -387,7 +380,7 @@ class Chosen extends AbstractChosen
 
       @form_field.options[result_data.options_index].selected = false
       @selected_option_count = @selected_option_count - 1
-      @results_all_chosen = false
+      @remaining_results = false
 
       this.result_clear_highlight()
       this.winnow_results() if @results_showing

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -344,7 +344,7 @@ class @Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = @selected_option_count + 1
-      @results_all_chosen = @selected_option_count == @results_count
+      @remaining_results = @selected_option_count == @results_count
 
       if @is_multiple
         this.choice_build item

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -170,6 +170,8 @@ class @Chosen extends AbstractChosen
     @selected_option_count = null
 
     @results_data = SelectParser.select_to_array @form_field
+    @results_count = @results_data.length
+    @results_all_chosen = false
 
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")
@@ -215,6 +217,10 @@ class @Chosen extends AbstractChosen
   results_show: ->
     if @is_multiple and @max_selected_options <= this.choices_count()
       @form_field.fire("chosen:maxselected", {chosen: this})
+      return false
+
+    if @is_multiple and @results_all_chosen
+      @form_field.fire("chosen:allselected", {chosen: this})
       return false
 
     @container.addClassName "chosen-with-drop"
@@ -342,7 +348,12 @@ class @Chosen extends AbstractChosen
       item.selected = true
 
       @form_field.options[item.options_index].selected = true
-      @selected_option_count = null
+      @selected_option_count = @selected_option_count + 1
+
+      if @selected_option_count == @results_count 
+        @results_all_chosen = true
+      else 
+        @results_all_chosen = false
 
       if @is_multiple
         this.choice_build item
@@ -374,7 +385,8 @@ class @Chosen extends AbstractChosen
       result_data.selected = false
 
       @form_field.options[result_data.options_index].selected = false
-      @selected_option_count = null
+      @selected_option_count = @selected_option_count - 1
+      @results_all_chosen = false
 
       this.result_clear_highlight()
       this.winnow_results() if @results_showing

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -171,7 +171,10 @@ class @Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
     @results_count = @results_data.length
-    @results_all_chosen = false
+    if @results_count > 0 
+      @results_all_chosen = false
+    else 
+      @results_all_chosen = true
 
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -171,10 +171,7 @@ class @Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
     @results_count = @results_data.length
-    if @results_count > 0 
-      @results_all_chosen = false
-    else 
-      @results_all_chosen = true
+    @remaining_results = @results_count == 0
 
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")
@@ -222,7 +219,7 @@ class @Chosen extends AbstractChosen
       @form_field.fire("chosen:maxselected", {chosen: this})
       return false
 
-    if @is_multiple and @results_all_chosen
+    if @is_multiple and @remaining_results
       @form_field.fire("chosen:allselected", {chosen: this})
       return false
 
@@ -347,11 +344,7 @@ class @Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = @selected_option_count + 1
-
-      if @selected_option_count == @results_count 
-        @results_all_chosen = true
-      else 
-        @results_all_chosen = false
+      @results_all_chosen = @selected_option_count == @results_count
 
       if @is_multiple
         this.choice_build item
@@ -384,7 +377,7 @@ class @Chosen extends AbstractChosen
 
       @form_field.options[result_data.options_index].selected = false
       @selected_option_count = @selected_option_count - 1
-      @results_all_chosen = false
+      @remaining_results = false
 
       this.result_clear_highlight()
       this.winnow_results() if @results_showing


### PR DESCRIPTION
Without checking to see if the total number of chosen results matches the total number of results in the `@results_data` array, when the `results_show` method is called, the chosen-drop elem will appear as an empty white box with a shadow - which to me, is an undesired effect.

The code changes are pretty straightforward.  I didn't see anywhere to write unit tests - although I'd be happy to write one for this if that is needed. 

Thanks for considering the changes!