### PR TITLE
Use content-box for text inputs

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -215,6 +215,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
         border: 0 !important;
         background: transparent !important;
         box-shadow: none;
+        box-sizing: content-box;
         color: #999;
         font-size: 100%;
         font-family: sans-serif;


### PR DESCRIPTION
It's normally the default anyway but it's becoming very popular to set
`* { box-sizing: content-box; }` because it fixes so many annoying things.
Unfortunately, it can cause a problem when height and top or bottom
padding are set. In the case of this element, if border-box has been
set, we will only have 5px of vertical space left. So make sure it's
using content-box.
