### PR TITLE
Add CSS selector to make sure full placeholder text is visible after deselecting

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -57,6 +57,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png');
   .chosen-default {
     color: #999;
   }
+  .chosen-single-with-deselect.chosen-default span,
   .chosen-single span {
     display: block;
     overflow: hidden;


### PR DESCRIPTION
When using the single deselect option, the class 'chosen-single-with-deselect' is added which makes room for the 'x' icon. When the option is then deselected, the icon is no longer shown, but the class is still there, and still reduces the amount of placeholder text that is shown. This can lead one select box having truncated placeholder text while another can show the text in full.

By adding a selector that takes advantage of the 'chosen-default' class, we can fit the full placeholder text at all times.

You could also remove the class 'chosen-single-with-deselect' after deselecting, but that would be 2 lines (1 each for jQuery and Prototype) instead of one :).

Fiddle here: http://jsfiddle.net/PncDb/3/

Bug was found and fixed 10/12/13
