### PR TITLE
add support for paste events

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -88,6 +88,8 @@ class Chosen extends AbstractChosen
     @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
     @search_field.bind 'keydown.chosen', (evt) => this.keydown_checker(evt); return
     @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
+    @search_field.bind 'cut.chosen', (evt) => this.clipboard_event_checker(evt); return
+    @search_field.bind 'paste.chosen', (evt) => this.clipboard_event_checker(evt); return
 
     if @is_multiple
       @search_choices.bind 'click.chosen', (evt) => this.choices_click(evt); return

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -72,6 +72,8 @@ class @Chosen extends AbstractChosen
     @search_field.observe "keyup", (evt) => this.keyup_checker(evt)
     @search_field.observe "keydown", (evt) => this.keydown_checker(evt)
     @search_field.observe "focus", (evt) => this.input_focus(evt)
+    @search_field.observe "cut", (evt) => this.clipboard_event_checker(evt)
+    @search_field.observe "paste", (evt) => this.clipboard_event_checker(evt)
 
     if @is_multiple
       @search_choices.observe "click", (evt) => this.choices_click(evt)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -222,6 +222,9 @@ class AbstractChosen
         # don't do anything on these keys
       else this.results_search()
 
+  clipboard_event_checker: (evt) ->
+    setTimeout (=> this.results_search()), 50
+
   container_width: ->
     return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
 


### PR DESCRIPTION
A short delay (currently 50ms) is required after the paste event for the
pasted text to enter the textbox.  Then we can trigger a `keyup` event as if
that copy had just been typed into the box manually.

This is meant to address #1601 opened by me today.
