### PR TITLE
Add Grunt-powered Jasmine spec runner and a first spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ chosen.zip
 .sass-cache
 .grunt
 _SpecRunner.html
+spec/public

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ public/*.js
 public/*.css
 chosen.zip
 .sass-cache
+.grunt
+_SpecRunner.html

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -36,6 +36,7 @@ module.exports = (grunt) ->
         files:
           'public/chosen.jquery.js': ['coffee/lib/select-parser.coffee', 'coffee/lib/abstract-chosen.coffee', 'coffee/chosen.jquery.coffee']
           'public/chosen.proto.js': ['coffee/lib/select-parser.coffee', 'coffee/lib/abstract-chosen.coffee', 'coffee/chosen.proto.coffee']
+          'spec/public/specs.js': 'spec/*.spec.coffee'
 
     uglify:
       options:
@@ -92,6 +93,13 @@ module.exports = (grunt) ->
         src: ['public/**/*']
         dest: "chosen_#{version_tag()}.zip"
 
+    jasmine:
+      jquery:
+        src: [ 'public/chosen.jquery.js' ]
+        options:
+          vendor: [ 'http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js' ]
+          specs: 'spec/public/*.js'
+
   grunt.loadNpmTasks 'grunt-contrib-coffee'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
   grunt.loadNpmTasks 'grunt-contrib-concat'
@@ -103,9 +111,11 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-build-gh-pages'
   grunt.loadNpmTasks 'grunt-zip'
   grunt.loadNpmTasks 'grunt-dom-munger'
+  grunt.loadNpmTasks 'grunt-contrib-jasmine'
 
   grunt.registerTask 'default', ['build']
   grunt.registerTask 'build', ['coffee', 'compass', 'concat', 'uglify', 'cssmin']
+  grunt.registerTask 'test', ['build', 'jasmine']
   grunt.registerTask 'gh_pages', ['copy:dist', 'build_gh_pages:gh_pages']
   grunt.registerTask 'prep_release', ['build','zip:chosen','package_jquery']
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -115,7 +115,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'default', ['build']
   grunt.registerTask 'build', ['coffee', 'compass', 'concat', 'uglify', 'cssmin']
-  grunt.registerTask 'test', ['build', 'jasmine']
+  grunt.registerTask 'test',  ['coffee', 'jasmine']
   grunt.registerTask 'gh_pages', ['copy:dist', 'build_gh_pages:gh_pages']
   grunt.registerTask 'prep_release', ['build','zip:chosen','package_jquery']
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "grunt-contrib-cssmin": "~0.6.1",
     "grunt-build-gh-pages": "0.0.4",
     "grunt-zip": "~0.9.2",
-    "grunt-dom-munger": "~2.0.1"
+    "grunt-dom-munger": "~2.0.1",
+    "grunt-contrib-jasmine": "~0.5.1"
   },
   "licenses": [
     {

--- a/spec/basic.spec.coffee
+++ b/spec/basic.spec.coffee
@@ -1,0 +1,3 @@
+describe "A suite", ->
+  it "contains spec with an expectation", ->
+    expect(true).toBe(true)

--- a/spec/basic.spec.coffee
+++ b/spec/basic.spec.coffee
@@ -20,3 +20,14 @@ describe "Basic setup", ->
       el = div.find(".chosen-#{clazz}")
       expect(el.size()).toBe(1)
 
+    # test a few interactions
+    expect(select.val()).toBe ""
+
+    container = div.find(".chosen-container")
+    container.trigger("mousedown") # open the drop
+    expect(container.hasClass("chosen-container-active")).toBe true
+    #select an item
+    container.find(".active-result").last().trigger("mouseup")
+
+    expect(select.val()).toBe "Afghanistan"
+

--- a/spec/basic.spec.coffee
+++ b/spec/basic.spec.coffee
@@ -1,3 +1,4 @@
-describe "A suite", ->
-  it "contains spec with an expectation", ->
-    expect(true).toBe(true)
+describe "Basic setup", ->
+  it "should add chosen to jQuery object", ->
+    expect(jQuery.fn.chosen).toBeDefined()
+

--- a/spec/basic.spec.coffee
+++ b/spec/basic.spec.coffee
@@ -2,3 +2,21 @@ describe "Basic setup", ->
   it "should add chosen to jQuery object", ->
     expect(jQuery.fn.chosen).toBeDefined()
 
+  it "should create very basic chosen", ->
+    tmpl = "
+      <select data-placeholder='Choose a Country...'>
+        <option value=''></option>
+        <option value='United States'>United States</option>
+        <option value='United Kingdom'>United Kingdom</option>
+        <option value='Afghanistan'>Afghanistan</option>
+      </select>
+    "
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    expect(select.size()).toBe(1)
+    select.chosen()
+    # very simple check that the necessary elements have been created
+    ["container", "container-single", "single", "default"].forEach (clazz)->
+      el = div.find(".chosen-#{clazz}")
+      expect(el.size()).toBe(1)
+

--- a/spec/public/specs.js
+++ b/spec/public/specs.js
@@ -1,8 +1,0 @@
-(function() {
-  describe("A suite", function() {
-    return it("contains spec with an expectation", function() {
-      return expect(true).toBe(true);
-    });
-  });
-
-}).call(this);

--- a/spec/public/specs.js
+++ b/spec/public/specs.js
@@ -1,0 +1,8 @@
+(function() {
+  describe("A suite", function() {
+    return it("contains spec with an expectation", function() {
+      return expect(true).toBe(true);
+    });
+  });
+
+}).call(this);


### PR DESCRIPTION
Hi Chosen,

as mentioned in #1401 there seems to be some appetite for introducing testing to chosen.

This pull request does exactly that by using the great jasmine spec runner for Grunt. It installs phantomjs through npm and uses that to run the tests. If you're not familiar with phantomjs: it's a headless webkit browser that is as good as a real browser.

The specs themselves are fairly simple so far but I tried to show an example of constructing a chosen element entirely in memory, doing some interactions on it and asserting the expected result.

If you want to run the tests just do a
```
npm install
grunt test
```

If you have any questions, please shoot. I'd love to incorporate your feedback into this PR.