### PR TITLE
Ignore invisible soft hyphen characters when matching options

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -153,7 +153,7 @@ class AbstractChosen
                 
         unless option.group and not @group_search
 
-          option.search_text = if option.group then option.label else option.html
+          option.search_text = (if option.group then option.label else option.html).replace(/\u00AD/g, '')
           option.search_match = this.search_string_match(option.search_text, regex)
           results += 1 if option.search_match and not option.group
 


### PR DESCRIPTION
Conditionally invisible soft hyphens (http://en.wikipedia.org/wiki/Soft_hyphen) can be used to break long words to many rows so the UI stays clean. There is no reason to take soft hyphens into account when matching text because users never enter it in the search box. It only introduces a bug where a long word cannot be matched because the user has not entered the invisible character in the search field.