### PR TITLE
Remove the use of jQuery's is() function for jQuery < 1.6 support.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -166,7 +166,7 @@ class Chosen extends AbstractChosen
 
   test_active_click: (evt) ->
     chosenContainer = $(evt.target).closest('.chosen-container')
-    if chosenContainer.length > 0 and @container[0] == chosenContainer[0]
+    if chosenContainer.length and @container[0] == chosenContainer[0]
       @active_field = true
     else
       this.close_field()


### PR DESCRIPTION
This change comes from HitmanInWis's issue at https://github.com/harvesthq/chosen/issues/1471

It removes the use of the jQuery is() function, which is different in jQuery < 1.6 so that a wider range of jQuery versions are support.
