### PR TITLE
Use text not html in search results

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -153,7 +153,7 @@ class AbstractChosen
                 
         unless option.group and not @group_search
 
-          option.search_text = if option.group then option.label else option.html
+          option.search_text = if option.group then option.label else option.text
           option.search_match = this.search_string_match(option.search_text, regex)
           results += 1 if option.search_match and not option.group
 


### PR DESCRIPTION
The search result should show the option text, not the html. Without this patch, things like Ember that use invisible elements (script tags) inside of option elements cause search to break:

![image](https://f.cloud.github.com/assets/1217/2178947/c360dbb6-9682-11e3-8cc9-b0b71609cddc.png)
