### PR TITLE
Restore user input

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -234,7 +234,7 @@ class Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.val(this.search_input)
+    @search_field.val(@search_input)
     this.winnow_results()
     @form_field_jq.trigger("chosen:showing_dropdown", {chosen: this})
 
@@ -248,7 +248,7 @@ class Chosen extends AbstractChosen
       @container.removeClass "chosen-with-drop"
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})
 
-    this.search_input = @search_field.val()
+    @search_input = @search_field.val()
     @results_showing = false
 
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -234,8 +234,7 @@ class Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.val @search_field.val()
-
+    @search_field.val(this.search_input)
     this.winnow_results()
     @form_field_jq.trigger("chosen:showing_dropdown", {chosen: this})
 
@@ -249,6 +248,7 @@ class Chosen extends AbstractChosen
       @container.removeClass "chosen-with-drop"
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})
 
+    this.search_input = @search_field.val()
     @results_showing = false
 
 
@@ -355,8 +355,6 @@ class Chosen extends AbstractChosen
         this.single_set_selected_text(item.text)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
-
-      @search_field.val ""
 
       @form_field_jq.trigger "change", {'selected': @form_field.options[item.options_index].value} if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -227,7 +227,7 @@ class @Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.value = this.search_input
+    @search_field.value = @search_input
 
     this.winnow_results()
     @form_field.fire("chosen:showing_dropdown", {chosen: this})
@@ -242,7 +242,7 @@ class @Chosen extends AbstractChosen
       @container.removeClassName "chosen-with-drop"
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})
 
-    this.search_input = @search_field.value
+    @search_input = @search_field.value
     @results_showing = false
 
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -227,7 +227,7 @@ class @Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.value = @search_field.value
+    @search_field.value = this.search_input
 
     this.winnow_results()
     @form_field.fire("chosen:showing_dropdown", {chosen: this})
@@ -242,6 +242,7 @@ class @Chosen extends AbstractChosen
       @container.removeClassName "chosen-with-drop"
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})
 
+    this.search_input = @search_field.value
     @results_showing = false
 
 
@@ -350,8 +351,6 @@ class @Chosen extends AbstractChosen
         this.single_set_selected_text(item.text)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
-
-      @search_field.value = ""
 
       @form_field.simulate("change") if typeof Event.simulate is 'function' && (@is_multiple || @form_field.selectedIndex != @current_selectedIndex)
       @current_selectedIndex = @form_field.selectedIndex

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -15,6 +15,7 @@ class AbstractChosen
     @click_test_action = (evt) => this.test_active_click(evt)
     @activate_action = (evt) => this.activate_field(evt)
     @active_field = false
+    @search_input = ""
     @mouse_on_container = false
     @results_showing = false
     @result_highlighted = null


### PR DESCRIPTION
These changes save any user input in a new variable named search_input. The user input is restored to the search field whenever the field regains focus, including after a result has already been selected. This allows the user to more easily correct their selection or continue where they left off should the field lose focus for any reason (either accidental or purposeful).

If this is not the desired default behavior, I do believe that this would be beneficial to have as an option.