### PR TITLE
Fix IME on Firefox.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -466,6 +466,7 @@ class Chosen extends AbstractChosen
         break
       when 13
         evt.preventDefault() if this.results_showing
+        @enter_was_keyed_down = true
         break
       when 38
         evt.preventDefault()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -466,6 +466,7 @@ class @Chosen extends AbstractChosen
         break
       when 13
         evt.preventDefault() if this.results_showing
+        @enter_was_keyed_down = true
         break
       when 38
         evt.preventDefault()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -217,7 +217,14 @@ class AbstractChosen
           this.results_search()
       when 13
         evt.preventDefault()
-        this.result_select(evt) if this.results_showing
+        # Work around Firefox preventing keystrokes from being detected
+        # while composing with an IME.
+        is_firefox = typeof InstallTrigger != 'undefined';
+        if is_firefox and !@enter_was_keyed_down
+          this.results_search()
+        else
+          this.result_select(evt) if this.results_showing
+        @enter_was_keyed_down = false
       when 27
         this.results_hide() if @results_showing
         return true


### PR DESCRIPTION
Hello, this pull request implements the IME part of #1946, in a hopefully proper way.

> Firefox prevents keystrokes from being detected while inputting with
an IME. That is, keystrokes produced from the start and the end of an
IME composition and its ending are blocked. As a result, pressing the
enter key to commit a composition does not filter the results and
select the previously highlighted result right away, preventing Firefox
users from ever changing the seleted item.

> To work around this problem, we differenciate “pressing enter to commit
a composition” from “pressing enter to select the highlighted result in
Chosen” by checking if the keydown event preceded the keyup one.

> Chrome and IE are not affected by this problem because they [do not
block key events during composition](https://bugzilla.mozilla.org/show_bug.cgi?id=354358#c40). If Firefox happen to switch to
Chrome and IE’s beheaviour, this commit should be reverted.
