### PR TITLE
Add 'chosen:search_results_updated' event

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -59,7 +59,7 @@ class Chosen extends AbstractChosen
     else
       @search_container = @container.find('div.chosen-search').first()
       @selected_item = @container.find('.chosen-single').first()
-    
+
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
@@ -235,6 +235,7 @@ class Chosen extends AbstractChosen
 
   update_results_content: (content) ->
     @search_results.html content
+    @form_field_jq.trigger("chosen:search_results_updated", {chosen: this})
 
   results_hide: ->
     if @results_showing
@@ -291,7 +292,7 @@ class Chosen extends AbstractChosen
       close_link = $('<a />', { class: 'search-choice-close', 'data-option-array-index': item.array_index })
       close_link.bind 'click.chosen', (evt) => this.choice_destroy_link_click(evt)
       choice.append close_link
-    
+
     @search_container.before  choice
 
   choice_destroy_link_click: (evt) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -92,7 +92,7 @@ class @Chosen extends AbstractChosen
       @container.select(".search-choice-close").each (choice) ->
         choice.stopObserving()
     else
-      @selected_item.stopObserving() 
+      @selected_item.stopObserving()
 
     if @search_field.tabIndex
       @form_field.tabIndex = @search_field.tabIndex
@@ -229,6 +229,7 @@ class @Chosen extends AbstractChosen
 
   update_results_content: (content) ->
     @search_results.update content
+    @form_field.fire("chosen:search_results_updated", {chosen: this})
 
   results_hide: ->
     if @results_showing
@@ -330,7 +331,7 @@ class @Chosen extends AbstractChosen
         high.removeClassName("active-result")
       else
         this.reset_single_select_options()
-      
+
       high.addClassName("result-selected")
 
       item = @results_data[ high.getAttribute("data-option-array-index") ]

--- a/public/options.html
+++ b/public/options.html
@@ -68,7 +68,7 @@
         <tr>
           <td>no_results_text</td>
           <td>"No results match"</td>
-          <td>The text to be displayed when no matching results are found. The current search is shown at the end of the text (e.g. 
+          <td>The text to be displayed when no matching results are found. The current search is shown at the end of the text (e.g.
            No reults match "Bad Search").</td>
         </tr>
         <tr>
@@ -209,6 +209,10 @@
         <tr>
           <td>chosen:hiding_dropdown</td>
           <td>triggered when Chosen's dropdown is closed (it also sends the <code class="language-javascript">chosen</code> object as a parameter).</td>
+        </tr>
+        <tr>
+          <td>chosen:search_results_updated</td>
+          <td>triggered when Chosen's search results are updated (it also sends the <code class="language-javascript">chosen</code> object as a parameter).</td>
         </tr>
       </table>
 


### PR DESCRIPTION
This event will be triggered on every update of the search results
area (via `update_results_content()`). It can be used, for example,
in case you need to attach extra info to your search result items.
