### PR TITLE
Use style width if select list is hidden and width option not set.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -223,7 +223,13 @@ class AbstractChosen
       else this.results_search()
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    return if @options.width? 
+      @options.width 
+    else if @form_field.offsetWidth
+      "#{@form_field.offsetWidth}px"
+    else if @form_field.style.width
+      @form_field.style.width
+    else "auto"
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
If the select list or its container is hidden, width is set to 0px. I know that we can set the width option on the chosen() method (ie, chosen({width: '100px'}), but that forces us to use a chosen() statement for each and every hidden select vs being able to simply call $('.chosen-select').chosen() (and being able to control look and feel with page level css).

If there is no width option and offsetWidth is 0px, then chosen should try to use the width style attribute on the select list.

Excuse any erroneous coffeescript, as this is my first time writing in it :-)

UPDATE: I just realized that my pull request could be more efficient by caching the offsetWidth property (which appears to cause a dom reflow everytime it's called). When I get a sec, I'll update the coffeescript...