### PR TITLE
Allow native select interface for iOS (including iPad) and Android—potential improvement over #1388

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -69,35 +69,36 @@ class Chosen extends AbstractChosen
     @form_field_jq.trigger("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); return
-    @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); return
+    unless this.use_native_interface()
+      @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); return
+      @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); return
 
-    @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
-    @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
-    @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
-    @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
+      @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
+      @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
+      @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
+      @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
 
-    @search_results.bind 'mouseup.chosen', (evt) => this.search_results_mouseup(evt); return
-    @search_results.bind 'mouseover.chosen', (evt) => this.search_results_mouseover(evt); return
-    @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
-    @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
+      @search_results.bind 'mouseup.chosen', (evt) => this.search_results_mouseup(evt); return
+      @search_results.bind 'mouseover.chosen', (evt) => this.search_results_mouseover(evt); return
+      @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
+      @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
 
-    @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
-    @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
-    @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
+      @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
+      @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
+      @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
+
+      @search_field.bind 'blur.chosen', (evt) => this.input_blur(evt); return
+      @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
+      @search_field.bind 'keydown.chosen', (evt) => this.keydown_checker(evt); return
+      @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
+      @search_field.bind 'cut.chosen', (evt) => this.clipboard_event_checker(evt); return
+      @search_field.bind 'paste.chosen', (evt) => this.clipboard_event_checker(evt); return
 
     @form_field_jq.bind "change.chosen", (evt) => this.results_update_field(evt); return
     @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
     @form_field_jq.bind "chosen:activate.chosen", (evt) => this.activate_field(evt); return
     @form_field_jq.bind "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
     @form_field_jq.bind "chosen:close.chosen", (evt) => this.input_blur(evt); return
-
-    @search_field.bind 'blur.chosen', (evt) => this.input_blur(evt); return
-    @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
-    @search_field.bind 'keydown.chosen', (evt) => this.keydown_checker(evt); return
-    @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
-    @search_field.bind 'cut.chosen', (evt) => this.clipboard_event_checker(evt); return
-    @search_field.bind 'paste.chosen', (evt) => this.clipboard_event_checker(evt); return
 
     if @is_multiple
       @search_choices.bind 'click.chosen', (evt) => this.choices_click(evt); return

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -29,7 +29,7 @@ class Chosen extends AbstractChosen
     container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
     container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
     container_classes.push "chosen-rtl" if @is_rtl
-    container_classes.push "use-native-interface" if this.use_native_interface()
+    container_classes.push "chosen-use-native" if this.use_native_interface()
 
     container_props =
       'class': container_classes.join ' '

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -44,9 +44,9 @@ class Chosen extends AbstractChosen
     @container = @form_field_jq.parent()
 
     if @is_multiple
-      @container.append '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
+      @container.prepend '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
     else
-      @container.append '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
+      @container.prepend '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
     @dropdown = @container.find('div.chosen-drop').first()
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -17,7 +17,7 @@ class @Chosen extends AbstractChosen
     container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
     container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
     container_classes.push "chosen-rtl" if @is_rtl
-    container_classes.push "use-native-interface" if this.use_native_interface()
+    container_classes.push "chosen-use-native" if this.use_native_interface()
 
     container_props =
       'class': container_classes.join ' '

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -30,9 +30,9 @@ class @Chosen extends AbstractChosen
     @container = @form_field.wrap(@container)
 
     if @is_multiple
-      @container.insert({ bottom: @multi_temp.evaluate({ "default": @default_text }) })
+      @container.insert({ top: @multi_temp.evaluate({ "default": @default_text }) })
     else
-      @container.insert({ bottom: @single_temp.evaluate({ "default": @default_text }) })
+      @container.insert({ top: @single_temp.evaluate({ "default": @default_text }) })
 
     @dropdown = @container.down('div.chosen-drop')
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -55,36 +55,37 @@ class @Chosen extends AbstractChosen
     @form_field.fire("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.observe "touchstart", (evt) => this.container_mousedown(evt)
-    @container.observe "touchend", (evt) => this.container_mouseup(evt)
+    unless this.use_native_interface()
+      @container.observe "touchstart", (evt) => this.container_mousedown(evt)
+      @container.observe "touchend", (evt) => this.container_mouseup(evt)
 
-    @container.observe "mousedown", (evt) => this.container_mousedown(evt)
-    @container.observe "mouseup", (evt) => this.container_mouseup(evt)
-    @container.observe "mouseenter", (evt) => this.mouse_enter(evt)
-    @container.observe "mouseleave", (evt) => this.mouse_leave(evt)
+      @container.observe "mousedown", (evt) => this.container_mousedown(evt)
+      @container.observe "mouseup", (evt) => this.container_mouseup(evt)
+      @container.observe "mouseenter", (evt) => this.mouse_enter(evt)
+      @container.observe "mouseleave", (evt) => this.mouse_leave(evt)
 
-    @search_results.observe "mouseup", (evt) => this.search_results_mouseup(evt)
-    @search_results.observe "mouseover", (evt) => this.search_results_mouseover(evt)
-    @search_results.observe "mouseout", (evt) => this.search_results_mouseout(evt)
-    @search_results.observe "mousewheel", (evt) => this.search_results_mousewheel(evt)
-    @search_results.observe "DOMMouseScroll", (evt) => this.search_results_mousewheel(evt)
+      @search_results.observe "mouseup", (evt) => this.search_results_mouseup(evt)
+      @search_results.observe "mouseover", (evt) => this.search_results_mouseover(evt)
+      @search_results.observe "mouseout", (evt) => this.search_results_mouseout(evt)
+      @search_results.observe "mousewheel", (evt) => this.search_results_mousewheel(evt)
+      @search_results.observe "DOMMouseScroll", (evt) => this.search_results_mousewheel(evt)
 
-    @search_results.observe "touchstart", (evt) => this.search_results_touchstart(evt)
-    @search_results.observe "touchmove", (evt) => this.search_results_touchmove(evt)
-    @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
+      @search_results.observe "touchstart", (evt) => this.search_results_touchstart(evt)
+      @search_results.observe "touchmove", (evt) => this.search_results_touchmove(evt)
+      @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
+
+      @search_field.observe "blur", (evt) => this.input_blur(evt)
+      @search_field.observe "keyup", (evt) => this.keyup_checker(evt)
+      @search_field.observe "keydown", (evt) => this.keydown_checker(evt)
+      @search_field.observe "focus", (evt) => this.input_focus(evt)
+      @search_field.observe "cut", (evt) => this.clipboard_event_checker(evt)
+      @search_field.observe "paste", (evt) => this.clipboard_event_checker(evt)
 
     @form_field.observe "change", (evt) => this.results_update_field(evt)
     @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
     @form_field.observe "chosen:activate", (evt) => this.activate_field(evt)
     @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
     @form_field.observe "chosen:close", (evt) => this.input_blur(evt)
-
-    @search_field.observe "blur", (evt) => this.input_blur(evt)
-    @search_field.observe "keyup", (evt) => this.keyup_checker(evt)
-    @search_field.observe "keydown", (evt) => this.keydown_checker(evt)
-    @search_field.observe "focus", (evt) => this.input_focus(evt)
-    @search_field.observe "cut", (evt) => this.clipboard_event_checker(evt)
-    @search_field.observe "paste", (evt) => this.clipboard_event_checker(evt)
 
     if @is_multiple
       @search_choices.observe "click", (evt) => this.choices_click(evt)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -149,7 +149,7 @@ class AbstractChosen
           results_group = @results_data[option.group_array_index]
           results += 1 if results_group.active_options is 0 and results_group.search_match
           results_group.active_options += 1
-                
+
         unless option.group and not @group_search
 
           option.search_text = if option.group then option.label else option.text
@@ -163,7 +163,7 @@ class AbstractChosen
               option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
 
             results_group.group_match = true if results_group?
-          
+
           else if option.group_array_index? and @results_data[option.group_array_index].search_match
             option.search_match = true
 
@@ -197,7 +197,7 @@ class AbstractChosen
     @selected_option_count = 0
     for option in @form_field.options
       @selected_option_count += 1 if option.selected
-    
+
     return @selected_option_count
 
   choices_click: (evt) ->
@@ -255,15 +255,20 @@ class AbstractChosen
     tmp.appendChild(element)
     tmp.innerHTML
 
-  # class methods and variables ============================================================ 
+  use_native_interface: ->
+    if @options.use_native_interface
+      return @options.use_native_interface
+    if /iP(ad|od|hone)/i.test(window.navigator.userAgent)
+      return true
+    if /Android/i.test(window.navigator.userAgent)
+      return true if /Mobile/i.test(window.navigator.userAgent)
+    return false
+
+  # class methods and variables ============================================================
 
   @browser_is_supported: ->
     if window.navigator.appName == "Microsoft Internet Explorer"
       return document.documentMode >= 8
-    if /iP(od|hone)/i.test(window.navigator.userAgent)
-      return false
-    if /Android/i.test(window.navigator.userAgent)
-      return false if /Mobile/i.test(window.navigator.userAgent)
     return true
 
   @default_multiple_text: "Select Some Options"

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -46,7 +46,6 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     bottom: 0;
     left: 0;
     width: 100%;
-    z-index: 100;
   }
 }
 /* @end */

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -32,6 +32,16 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   a{
     cursor: pointer;
   }
+  select {
+    display: none;
+  }
+  &.use-native-interface select {
+    display: initial;
+    height: 100%;
+    opacity: 0;
+    position: absolute;
+    z-index: 100;
+  }
 }
 /* @end */
 

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -36,6 +36,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     display: none;
   }
   &.chosen-use-native select {
+    -webkit-appearance: menulist-button;
     display: initial;
     height: 100%;
     opacity: 0;

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -35,7 +35,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   select {
     display: none;
   }
-  &.use-native-interface select {
+  &.chosen-use-native select {
     display: initial;
     height: 100%;
     opacity: 0;

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -41,6 +41,11 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     height: 100%;
     opacity: 0;
     position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
     z-index: 100;
   }
 }


### PR DESCRIPTION
Using chosen on small touch screens can be difficult and can feel clumsy. It looks like this was previously discussed in #1388, but the solution was to totally disable chosen for iPhones, iPods, and Android.

I think we can do a little better than that by combining the superior inactive-state UI of chosen with the superior active-state UI of the mobile device browser's select field interface. Not to mention the other features of chosen, [such as `max_selected_options`](https://github.com/harvesthq/chosen/pull/1388#issuecomment-37421975), that are lost right now by completely disabling chosen for mobile users.

We can accomplish this through a sort-of trick where a form element's opacity can be set to 0 so that it is unseen while still remaining interactive.

In this case, we can render the `.chosen-select` node in front of the `.chosen-choices` or `.chosen-single` node, but with an opacity of 0, so that it is invisible but interactive.

![img_0003](https://cloud.githubusercontent.com/assets/706922/3305770/2b00d5aa-f65a-11e3-8a53-bbb19661bb13.PNG)
![img_0005](https://cloud.githubusercontent.com/assets/706922/3305852/2bbee3a0-f65b-11e3-8a60-3ec777adea44.PNG)

This *does* come at the expense of search on iPads, but I think the native experience so far outweights the default chosen experience here that it is an acceptable compromise.

Additionally, all of this behavior can be toggled with a `use_native_interface` option so the current (non-native) behavior could be forced if desired. However, I have configured it to be enabled by default for iOS (including iPads) and for Android through the same userAgent string matching that was previously used to disable chosen on those devices.

This does require one major change to the markup structure: `.chosen-select` is now nested inside of `.chosen-container` rather than being a previous sibling to it. I did this so I could use `.chosen-container` as a positioning anchor for `.chosen-select`.

Happy to make adjustments if you think anything could be better. Thanks!