### PR TITLE
Keyboard appears for a second when selecting a chosen-multiple element

### DIFF
--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -9,7 +9,7 @@ class @Chosen extends AbstractChosen
 
     # HTML Templates
     @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>')
-    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
+    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input readonly type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_up_html: ->


### PR DESCRIPTION
on mobile devices when selecting a chosen-multiple element, the keyboard appears for a second because the textfield get focus.

If we mark it as readonly we get rid of this problem
