### PR TITLE
Support jQuery < 1.6 by not using $.fn.is().

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -166,7 +166,8 @@ class Chosen extends AbstractChosen
 
 
   test_active_click: (evt) ->
-    if @container.is($(evt.target).closest('.chosen-container'))
+    active_container = $(evt.target).closest('.chosen-container')
+    if active_container.length and @container[0] == active_container[0]
       @active_field = true
     else
       this.close_field()


### PR DESCRIPTION
Adapted from rooby's pull request for issue #1555:
- Condensed into one commit.
- Renamed local var chosenContainer -> active_container to (I hope) better reflect what the variable represents, and project naming conventions.
