### PR TITLE
no_results_fallback_option_index

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,6 +29,8 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
+    # in case of no_results, the <option> with no_results_fallback_option_index will be selected (e.g. "other", "default" etc.)
+    @no_results_fallback_option_index = if@options.no_results_fallback_option_index? then @options.no_results_fallback_option_index else -1
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -169,10 +171,12 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
-    if results < 1 and searchText.length
+    if results < 1 and searchText.length and this.no_results_fallback_option_index == -1
       this.update_results_content ""
       this.no_results searchText
     else
+      if this.no_results_fallback_option_index != -1
+        this.results_data[this.no_results_fallback_option_index].search_match = true
       this.update_results_content this.results_option_build()
       this.winnow_results_set_highlight()
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,7 +29,6 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
-    # in case of no_results, the first <option> with data-fallback attribute will be selected (e.g. "other", "default" etc.)
     @no_results_fallback = @options.no_results_fallback || false
 
   set_default_text: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,8 +29,8 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
-    # in case of no_results, the <option> at this index will be selected (e.g. "other", "default" etc.)
-    @no_results_fallback_option_index = @options.no_results_fallback_option_index || -1
+    # in case of no_results, the first <option> with data-fallback attribute will be selected (e.g. "other", "default" etc.)
+    @no_results_fallback = @options.no_results_fallback || false
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -171,12 +171,14 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
-    if results < 1 and searchText.length and this.no_results_fallback_option_index == -1
+    if results < 1 and searchText.length and not this.no_results_fallback
       this.update_results_content ""
       this.no_results searchText
     else
-      if this.no_results_fallback_option_index != -1
-        this.results_data[this.no_results_fallback_option_index].search_match = true
+      if this.no_results_fallback
+        fallbackOptions = this.results_data.filter (el) -> el.is_fallback
+        if fallbackOptions.length > 0
+          fallbackOptions[0].search_match = true;
       this.update_results_content this.results_option_build()
       this.winnow_results_set_highlight()
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,8 +29,8 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
-    # in case of no_results, the <option> with no_results_fallback_option_index will be selected (e.g. "other", "default" etc.)
-    @no_results_fallback_option_index = if@options.no_results_fallback_option_index? then @options.no_results_fallback_option_index else -1
+    # in case of no_results, the <option> at this index will be selected (e.g. "other", "default" etc.)
+    @no_results_fallback_option_index = @options.no_results_fallback_option_index || -1
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -36,6 +36,7 @@ class SelectParser
           group_array_index: group_position
           classes: option.className
           style: option.style.cssText
+          is_fallback: option.getAttribute('data-fallback') != null
       else
         @parsed.push
           array_index: @parsed.length

--- a/public/options.html
+++ b/public/options.html
@@ -109,6 +109,13 @@
             <p><strong>Note:</strong> this is for multiple selects only. In single selects, the selected result will always be displayed.</p>
           </td>
         </tr>
+        <tr>
+          <td>no_results_fallback</td>
+          <td>false</td>
+          <td>
+            <p>If <code class="language-javascript">true</code>, then in case of no matches, the first <code class="language-html">&lt;option&gt;</code> with <code class="language-javascript">data-fallback</code> attribute will be selected (e.g. "other", "default" etc.)</p>
+          </td>
+        </tr>
       </table>
 
       <h2><a name="attributes" class="anchor" href="#attributes">Attributes</a></h2>


### PR DESCRIPTION
Gives possibility to have one `<option>` from the original `<select>` chosen as a fallback default. 

If the user filters out all other `<option>`s, then this `<option>` will remain selected and highlighted. On `blur`, it will remain selected. 

Particularly useful for cases where a value is required and "Other" is valid `<option>`.

![chosen-no_options_fallback](https://cloud.githubusercontent.com/assets/4896806/2655163/ec7b8ff4-bfe1-11e3-87ac-803b01659eb9.png)