### PR TITLE
Disable Chosen on all Mobile devices

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -258,13 +258,13 @@ class AbstractChosen
   # class methods and variables ============================================================ 
 
   @browser_is_supported: ->
+    if /Mobile/i.test(navigator.userAgent)
+      return false
+  
     if window.navigator.appName == "Microsoft Internet Explorer"
       return document.documentMode >= 8
-    if /iP(od|hone)/i.test(window.navigator.userAgent)
-      return false
-    if /Android/i.test(window.navigator.userAgent)
-      return false if /Mobile/i.test(window.navigator.userAgent)
-    return true
+  
+    true
 
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"


### PR DESCRIPTION
Previously, only iPhone/iPod and Android devices with `Mobile` in the userAgent string were disabled.

But as noted in #1848 there are (obviously) more mobile devices with different userAgent strings. But all of them include `Mobile` in it. 

With the possible exception for BlackBerry. So maybe the regex should be `/Mobile|BlackBerry/i`.

@harvesthq/chosen-developers What do you guys think?
