### PR TITLE
Trigger/Fire Results Showing Event After Winnow

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -224,7 +224,6 @@ class Chosen extends AbstractChosen
       return false
 
     @container.addClass "chosen-with-drop"
-
     @results_showing = true
 
     @search_field.focus()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -218,14 +218,13 @@ class @Chosen extends AbstractChosen
       return false
 
     @container.addClassName "chosen-with-drop"
-    @form_field.fire("chosen:showing_dropdown", {chosen: this})
-
     @results_showing = true
 
     @search_field.focus()
     @search_field.value = @search_field.value
 
     this.winnow_results()
+    @form_field.fire("chosen:showing_dropdown", {chosen: this})
 
   update_results_content: (content) ->
     @search_results.update content


### PR DESCRIPTION
@harvesthq/chosen-developers 

In #1476, @lagrz pointed out that triggering the `chosen:showing_dropdown` event before the list is built creates a scenario where the returned list content value does not match what is expected to be there. This is resolved by simply triggering the event after the results are winnowed.

Thanks @lagrz!
