### PR TITLE
Use word boundary matching

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -131,6 +131,7 @@ class AbstractChosen
     escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
 
     regexString = if @search_contains then escapedSearchText else "\\b#{escapedSearchText}\\w*\\b"
+    regexString = "^#{regexString}" unless @enable_split_word_search or @search_contains
     regex = new RegExp(regexString, 'i')
 
     for option in @results_data


### PR DESCRIPTION
@harvesthq/chosen-developers This fixes #75 (which has been around for 2 years already..), #1463 and actually also #1216, because the provided solution over there won't work.

By making use of word boundary matching (http://www.regular-expressions.info/wordboundaries.html) the split word search is much cleaner (no more actual splitting of strings), and the search results are better. 

**Example:**
There is a Chosen select box with the option 'Heard Island and Mcdonald Islands' (like on the [example page](http://harvesthq.github.io/chosen/)). With `enable_split_word_search` set to `true` (default) searching for 'and Mc' won't show any results. Although searching for 'and' and 'Mcdonald' does.

With my modifications the results will show as expected.
