### PR TITLE
Use word boundary matching

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -214,6 +214,7 @@ class AbstractChosen
 
   get_search_regex: (escaped_search_string) ->
     regex_string = if @search_contains then escaped_search_string else "\\b#{escaped_search_string}\\w*\\b"
+    regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     new RegExp(regex_string, 'i')
 
   choices_count: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -172,6 +172,7 @@ class AbstractChosen
 
       option.search_match = false
       results_group = null
+      search_match = null
 
       if this.include_option_in_results(option)
 
@@ -187,14 +188,14 @@ class AbstractChosen
         option.search_text = if option.group then option.label else option.html
 
         unless option.group and not @group_search
-          option.search_match = regex.test(option.search_text)
+          search_match = this.search_string_match(option.search_text, regex)
+          option.search_match = search_match?
 
           results += 1 if option.search_match and not option.group
 
           if option.search_match
             if searchText.length
-              match = regex.exec(option.search_text)
-              startpos = match.index
+              startpos = search_match.index
               text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
               option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
 
@@ -216,6 +217,9 @@ class AbstractChosen
     regex_string = if @search_contains then escaped_search_string else "\\b#{escaped_search_string}\\w*\\b"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     new RegExp(regex_string, 'i')
+
+  search_string_match: (search_string, regex) ->
+    regex.exec(search_string)
 
   choices_count: ->
     return @selected_option_count if @selected_option_count?

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -216,7 +216,8 @@ class AbstractChosen
   get_search_regex: (escaped_search_string) ->
     regex_string = if @search_contains then escaped_search_string else "\\b#{escaped_search_string}\\w*\\b"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
-    new RegExp(regex_string, 'i')
+    regex_flag = if @case_sensitive_search then "" else "i"
+    new RegExp(regex_string, regex_flag)
 
   search_string_match: (search_string, regex) ->
     regex.exec(search_string)


### PR DESCRIPTION
@harvesthq/chosen-developers 

This is a new PR for @koenpunt's excellent #1465. In his words:

> By making use of word boundary matching (http://www.regular-expressions.info/wordboundaries.html) the split word search is much cleaner (no more actual splitting of strings), and the search results are better.

I want to be very careful about merging this in, but I'm loving what I see so far. With default options set:

<table>
<tr>
  <th>Search String</th>
  <th>Expected to Match</th>
  <th>Old way</th>
  <th>New way</th>
</tr>
<tr>
  <td>Democratic Republic of</td>
  <td>Congo, The Democratic Republic of The</td>
  <td>:poop:</td>
  <td>:+1:</td>
</tr>
<tr>
  <td>of America</td>
  <td>United States (of America)</td>
  <td>:poop:</td>
  <td>:+1:</td>
</tr>
<tr>
  <td>Holland</td>
  <td>Netherlands/Holland</td>
  <td>:poop:</td>
  <td>:+1:</td>
</tr>
</table>


Here's what I think we should do before this gets a final :shipit:
- [ ] Add unit tests for verifying that search results are correct. To do this, we might need to break the actual search match function out of the winnow method.
- [ ] Performance Test with 1000s of items (perhaps replacing test + match with a single match call)
- [ ] Determine if we need to make an API change related to `enable_split_word_search` or `search_contains`. I don't think you should be able to turn off `enable_split_word_search` if `search_contains` is `true`, but I want to do some experimenting there.

Fixes #75 and #1463 
