### PR TITLE
add jspm package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,13 @@
     "dependencies": {
       "jquery": ">=1.4.4"
     }
+  },
+  "jspm": {
+    "main": "chosen.jquery.js",
+    "files": ["chosen.jquery.js", "chosen.css", "chosen-sprite.png", "chosen-sprite@2x.png"],
+    "shim": {
+      "chosen.jquery": ["./chosen.css!", "jquery"]
+    },
+    "buildConfig": { "uglify": true }
   }
 }


### PR DESCRIPTION
Further to #1655, I've included the necessary changes in the package.json here.

I've relaxed the jQuery constraint, so that this can be used with any version of jquery as simply as:

```javascript
  jspm.config({
    map: {
      jquery: 'jquery@1.8'
    }
  });
```

Being included before the require to `jspm.import('chosen')`

This allows the exact version to be environment-specific. Semver ranges will be supported in a future version as well, but that is a few months away.

The demo is still available here - http://jsbin.com/EfOYaBE/2/edit

Any further questions just ask.