### PR TITLE
Tab completion in multi-select

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -459,7 +459,9 @@ class Chosen extends AbstractChosen
         @backstroke_length = this.search_field.val().length
         break
       when 9
-        this.result_select(evt) if this.results_showing and not @is_multiple
+        if this.results_showing
+          evt.preventDefault() if @is_multiple
+          this.result_select(evt)
         @mouse_on_container = false
         break
       when 13

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -458,7 +458,9 @@ class @Chosen extends AbstractChosen
         @backstroke_length = this.search_field.value.length
         break
       when 9
-        this.result_select(evt) if this.results_showing and not @is_multiple
+        if this.results_showing
+          evt.preventDefault() if @is_multiple
+          this.result_select(evt)
         @mouse_on_container = false
         break
       when 13


### PR DESCRIPTION
### Current result

When using the multi-select option, pressing tab does not select the highlighted result. 
### Expected result

Pressing tab should select the highlighted result. If there is no highlighted result then we should navigate to the next input. Here is a [fiddle](http://jsfiddle.net/_iains/dLezP/embedded/result/) with the desired result. 

Also referenced in issue #1273 

Do people agree this should be the default or would you prefer it to be wrapped in option? Maybe something like `allowsMutliSelectTabCompletion`. 
