### PR TITLE
make sprite vars default to be able to preset outside of chosen

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -2,8 +2,8 @@
 @import "compass/css3/images";
 @import "compass/css3/user-interface";
 
-$chosen-sprite: image-url('chosen-sprite.png');
-$chosen-sprite-retina: image-url('chosen-sprite@2x.png');
+$chosen-sprite: image-url('chosen-sprite.png') !default;
+$chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 
 /* @group Base */
 .chosen-container {


### PR DESCRIPTION
This sets $chosen-sprite and $chosen-sprite-retina to default. It is then possible to define these variables before importing the chosen.scss file.

This gives you more flexibility to use your own folder structure since compass only knows about one `images_dir` per project and computes the image-url relative to this config setting.
