### PR TITLE
Accessible `<select>` elem solution

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -45,7 +45,7 @@ class Chosen extends AbstractChosen
     else
       @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
-    @form_field_jq.addClass('sr-only').after @container
+    @form_field_jq.addClass('chosen-sr-only').after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -34,6 +34,7 @@ class Chosen extends AbstractChosen
       'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
       'title': @form_field.title
+      'aria-hidden': true
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
@@ -44,7 +45,7 @@ class Chosen extends AbstractChosen
     else
       @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
-    @form_field_jq.hide().after @container
+    @form_field_jq.addClass('sr-only').after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -28,7 +28,7 @@ class @Chosen extends AbstractChosen
 
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
 
-    @form_field.addClassName('sr-only').insert({ after: @container })
+    @form_field.addClassName('chosen-sr-only').insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
 
     @search_field = @container.down('input')

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -22,12 +22,13 @@ class @Chosen extends AbstractChosen
       'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
       'title': @form_field.title
+      'aria-hidden': true
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
 
-    @form_field.hide().insert({ after: @container })
+    @form_field.addClassName('sr-only').insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
 
     @search_field = @container.down('input')

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -417,3 +417,15 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   }
 }
 /* @end */
+
+/* @group Accessibility helpers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -419,7 +419,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 /* @end */
 
 /* @group Accessibility helpers */
-.sr-only {
+.chosen-sr-only {
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
> Proposed solution for [Issue 264](https://github.com/harvesthq/chosen/issues/264)

Instead of taking the "deep dive" into making the Chosen markup accessible, my proposed solution takes a _much_ simpler approach centered around the principles of progressive enhancement.

Instead of using `display: none` on the converted `<select>` element, I have used a utility CSS class that follows [accepted best practices for hiding content](http://a11yproject.com/posts/how-to-hide-content/) so that it is accessible to screen readers.  In addition to this, I have added an `aria-hidden=true` to the `<div class="chosen-container">` element.

The combination of these two simple changes makes for an accessible solution because: 
- The `<select>` element will be the control used by screen readers
- The `<div class="chosen-container">` element will be ignored by screen readers

Obviously a fully-accessible `listbox` solution would be ideal - but IMO, this change will go a long way to making existing Chosen implementations accessible today.
