### PR TITLE
Added title attribute to options and optgroups

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -88,6 +88,7 @@ class AbstractChosen
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
     option_el.innerHTML = option.search_text
+    option_el.title = option.title if option.title
 
     this.outerHTML(option_el)
 
@@ -98,6 +99,7 @@ class AbstractChosen
     group_el = document.createElement("li")
     group_el.className = "group-result"
     group_el.innerHTML = group.search_text
+    group_el.title = group.title if group.title
 
     this.outerHTML(group_el)
 

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -16,6 +16,7 @@ class SelectParser
       array_index: group_position
       group: true
       label: this.escapeExpression(group.label)
+      title: group.title if group.title
       children: 0
       disabled: group.disabled
     this.add_option( option, group_position, group.disabled ) for option in group.childNodes
@@ -31,6 +32,7 @@ class SelectParser
           value: option.value
           text: option.text
           html: option.innerHTML
+          title: option.title if option.title
           selected: option.selected
           disabled: if group_disabled is true then group_disabled else option.disabled
           group_array_index: group_position


### PR DESCRIPTION
Minor patch to close #1692. The `title` attribute from the original `<option>` and `<optgroup>` are preserved when generating the `<li>` for chosen.