### PR TITLE
Add a way to do left bound word search to chosen for arbitrary word bounardies

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -24,7 +24,7 @@ class AbstractChosen
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
     @group_search = if @options.group_search? then @options.group_search else true
     @search_contains = @options.search_contains || false
-    @search_contains_prefixes = @options.search_contains_prefixes || false
+    @search_contains_prefix = @options.search_contains_prefix || false
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
@@ -133,9 +133,9 @@ class AbstractChosen
     searchText = this.get_search_text()
     escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     regexAnchor = if @search_contains then "" else "^"
-    if @search_contains_prefixes?
-      @search_contains_prefixes_regex = new RegExp('^' + @search_contains_prefixes, 'i') if not @search_contains_prefixes_regex?
-      regexAnchor = '^' + escapedSearchText + '|' + (if @search_contains_prefixes_regex.test(searchText) then '' else @search_contains_prefixes)
+    if @search_contains_prefix?
+      @search_contains_prefix_regex = new RegExp('^' + @search_contains_prefix, 'i') if not @search_contains_prefix_regex?
+      regexAnchor = '^' + escapedSearchText + '|' + (if @search_contains_prefix_regex.test(searchText) then '' else @search_contains_prefix)
     regex = new RegExp(regexAnchor + escapedSearchText, 'i')
     zregex = new RegExp(escapedSearchText, 'i')
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -24,7 +24,7 @@ class AbstractChosen
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
     @group_search = if @options.group_search? then @options.group_search else true
     @search_contains = @options.search_contains || false
-    @search_contains_prefix = if @options.search_contains_prefix || false
+    @search_contains_prefixes = @options.search_contains_prefixes || false
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
@@ -133,8 +133,9 @@ class AbstractChosen
     searchText = this.get_search_text()
     escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     regexAnchor = if @search_contains then "" else "^"
-    if @search_contains_prefix?
-      regexAnchor = '^' + escapedSearchText + '|' + (if searchText.indexOf(@search_contains_prefix) == 0 then '' else @search_contains_prefix)
+    if @search_contains_prefixes?
+      @search_contains_prefixes_regex = new RegExp('^' + @search_contains_prefixes, 'i') if not @search_contains_prefixes_regex?
+      regexAnchor = '^' + escapedSearchText + '|' + (if @search_contains_prefixes_regex.test(searchText) then '' else @search_contains_prefixes)
     regex = new RegExp(regexAnchor + escapedSearchText, 'i')
     zregex = new RegExp(escapedSearchText, 'i')
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -24,6 +24,7 @@ class AbstractChosen
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
     @group_search = if @options.group_search? then @options.group_search else true
     @search_contains = @options.search_contains || false
+    @search_contains_prefix = if @options.search_contains_prefix || false
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
@@ -132,6 +133,8 @@ class AbstractChosen
     searchText = this.get_search_text()
     escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     regexAnchor = if @search_contains then "" else "^"
+    if @search_contains_prefix?
+      regexAnchor = '^' + escapedSearchText + '|' + (if searchText.indexOf(@search_contains_prefix) == 0 then '' else @search_contains_prefix)
     regex = new RegExp(regexAnchor + escapedSearchText, 'i')
     zregex = new RegExp(escapedSearchText, 'i')
 

--- a/public/options.html
+++ b/public/options.html
@@ -87,6 +87,11 @@
           <td>By default, Chosen's search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()'s and []'s.</td>
         </tr>
         <tr>
+          <td>search_contains_prefix</td>
+          <td>false</td>
+          <td>Setting this to any string will use it as a separator and match the start of any word. search_contains_prefix='_' then option of 'time_on_site' will be matched by any of (_?(time|on|site). This can be any regex pattern, so [._\s] will do left bound word search for words.
+        </tr>
+        <tr>
           <td>single_backstroke_delete</td>
           <td>true</td>
           <td>By default, pressing delete/backspace on multiple selects will remove a selected choice. When <code class="language-javascript">false</code>, pressing delete/backspace will highlight the last choice, and a second press deselects it.</td>


### PR DESCRIPTION
I wanted a way to search on a dropdown that had separators dev_db.time_on_site_logs, and wanted left bound search on period / space / underscore. This supports that and a bit more -- you can use the particular separator to only left-bound your search on that separator so _logs vs .logs.

Not super thrilled about the name / docs, but happy to work on that if you like the idea.
