### PR TITLE
Calling activate_field on choices_click, fixes #1729

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -202,6 +202,7 @@ class AbstractChosen
 
   choices_click: (evt) ->
     evt.preventDefault()
+    this.activate_field()
     this.results_show() unless @results_showing or @is_disabled
 
   keyup_checker: (evt) ->


### PR DESCRIPTION
Fixes #1729 simply by sending focus to `.search-field input` when clicking `.chosen-choices`.

At first, I imagined two possible solutions to this issue:
1. Modify the width of `.search-field input` to fill the width of `.chosen-choices` minus the width of any currently selected values.
2. Send focus to `.search-field input` when clicking `.chosen-choices`.

The first option was not selected as it was more complicated and it would fail to address the case of clicking inside the red circled area in the following screenshot:
![screen shot 2014-01-16 at 7 20 14 pm](https://f.cloud.github.com/assets/706922/1937700/a283cadc-7f2d-11e3-8dc3-cef367086f2d.png)
