### PR TITLE
Verify that chosen is instanceof Chosen, fixes #1914

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -8,9 +8,9 @@ $.fn.extend({
     this.each (input_field) ->
       $this = $ this
       chosen = $this.data('chosen')
-      if options is 'destroy' && chosen
+      if options is 'destroy' && chosen instanceof Chosen
         chosen.destroy()
-      else unless chosen
+      else unless chosen instanceof Chosen
         $this.data('chosen', new Chosen(this, options))
 
       return


### PR DESCRIPTION
Previously, if the Chosen `<select>` had a `data-chosen` attribute, it was never initialized. 
Now we verify if `chosen` is an actual instance of `Chosen` 
