### PR TITLE
Fixing focus issue:

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -467,6 +467,9 @@ class Chosen extends AbstractChosen
       when 13
         evt.preventDefault() if this.results_showing
         break
+      when 32
+        evt.preventDefault() if @disable_search
+        break
       when 38
         evt.preventDefault()
         this.keyup_arrow()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -467,6 +467,9 @@ class @Chosen extends AbstractChosen
       when 13
         evt.preventDefault() if this.results_showing
         break
+      when 32
+        evt.preventDefault() if @disable_search
+        break
       when 38
         evt.preventDefault()
         this.keyup_arrow()


### PR DESCRIPTION
When disable_search flag is on, focus + hitting spacebar on the dropdown
causes the page to scroll and open the popup.
Adding preventDefault when the spacebar disables the scroll event to
happen.
