### PR TITLE
Prevent search field losing focus

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -203,6 +203,8 @@ class AbstractChosen
   choices_click: (evt) ->
     evt.preventDefault()
     this.results_show() unless @results_showing or @is_disabled
+    if @results_showing and not @is_disabled
+      @search_field.focus() unless @is_multiple and @max_selected_options <= this.choices_count()
 
   keyup_checker: (evt) ->
     stroke = evt.which ? evt.keyCode


### PR DESCRIPTION
First click to chosen container works fine (search_field gets focus), but when chosen is already active(this.results_showing == true) then input loses focus unless clicked on the search field itself