### PR TITLE
Support for Fuzzy Searching Strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   compass

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -26,6 +26,7 @@ class AbstractChosen
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
     @group_search = if @options.group_search? then @options.group_search else true
     @search_contains = @options.search_contains || false
+    @search_fuzzy = @options.search_fuzzy || false
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
@@ -147,7 +148,7 @@ class AbstractChosen
     searchText = this.get_search_text()
     escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
     zregex = new RegExp(escapedSearchText, 'i')
-    regex = this.get_search_regex(escapedSearchText)
+    regex = this.get_search_regex(searchText)
 
     for option in @results_data
 
@@ -173,9 +174,7 @@ class AbstractChosen
 
           if option.search_match
             if searchText.length
-              startpos = option.search_text.search zregex
-              text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
-              option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
+                option.search_text = this.highlight_search_result(regex, zregex, option.search_text, searchText)
 
             results_group.group_match = true if results_group?
 
@@ -191,9 +190,49 @@ class AbstractChosen
       this.update_results_content this.results_option_build()
       this.winnow_results_set_highlight()
 
-  get_search_regex: (escaped_search_string) ->
-    regex_anchor = if @search_contains then "" else "^"
-    new RegExp(regex_anchor + escaped_search_string, 'i')
+  highlight_search_result: (regex, zregex, value, search) ->
+    if @search_fuzzy
+      search_text = []
+
+      tokens = search.split(' ').sort (a, b) ->
+        b.length - a.length
+
+      search_string = value.split ' '
+
+      for string in search_string
+        for token in tokens
+          if string.indexOf('<em>') == -1 && string.indexOf('</em>') == -1
+            string = string.replace(new RegExp('(' + token.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&") + ')', 'gi'), '<em>$1</em>')
+        search_text.push string
+
+      result = search_text.join ' '
+    else
+      startpos = value.search zregex
+      text = value.substr(0, startpos + search.length) + '</em>' + value.substr(startpos + search.length)
+      result = text.substr(0, startpos) + '<em>' + text.substr(startpos)
+
+    result
+
+  get_tokenized_regex_string: (text) ->
+    regex_tokens = []
+    tokens = this.get_tokenized_search_string text
+
+    for text in tokens
+      text = text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+      regex_tokens.push "(?=.*" + text + ")"
+
+    regex_tokens.join ''
+
+  get_tokenized_search_string: (text) ->
+    text.split ' '
+
+  get_search_regex: (text) ->
+    if @search_fuzzy
+      new RegExp(this.get_tokenized_regex_string(text), 'i')
+    else
+      text = text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+      regex_anchor = if @search_contains then "" else "^"
+      new RegExp(text, 'i')
 
   search_string_match: (search_string, regex) ->
     if regex.test search_string
@@ -284,4 +323,3 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
-

--- a/public/index.html
+++ b/public/index.html
@@ -1298,7 +1298,7 @@
 
       <h2><a name="right-to-left-support" class="anchor" href="#right-to-left-support">Right to Left Support</a></h2>
       <div class="side-by-side clearfix">
-        <p>Chosen supports right to left select boxes too. just add <code class="language-javascript">"chosen-rtl"</code> in addition to <code class="language-javascript">"chosen-select"</code> to your select tags and you are good to go.</p>
+        <p>Chosen supports right to left select boxes too. Just add <code class="language-javascript">"chosen-rtl"</code> in addition to <code class="language-javascript">"chosen-select"</code> to your select tags and you are good to go.</p>
         <pre><code class="language-markup">&lt;select class="chosen-select <strong>chosen-rtl</strong>"&gt;</code></pre>
         <div>
           <em>Single right to left select</em>
@@ -1322,6 +1322,80 @@
             <option>Giant Panda</option>
             <option selected>Sloth Bear</option>
             <option selected>Polar Bear</option>
+          </select>
+        </div>
+      </div>
+
+      <h2><a name="fuzzy-search-support" class="anchor" href="#fuzzy-search-support">Fuzzy Search Support</a></h2>
+      <div class="side-by-side clearfix">
+        <p>Chosen supports fuzzy search in select boxes too. Just add <code class="language-javascript">"search_fuzzy:true"</code> to your options and you are good to go.</p>
+        <div>
+          <em>Single Select</em>
+          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" class="chosen-select-fuzzy" tabindex="15">
+            <option value=""></option>
+            <option>American Black Bear</option>
+            <option>Asiatic Black Bear</option>
+            <option>Brown Bear</option>
+            <option>Giant Panda</option>
+            <option>Sloth Bear</option>
+            <option>Sun Bear</option>
+            <option>Polar Bear</option>
+            <option>Spectacled Bear</option>
+            <option>Cocos (Keeling) Islands</option>
+          </select>
+        </div>
+        <div>
+          <em>Single Select with Groups</em>
+          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select-fuzzy" tabindex="5">
+            <option value=""></option>
+            <optgroup label="NFC EAST">
+              <option>Dallas Cowboys</option>
+              <option>New York Giants</option>
+              <option>Philadelphia Eagles</option>
+              <option>Washington Redskins</option>
+            </optgroup>
+            <optgroup label="NFC NORTH">
+              <option>Chicago Bears</option>
+              <option>Detroit Lions</option>
+              <option>Green Bay Packers</option>
+              <option>Minnesota Vikings</option>
+            </optgroup>
+            <optgroup label="NFC SOUTH">
+              <option>Atlanta Falcons</option>
+              <option>Carolina Panthers</option>
+              <option>New Orleans Saints</option>
+              <option>Tampa Bay Buccaneers</option>
+            </optgroup>
+            <optgroup label="NFC WEST">
+              <option>Arizona Cardinals</option>
+              <option>St. Louis Rams</option>
+              <option>San Francisco 49ers</option>
+              <option>Seattle Seahawks</option>
+            </optgroup>
+            <optgroup label="AFC EAST">
+              <option>Buffalo Bills</option>
+              <option>Miami Dolphins</option>
+              <option>New England Patriots</option>
+              <option>New York Jets</option>
+            </optgroup>
+            <optgroup label="AFC NORTH">
+              <option>Baltimore Ravens</option>
+              <option>Cincinnati Bengals</option>
+              <option>Cleveland Browns</option>
+              <option>Pittsburgh Steelers</option>
+            </optgroup>
+            <optgroup label="AFC SOUTH">
+              <option>Houston Texans</option>
+              <option>Indianapolis Colts</option>
+              <option>Jacksonville Jaguars</option>
+              <option>Tennessee Titans</option>
+            </optgroup>
+            <optgroup label="AFC WEST">
+              <option>Denver Broncos</option>
+              <option>Kansas City Chiefs</option>
+              <option>Oakland Raiders</option>
+              <option>San Diego Chargers</option>
+            </optgroup>
           </select>
         </div>
       </div>
@@ -1459,6 +1533,7 @@
   <script type="text/javascript">
     var config = {
       '.chosen-select'           : {},
+      '.chosen-select-fuzzy'     : {search_fuzzy:true},
       '.chosen-select-deselect'  : {allow_single_deselect:true},
       '.chosen-select-no-single' : {disable_search_threshold:10},
       '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -1327,6 +1327,79 @@
         </div>
       </div>
 
+      <h2><a name="fuzzy-search-support" class="anchor" href="#fuzzy-search-support">Fuzzy Search Support</a></h2>
+      <div class="side-by-side clearfix">
+        <p>Chosen supports fuzzy search in select boxes too. Just add <code class="language-javascript">"search_fuzzy:true"</code> to your options and you are good to go.</p>
+        <div>
+          <em>Single Select</em>
+          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" class="chosen-select-fuzzy" tabindex="15">
+            <option value=""></option>
+            <option>American Black Bear</option>
+            <option>Asiatic Black Bear</option>
+            <option>Brown Bear</option>
+            <option>Giant Panda</option>
+            <option>Sloth Bear</option>
+            <option>Sun Bear</option>
+            <option>Polar Bear</option>
+            <option>Spectacled Bear</option>
+          </select>
+        </div>
+        <div>
+          <em>Single Select with Groups</em>
+          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select-fuzzy" tabindex="5">
+            <option value=""></option>
+            <optgroup label="NFC EAST">
+              <option>Dallas Cowboys</option>
+              <option>New York Giants</option>
+              <option>Philadelphia Eagles</option>
+              <option>Washington Redskins</option>
+            </optgroup>
+            <optgroup label="NFC NORTH">
+              <option>Chicago Bears</option>
+              <option>Detroit Lions</option>
+              <option>Green Bay Packers</option>
+              <option>Minnesota Vikings</option>
+            </optgroup>
+            <optgroup label="NFC SOUTH">
+              <option>Atlanta Falcons</option>
+              <option>Carolina Panthers</option>
+              <option>New Orleans Saints</option>
+              <option>Tampa Bay Buccaneers</option>
+            </optgroup>
+            <optgroup label="NFC WEST">
+              <option>Arizona Cardinals</option>
+              <option>St. Louis Rams</option>
+              <option>San Francisco 49ers</option>
+              <option>Seattle Seahawks</option>
+            </optgroup>
+            <optgroup label="AFC EAST">
+              <option>Buffalo Bills</option>
+              <option>Miami Dolphins</option>
+              <option>New England Patriots</option>
+              <option>New York Jets</option>
+            </optgroup>
+            <optgroup label="AFC NORTH">
+              <option>Baltimore Ravens</option>
+              <option>Cincinnati Bengals</option>
+              <option>Cleveland Browns</option>
+              <option>Pittsburgh Steelers</option>
+            </optgroup>
+            <optgroup label="AFC SOUTH">
+              <option>Houston Texans</option>
+              <option>Indianapolis Colts</option>
+              <option>Jacksonville Jaguars</option>
+              <option>Tennessee Titans</option>
+            </optgroup>
+            <optgroup label="AFC WEST">
+              <option>Denver Broncos</option>
+              <option>Kansas City Chiefs</option>
+              <option>Oakland Raiders</option>
+              <option>San Diego Chargers</option>
+            </optgroup>
+          </select>
+        </div>
+      </div>
+
       <h2><a name="change-update-events" class="anchor" href="#change-update-events">Change / Update Events</a></h2>
       <div class="side-by-side clearfix">
         <ul>
@@ -1458,6 +1531,7 @@
   document.observe('dom:loaded', function(evt) {
     var config = {
       '.chosen-select'           : {},
+      '.chosen-select-fuzzy'     : {search_fuzzy:true},
       '.chosen-select-deselect'  : {allow_single_deselect:true},
       '.chosen-select-no-single' : {disable_search_threshold:10},
       '.chosen-select-no-results': {no_results_text: "Oops, nothing found!"},

--- a/public/options.html
+++ b/public/options.html
@@ -87,6 +87,11 @@
           <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()s and []s.</td>
         </tr>
         <tr>
+          <td>search_fuzzy</td>
+          <td>false</td>
+          <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matching any part of a word in any part of the string. This is especially useful for options that are long phrases.</td>
+        </tr>
+        <tr>
           <td>single_backstroke_delete</td>
           <td>true</td>
           <td>By default, pressing delete/backspace on multiple selects will remove a selected choice. When <code class="language-javascript">false</code>, pressing delete/backspace will highlight the last choice, and a second press deselects it.</td>


### PR DESCRIPTION
The chosen library has been great to work with so far. While working on a project I came across a use case where I needed a more flexible search on the options in a select box.

This change set addresses that issue by implementing a sort of fuzzy search across the options. 

I'm no expert in CoffeeScript, so feel free to pull the code apart or suggest modifications.
##### Example

With the select box of:

``` html
<select data-placeholder="Your Favorite Types of Bear" class="chosen-select" multiple>
  <option value=""></option>
  <option>American Black Bear</option>
  <option>Asiatic Black Bear</option>
  <option>Brown Bear</option>
  <option selected>Giant Panda</option>
  <option>Sloth Bear</option>
  <option>Sun Bear</option>
  <option>Polar Bear</option>
  <option>Spectacled Bear</option>
</select>
```

Searching `Sp Bear` or `Bear Sp` will show  `Spectacled Bear`
