### PR TITLE
Update license year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 #### Chosen
 - by Patrick Filler for [Harvest](http://getharvest.com)
-- Copyright (c) 2011-2013 by Harvest
+- Copyright (c) 2011-2014 by Harvest
 
 Available for use under the [MIT License](http://en.wikipedia.org/wiki/MIT_License)
 


### PR DESCRIPTION
Fix outdated copyright year (updated to 2014).
The copyright year was out of date. Copyright notices must reflect the current year, so this commit updates the listed year to 2014.

See http://www.copyright.gov/circs/circ01.pdf for more info.
