### PR TITLE
Fix multiselect input padding in Firefox.

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -208,7 +208,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
       white-space: nowrap;
       input[type="text"] {
         margin: 1px 0;
-        padding: 5px;
+        padding-left: 5px;
         height: 15px;
         outline: 0;
         border: 0 !important;


### PR DESCRIPTION
Fixes the following padding issue in Firefox for multi-selects.

![screen shot 2014-02-26 at 3 39 42 pm](https://f.cloud.github.com/assets/600638/2276737/4e85b998-9f37-11e3-81a2-c34538dd5373.png)
