### PR TITLE
Change `search_text` to use `option.text` rather than `option.html`

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -153,7 +153,7 @@ class AbstractChosen
                 
         unless option.group and not @group_search
 
-          option.search_text = if option.group then option.label else option.html
+          option.search_text = if option.group then option.label else option.text
           option.search_match = this.search_string_match(option.search_text, regex)
           results += 1 if option.search_match and not option.group
 


### PR DESCRIPTION
Ember.js litters the DOM with `<script>` tags that are used to perform its DOM binding. So when using an `Ember.Select` component with Chosen, searches would never return results because the regex binds to the start using `/^...`, and the value of `option.html` always starts with a `<script>` tag - so it would never match the regex.

This PR fixes the problem by searching on `option.text`. Another solution would be to change the regex to not bind to the start, but these seemed to be a less significant change.
