### PR TITLE
Call show_search_field_default after a result is selected.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -351,8 +351,7 @@ class Chosen extends AbstractChosen
         this.single_set_selected_text(item.text)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
-
-      @search_field.val ""
+      this.show_search_field_default()
 
       @form_field_jq.trigger "change", {'selected': @form_field.options[item.options_index].value} if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -346,8 +346,7 @@ class @Chosen extends AbstractChosen
         this.single_set_selected_text(item.text)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
-
-      @search_field.value = ""
+      this.show_search_field_default()
 
       @form_field.simulate("change") if typeof Event.simulate is 'function' && (@is_multiple || @form_field.selectedIndex != @current_selectedIndex)
       @current_selectedIndex = @form_field.selectedIndex


### PR DESCRIPTION
@harvesthq/chosen-developers 

#1701 is kind of a non-issue in my eyes, but the change is simple enough and I actually prefer this to what exists now. After selecting a result, we should always be resetting a field's value the same way. This adds an extra class removal call in the non-multiple version, but it's harmless.

What say you?

Fixes #1701