### PR TITLE
Add right padding when allow_single_delect=true

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -229,7 +229,12 @@ class AbstractChosen
     setTimeout (=> this.results_search()), 50
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    if @options.width?
+      @options.width
+    else if @options.allow_single_deselect?
+      "#{@form_field.offsetWidth+25}px"
+    else 
+      "#{@form_field.offsetWidth}px"
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
The "x" button covers up the text when allow_single_deselect=true. For example, if my options are "yes" and "no", the options are entirely covered by the "x".

Increasing the width by 25px fixes this problem for all cases.