### PR TITLE
add support for scpecial characters

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -189,8 +189,8 @@ class AbstractChosen
     results = 0
 
     searchText = this.get_search_text()
-    escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     escapedSearchText = this.convert_accented_characters(escapedSearchText);
+    escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     zregex = new RegExp(escapedSearchText, 'i')
     regex = this.get_search_regex(escapedSearchText)
 


### PR DESCRIPTION
Add support for special characters on search.

Example: When I search for "Sao Paulo" (without ~) doesn't match with "São Paulo" (with ~).

I added a function convert_accented_characters, it convert a search query and search results special characters to match.
