### PR TITLE
Fixed result-selected class being added to more than one option after the first use of the drop down.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -340,7 +340,11 @@ class Chosen extends AbstractChosen
 
       item = @results_data[ high[0].getAttribute("data-option-array-index") ]
       item.selected = true
-
+      unless @is_multiple
+        iter = 0
+        while iter < @results_data.length
+          @results_data[iter].selected = false
+          iter++
       @form_field.options[item.options_index].selected = true
       @selected_option_count = null
 


### PR DESCRIPTION


The result-selected class can be sometimes used to hide the currently selected option to avoid redundancy in the options being shown in single mode. But because of the issue that this change fixes it is sometimes added to two options - the current and the previously selected one. 