### PR TITLE
"chosen:close" triggerable event

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -59,7 +59,7 @@ class Chosen extends AbstractChosen
     else
       @search_container = @container.find('div.chosen-search').first()
       @selected_item = @container.find('.chosen-single').first()
-    
+
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
@@ -292,7 +292,7 @@ class Chosen extends AbstractChosen
       close_link = $('<a />', { class: 'search-choice-close', 'data-option-array-index': item.array_index })
       close_link.bind 'click.chosen', (evt) => this.choice_destroy_link_click(evt)
       choice.append close_link
-    
+
     @search_container.before  choice
 
   choice_destroy_link_click: (evt) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -93,7 +93,7 @@ class @Chosen extends AbstractChosen
       @container.select(".search-choice-close").each (choice) ->
         choice.stopObserving()
     else
-      @selected_item.stopObserving() 
+      @selected_item.stopObserving()
 
     if @search_field.tabIndex
       @form_field.tabIndex = @search_field.tabIndex
@@ -331,7 +331,7 @@ class @Chosen extends AbstractChosen
         high.removeClassName("active-result")
       else
         this.reset_single_select_options()
-      
+
       high.addClassName("result-selected")
 
       item = @results_data[ high.getAttribute("data-option-array-index") ]

--- a/public/options.html
+++ b/public/options.html
@@ -68,7 +68,7 @@
         <tr>
           <td>no_results_text</td>
           <td>"No results match"</td>
-          <td>The text to be displayed when no matching results are found. The current search is shown at the end of the text (e.g. 
+          <td>The text to be displayed when no matching results are found. The current search is shown at the end of the text (e.g.
            No reults match "Bad Search").</td>
         </tr>
         <tr>


### PR DESCRIPTION
So... I did a thing?  In code?  And it seems to even work!

This adds a `chosen:close` triggerable event, which does the logical opposite of the `chosen:open` event.  See https://github.com/harvesthq/chosen/commit/3709cc8b8832f7a7b4558d0be97b1301b2a92b02 for the relevant code -- the other commits are for adding docs and some editor-supplied whitespace cleanup.

Fixes https://github.com/harvesthq/chosen/issues/1662

I obviously have no idea what I'm doing, so feel free to correct me.
