### PR TITLE
Issue #1686 : onFocus causes auto scroll to x=0 when search is hidden

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -125,8 +125,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png');
     background-clip: padding-box;
   }
   &.chosen-container-single-nosearch .chosen-search {
-    position: absolute;
-    left: -9999px;
+    display: none;
   }
 }
 /* @end */


### PR DESCRIPTION
Changing the search box from being placed at -9999 to not being displayed, fixes the issue at hand.
