### PR TITLE
Trim option's innerHTML to allow searching in weird HTML code

### DIFF
--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -20,7 +20,6 @@ class SelectParser
       disabled: group.disabled
     this.add_option( option, group_position, group.disabled ) for option in group.childNodes
 
-
   add_option: (option, group_position, group_disabled) ->
     if option.nodeName.toUpperCase() is "OPTION"
       if option.text != ""

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -30,7 +30,7 @@ class SelectParser
           options_index: @options_index
           value: option.value
           text: option.text
-          html: option.innerHTML
+          html: option.innerHTML.trim()
           selected: option.selected
           disabled: if group_disabled is true then group_disabled else option.disabled
           group_array_index: group_position

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -20,6 +20,7 @@ class SelectParser
       disabled: group.disabled
     this.add_option( option, group_position, group.disabled ) for option in group.childNodes
 
+
   add_option: (option, group_position, group_disabled) ->
     if option.nodeName.toUpperCase() is "OPTION"
       if option.text != ""
@@ -30,7 +31,7 @@ class SelectParser
           options_index: @options_index
           value: option.value
           text: option.text
-          html: option.innerHTML.trim()
+          html: option.innerHTML.replace(/^\s+|\s+$/g, '')
           selected: option.selected
           disabled: if group_disabled is true then group_disabled else option.disabled
           group_array_index: group_position


### PR DESCRIPTION
With this change, if the HTML is (note the linebreaks)

```
<option>
    string
</option>
```

chosen will now find this option when searching for "st".
