### PR TITLE
handle hidden fields to avoid "0" width issue

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -223,7 +223,13 @@ class AbstractChosen
       else this.results_search()
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    if @options.width 
+      return @options.width 
+    else
+      if $(@sublform_field).is(":visible")
+        return "#{@form_field.offsetWidth}px"
+      else
+        return "auto";
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
Hi,

When elements are hidden during the initialization of chosen, it was returning "0px" for the container width causing it to glitch out. This fixes that but returning "auto" which will make it inherit the width of the container instead. 

Let me know if there are any questions,

Thanks
