### PR TITLE
Prevent focus event scrolling

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -91,7 +91,7 @@ class Chosen extends AbstractChosen
     @search_field.bind 'blur.chosen', (evt) => this.input_blur(evt); return
     @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
     @search_field.bind 'keydown.chosen', (evt) => this.keydown_checker(evt); return
-    @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
+    @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt);choice_destroy_link_click(evt); return
     @search_field.bind 'cut.chosen', (evt) => this.clipboard_event_checker(evt); return
     @search_field.bind 'paste.chosen', (evt) => this.clipboard_event_checker(evt); return
 


### PR DESCRIPTION
If you want to click on a "chosen-container" where the page offset is higher than the browser width,
you´ll be scrolled to position 0 on the x axis in you browser.

It could be prevented with the existing choice_destroy_link_click function
