### PR TITLE
Add note that Chosen is disabled on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1430,7 +1430,7 @@
        </li>
        <li>
           <h3>What browsers are supported?</h3>
-          <p>All modern desktop browsers are supported (Firefox, Chrome, Safari and IE9). Legacy support for IE8 is also enabled. Chosen is disabled on iPhone, iPod, and Android devices (<a href="https://github.com/harvesthq/chosen/pull/1388">more information</a>).</p>
+          <p>All modern desktop browsers are supported (Firefox, Chrome, Safari and IE9). Legacy support for IE8 is also enabled. Chosen is disabled on iPhone, iPod Touch, and Android mobile devices (<a href="https://github.com/harvesthq/chosen/pull/1388">more information</a>).</p>
        </li>
        <li>
           <h3>Didn't there used to be a Prototype version of Chosen?</h3>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -1432,7 +1432,7 @@
         </li>
         <li>
           <h3>What browsers are supported?</h3>
-          <p>All modern desktop browsers are supported (Firefox, Chrome, Safari and IE9). Legacy support for IE8 is also enabled. Chosen is disabled on iPhone, iPod, and Android devices (<a href="https://github.com/harvesthq/chosen/pull/1388">more information</a>).</p>
+          <p>All modern desktop browsers are supported (Firefox, Chrome, Safari and IE9). Legacy support for IE8 is also enabled. Chosen is disabled on iPhone, iPod Touch, and Android mobile devices (<a href="https://github.com/harvesthq/chosen/pull/1388">more information</a>).</p>
         </li>
       </ul>
 


### PR DESCRIPTION
@harvesthq/chosen-developers Follow up on [this comment](https://github.com/harvesthq/chosen/issues/1589#issuecomment-33121682) -- we never actually note anywhere that Chosen is disabled by default on iPhone/Android, and that the supported browsers we mention are the desktop versions of those browsers.
