### PR TITLE
Added alias characters options description

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -109,6 +109,13 @@
             <p><strong>Note:</strong> this is for multiple selects only. In single selects, the selected result will always be displayed.</p>
           </td>
         </tr>
+        <tr>
+          <td>alias_characters</td>
+          <td>[]</td>
+          <td>
+            <p>By default, Chosen is an exact match selector. By setting this option to an array of characters to be aliases of each other, Chosen will make treat these characters as the same in the search.</p>
+          </td>
+        </tr>
       </table>
 
       <h2><a name="attributes" class="anchor" href="#attributes">Attributes</a></h2>


### PR DESCRIPTION
We came across a situation where we had to be insensitive to certain special characters in the search such as ' ' and '-'. Therefore, we would like to implement an option that would treat certain characters the same in the search. 

For example, I have an item that is called 'Oil Filter B-99'. I would like this item to be searchable by either entering 'B 99', 'B99' or 'B-99'. 
