### PR TITLE
Validation purposes

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -44,7 +44,7 @@ class Chosen extends AbstractChosen
     else
       @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
-    @form_field_jq.hide().after @container
+    @form_field_jq.css({'position':'absolute', 'left':'-9999px', 'height':'1px'}).after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()


### PR DESCRIPTION
Position absolute instead of display none to original select for validation purposes. There are situations where you don't want to validation :hidden fields, which will cause the selects to be on that group too. Hiding them with position absolute solves the issue (especially if you're using parsleyjs validation)
