### PR TITLE
Docs should state that we (maintainers) will reopen issues.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -74,7 +74,7 @@ Example:
 
 **Note:** In an effort to keep open issues to a manageable number, we will close any issues
 that do not provide enough information for us to be able to work on a solution.
-You will be encouraged to reopen it after providing the necessary details.
+You will be encouraged to provide the necessary details, after which we will reopen the issue.
 
 <a name="features"></a>
 ## Feature requests


### PR DESCRIPTION
@harvesthq/chosen-developers We have been encouraging people to reopen issue once they have provided more info. However, only maintainers can reopen issues. I've updated the language in `contributing.md`. We should also adjust our responses when closing issues.
