### PR TITLE
fix to work with bootstrap modals

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -223,7 +223,12 @@ class AbstractChosen
       else this.results_search()
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    if @options.width
+      return @options.width
+    else
+      if @form_field.offsetWidth == 0
+        return "" + $(this.form_field).width() + "px"
+      return "#{@form_field.offsetWidth}px"
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
Fixes issue where chosen elements that were initialized in a hidden modal, and then displayed, are shown with the proper width/visibility.
