### PR TITLE
Add a default color to chosen results

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -133,6 +133,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 
 /* @group Results */
 .chosen-container .chosen-results {
+  color: #444;
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
@@ -162,6 +163,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
       color: #fff;
     }
     &.no-results {
+      color: #777;
       display: list-item;
       background: #f4f4f4;
     }
@@ -212,14 +214,11 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
         border: 0 !important;
         background: transparent !important;
         box-shadow: none;
-        color: #666;
+        color: #999;
         font-size: 100%;
         font-family: sans-serif;
         line-height: normal;
         border-radius: 0;
-      }
-      .default {
-        color: #999;
       }
     }
     &.search-choice {
@@ -303,7 +302,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     border: 1px solid #5897fb;
     box-shadow: 0 0 5px rgba(#000,.3);
     li.search-field input[type="text"] {
-      color: #111 !important;
+      color: #222 !important;
     }
   }
 }


### PR DESCRIPTION
This fixes https://github.com/harvesthq/chosen/issues/1724#issuecomment-34399579. With no color on `.chosen-results` it defaulted to body text, which is not good if that's anything other than a black. I matched the color to `.chosen-single`.

While doing this I quickly looked at colors and changed two small things. I made `.no-results` lighter, and found that the multiple select input did not need `color: #999` on a separate `.default` style, so I fixed that.
