### PR TITLE
Make it trigger 'chosen:showing_dropdown' event only after li fields are...

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -72,6 +72,9 @@ Example:
 > causing the bug, and potential solutions (and your opinions on their
 > merits).
 
+**Note:** In an effort to keep open issues to a manageable number, we will close any issues
+that do not provide enough information for us to be able to work on a solution.
+You will be encouraged to reopen it after providing the necessary details.
 
 <a name="features"></a>
 ## Feature requests


### PR DESCRIPTION
... populated

This fixes the timing of the showing_dropdown event to only trigger after the inner LI's are created. This is a bug for users who want to add additional styling such as images inside the lists or any other type of stylings.

A JSFIDDLE was created to demonstrate the bug http://jsfiddle.net/lagrz/3A5jq/
