### PR TITLE
Ignore context (right click) mousedown events

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -116,7 +116,7 @@ class Chosen extends AbstractChosen
       @selected_item.bind "focus.chosen", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    if !@is_disabled
+    if !@is_disabled && (evt && evt.which != 3)
       if evt and evt.type is "mousedown" and not @results_showing
         evt.preventDefault()
 
@@ -269,11 +269,12 @@ class Chosen extends AbstractChosen
       @search_field.removeClass "default"
 
   search_results_mouseup: (evt) ->
-    target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
-    if target.length
-      @result_highlight = target
-      this.result_select(evt)
-      @search_field.focus()
+    if evt and evt.which != 3
+      target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
+      if target.length
+        @result_highlight = target
+        this.result_select(evt)
+        @search_field.focus()
 
   search_results_mouseover: (evt) ->
     target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -116,7 +116,11 @@ class Chosen extends AbstractChosen
       @selected_item.bind "focus.chosen", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    if !@is_disabled && (evt && evt.which != 3)
+    mousedown_type = false
+    if evt 
+      mousedown_type = this.mousedown_checker(evt)
+
+    if !@is_disabled and (evt and mousedown_type == 'left')
       if evt and evt.type is "mousedown" and not @results_showing
         evt.preventDefault()
 
@@ -165,7 +169,8 @@ class Chosen extends AbstractChosen
 
 
   test_active_click: (evt) ->
-    if @container.is($(evt.target).closest('.chosen-container'))
+    mousedown_type = this.mousedown_checker(evt)
+    if mousedown_type == 'left' and @container.is($(evt.target).closest('.chosen-container'))
       @active_field = true
     else
       this.close_field()
@@ -269,7 +274,8 @@ class Chosen extends AbstractChosen
       @search_field.removeClass "default"
 
   search_results_mouseup: (evt) ->
-    if evt and evt.which != 3
+    mousedown_type = this.mousedown_checker(evt)
+    if mousedown_type == 'left'
       target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
       if target.length
         @result_highlight = target
@@ -470,6 +476,27 @@ class Chosen extends AbstractChosen
         evt.preventDefault()
         this.keydown_arrow()
         break
+
+  mousedown_checker: (evt) ->
+    evt = evt || window.event
+    mousedown_type = null
+    if (!evt.which and evt.button != undefined)
+      evt.which = ( evt.button & 1 ? 1 : ( evt.button & 2 ? 3 : ( evt.button & 4 ? 2 : 0 ) ) )
+
+    switch evt.which
+      when 1
+        mousedown_type = 'left'
+        break
+      when 2
+        mousedown_type = 'right'
+        break
+      when 3
+        mousedown_type = 'middle'
+        break
+      else
+        mousedown_type = 'other'
+
+    return mousedown_type
 
   search_field_scale: ->
     if @is_multiple

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -477,27 +477,6 @@ class Chosen extends AbstractChosen
         this.keydown_arrow()
         break
 
-  mousedown_checker: (evt) ->
-    evt = evt || window.event
-    mousedown_type = null
-    if (!evt.which and evt.button != undefined)
-      evt.which = ( evt.button & 1 ? 1 : ( evt.button & 2 ? 3 : ( evt.button & 4 ? 2 : 0 ) ) )
-
-    switch evt.which
-      when 1
-        mousedown_type = 'left'
-        break
-      when 2
-        mousedown_type = 'right'
-        break
-      when 3
-        mousedown_type = 'middle'
-        break
-      else
-        mousedown_type = 'other'
-
-    return mousedown_type
-
   search_field_scale: ->
     if @is_multiple
       h = 0

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -116,11 +116,7 @@ class Chosen extends AbstractChosen
       @selected_item.bind "focus.chosen", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    mousedown_type = false
-    if evt 
-      mousedown_type = this.mousedown_checker(evt)
-
-    if !@is_disabled and (evt and mousedown_type == 'left')
+    if !@is_disabled and (evt and this.mousedown_checker(evt) == 'left')
       if evt and evt.type is "mousedown" and not @results_showing
         evt.preventDefault()
 
@@ -169,8 +165,7 @@ class Chosen extends AbstractChosen
 
 
   test_active_click: (evt) ->
-    mousedown_type = this.mousedown_checker(evt)
-    if mousedown_type == 'left' and @container.is($(evt.target).closest('.chosen-container'))
+    if this.mousedown_checker(evt) == 'left' and @container.is($(evt.target).closest('.chosen-container'))
       @active_field = true
     else
       this.close_field()
@@ -274,8 +269,7 @@ class Chosen extends AbstractChosen
       @search_field.removeClass "default"
 
   search_results_mouseup: (evt) ->
-    mousedown_type = this.mousedown_checker(evt)
-    if mousedown_type == 'left'
+    if this.mousedown_checker(evt) == 'left'
       target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
       if target.length
         @result_highlight = target

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -477,27 +477,6 @@ class @Chosen extends AbstractChosen
         this.keydown_arrow()
         break
 
-  mousedown_checker: (evt) ->
-    evt = evt || window.event
-    mousedown_type = null
-    if (!evt.which and evt.button != undefined)
-      evt.which = ( evt.button & 1 ? 1 : ( evt.button & 2 ? 3 : ( evt.button & 4 ? 2 : 0 ) ) )
-
-    switch evt.which
-      when 1
-        mousedown_type = 'left'
-        break
-      when 2
-        mousedown_type = 'right'
-        break
-      when 3
-        mousedown_type = 'middle'
-        break
-      else
-        mousedown_type = 'other'
-
-    return mousedown_type
-
   search_field_scale: ->
     if @is_multiple
       h = 0

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -113,7 +113,7 @@ class @Chosen extends AbstractChosen
       @selected_item.observe "focus", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    if !@is_disabled
+    if !@is_disabled && (evt && evt.which != 3)
       if evt and evt.type is "mousedown" and not @results_showing
         evt.stop()
 
@@ -263,11 +263,12 @@ class @Chosen extends AbstractChosen
       @search_field.removeClassName "default"
 
   search_results_mouseup: (evt) ->
-    target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
-    if target
-      @result_highlight = target
-      this.result_select(evt)
-      @search_field.focus()
+    if evt and evt.which != 3
+      target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
+      if target
+        @result_highlight = target
+        this.result_select(evt)
+        @search_field.focus()
 
   search_results_mouseover: (evt) ->
     target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -113,7 +113,11 @@ class @Chosen extends AbstractChosen
       @selected_item.observe "focus", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    if !@is_disabled && (evt && evt.which != 3)
+    mousedown_type = false
+    if evt 
+      mousedown_type = this.mousedown_checker(evt)
+    
+    if !@is_disabled and (evt and mousedown_type == 'left')
       if evt and evt.type is "mousedown" and not @results_showing
         evt.stop()
 
@@ -160,7 +164,8 @@ class @Chosen extends AbstractChosen
     @search_field.focus()
 
   test_active_click: (evt) ->
-    if evt.target.up('.chosen-container') is @container
+    mousedown_type = this.mousedown_checker(evt)
+    if mousedown_type == 'left' and evt.target.up('.chosen-container') is @container
       @active_field = true
     else
       this.close_field()
@@ -263,7 +268,8 @@ class @Chosen extends AbstractChosen
       @search_field.removeClassName "default"
 
   search_results_mouseup: (evt) ->
-    if evt and evt.which != 3
+    mousedown_type = this.mousedown_checker(evt)
+    if mousedown_type == 'left'
       target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
       if target
         @result_highlight = target
@@ -470,6 +476,27 @@ class @Chosen extends AbstractChosen
         evt.preventDefault()
         this.keydown_arrow()
         break
+
+  mousedown_checker: (evt) ->
+    evt = evt || window.event
+    mousedown_type = null
+    if (!evt.which and evt.button != undefined)
+      evt.which = ( evt.button & 1 ? 1 : ( evt.button & 2 ? 3 : ( evt.button & 4 ? 2 : 0 ) ) )
+
+    switch evt.which
+      when 1
+        mousedown_type = 'left'
+        break
+      when 2
+        mousedown_type = 'right'
+        break
+      when 3
+        mousedown_type = 'middle'
+        break
+      else
+        mousedown_type = 'other'
+
+    return mousedown_type
 
   search_field_scale: ->
     if @is_multiple

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -113,11 +113,7 @@ class @Chosen extends AbstractChosen
       @selected_item.observe "focus", @activate_action if !@is_multiple
 
   container_mousedown: (evt) ->
-    mousedown_type = false
-    if evt 
-      mousedown_type = this.mousedown_checker(evt)
-    
-    if !@is_disabled and (evt and mousedown_type == 'left')
+    if !@is_disabled and (evt and this.mousedown_checker(evt) == 'left')
       if evt and evt.type is "mousedown" and not @results_showing
         evt.stop()
 
@@ -164,8 +160,7 @@ class @Chosen extends AbstractChosen
     @search_field.focus()
 
   test_active_click: (evt) ->
-    mousedown_type = this.mousedown_checker(evt)
-    if mousedown_type == 'left' and evt.target.up('.chosen-container') is @container
+    if this.mousedown_checker(evt) == 'left' and evt.target.up('.chosen-container') is @container
       @active_field = true
     else
       this.close_field()
@@ -268,8 +263,7 @@ class @Chosen extends AbstractChosen
       @search_field.removeClassName "default"
 
   search_results_mouseup: (evt) ->
-    mousedown_type = this.mousedown_checker(evt)
-    if mousedown_type == 'left'
+    if this.mousedown_checker(evt) == 'left'
       target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
       if target
         @result_highlight = target

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -201,6 +201,27 @@ class AbstractChosen
     evt.preventDefault()
     this.results_show() unless @results_showing or @is_disabled
 
+  mousedown_checker: (evt) ->
+    evt = evt || window.event
+    mousedown_type = null
+    if (!evt.which and evt.button != undefined)
+      evt.which = ( evt.button & 1 ? 1 : ( evt.button & 2 ? 3 : ( evt.button & 4 ? 2 : 0 ) ) )
+
+    switch evt.which
+      when 1
+        mousedown_type = 'left'
+        break
+      when 2
+        mousedown_type = 'right'
+        break
+      when 3
+        mousedown_type = 'middle'
+        break
+      else
+        mousedown_type = 'other'
+
+    return mousedown_type
+
   keyup_checker: (evt) ->
     stroke = evt.which ? evt.keyCode
     this.search_field_scale()


### PR DESCRIPTION
Otherwise, the native browser context menu appears on right click of container, and on right click of search result item, AND the default chosen "click" action occurs at the same time, producing an unexpected result for the end-user.

Fixes #949
