### PR TITLE
Documentation update: Added a note about triggering chosen:updated after modifying attributes.

### DIFF
--- a/public/docsupport/style.css
+++ b/public/docsupport/style.css
@@ -30,6 +30,7 @@ footer { color: #999; padding-top: 40px; font-size: 0.8em; text-align: center; }
 body { font-family: sans-serif; font-size: 1em; }
 
 p { margin: 0 0 .7em; max-width: 700px; }
+table+p { margin-top: 1em; }
 
 h2 { border-bottom: 1px solid #ccc; font-size: 1.2em; margin: 3em 0 1em 0; font-weight: bold;}
 h3 { font-weight: bold; }

--- a/public/options.html
+++ b/public/options.html
@@ -145,6 +145,15 @@
         </tr>
       </table>
 
+      <p><strong>Note:</strong> When modifying attributes after instantiation, you must <a href='#triggerable-events'>trigger</a> an <code class="language-html">chosen:updated</code> event to update the select field.</p>
+
+      <h3>Example:</h3>
+
+<pre>
+  <code class="language-javascript">$("#form_field_with_chosen").prop("disabled", true).trigger("chosen:updated")</code>
+</pre>
+
+
       <h2><a name="classes" class="anchor" href="#classes">Classes</a></h2>
       <p>Classes placed on the select tag can be used to configure Chosen.</p>
 
@@ -216,7 +225,7 @@
         </tr>
       </table>
 
-      <p style="margin-top: 1em;">
+      <p>
         <strong>Note:</strong> all custom Chosen events (those that being with <code class="language-javascript">chosen:</code>) also include the <code class="language-javascript">chosen</code> object as a parameter.
       </p>
 
@@ -227,7 +236,7 @@
 
 <pre>
   <code class="language-javascript">// tell Chosen that a select has changed
-    $('.my_select_box').trigger('chosen:updated');</code>
+  $('.my_select_box').trigger('chosen:updated');</code>
 </pre>
 
       <table class="docs-table">


### PR DESCRIPTION
I spent awhile trying to figure out how to enable/disable an initialised chosen field. Eventually, I found this issue with comments that explains how to do it: https://github.com/harvesthq/chosen/pull/651. IMO it's not that clear from the docs so I've added a note w/ example to the options page.

Added new style definition for paragraphs after a table (table+p), removed inline margin & fixed example alignment issue.
