### PR TITLE
Adding accessibility to chosen:

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -40,15 +40,24 @@ class Chosen extends AbstractChosen
     @container = ($ "<div />", container_props)
 
     if @is_multiple
-      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
+      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results" role="listbox" tabindex="-1"></ul></div>'
     else
-      @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
+      @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results" role="listbox" tabindex="-1"></ul></div>'
 
     @form_field_jq.hide().after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()
     @search_results = @container.find('ul.chosen-results').first()
+    @search_results.attr('id', @unique_id + "-" + "listbox")
+    @search_results.attr('attr-labelledby', @unique_id)
+    @search_field.attr(
+      'id': @unique_id
+      'role': 'combobox'
+      'aria-haspopup': 'true'
+      'aria-owns': @search_results.attr('id')
+      'aria-expanded': 'false'
+    )
     this.search_field_scale()
 
     @search_no_results = @container.find('li.no-results').first()
@@ -208,6 +217,8 @@ class Chosen extends AbstractChosen
 
       @result_highlight = el
       @result_highlight.addClass "highlighted"
+      @search_results.attr('aria-labelledby', el.attr('id'))
+      @search_field.attr('aria-activedescendant', el.attr('id'))
 
       maxHeight = parseInt @search_results.css("maxHeight"), 10
       visible_top = @search_results.scrollTop()
@@ -231,6 +242,7 @@ class Chosen extends AbstractChosen
       return false
 
     @container.addClass "chosen-with-drop"
+    @search_field.attr("aria-expanded", true)
     @results_showing = true
 
     @search_field.focus()
@@ -247,6 +259,7 @@ class Chosen extends AbstractChosen
       this.result_clear_highlight()
 
       @container.removeClass "chosen-with-drop"
+      @search_field.attr("aria-expanded", false)
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})
 
     @results_showing = false

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -8,8 +8,8 @@ class @Chosen extends AbstractChosen
     super()
 
     # HTML Templates
-    @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>')
-    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
+    @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results" role="listbox" tabindex="-1"></ul></div>')
+    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results" role="listbox" tabindex="-1"></ul></div>')
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_up_html: ->
@@ -32,6 +32,15 @@ class @Chosen extends AbstractChosen
 
     @search_field = @container.down('input')
     @search_results = @container.down('ul.chosen-results')
+    @search_results.writeAttribute('id', @unique_id + "-" + "listbox")
+    @search_results.writeAttribute('attr-labelledby', @unique_id)
+    @search_field.writeAttribute(
+      'id': @unique_id
+      'role': 'combobox'
+      'aria-haspopup': 'true'
+      'aria-owns': @search_results.readAttribute('id')
+      'aria-expanded': 'false'
+    )
     this.search_field_scale()
 
     @search_no_results = @container.down('li.no-results')
@@ -201,6 +210,8 @@ class @Chosen extends AbstractChosen
 
       @result_highlight = el
       @result_highlight.addClassName "highlighted"
+      @search_results.writeAttribute('aria-labelledby', el.readAttribute('id'))
+      @search_field.writeAttribute('aria-activedescendant', el.readAttribute('id'))
 
       maxHeight = parseInt @search_results.getStyle('maxHeight'), 10
       visible_top = @search_results.scrollTop
@@ -224,6 +235,7 @@ class @Chosen extends AbstractChosen
       return false
 
     @container.addClassName "chosen-with-drop"
+    @search_field.writeAttribute("aria-expanded", true)
     @results_showing = true
 
     @search_field.focus()
@@ -240,6 +252,7 @@ class @Chosen extends AbstractChosen
       this.result_clear_highlight()
 
       @container.removeClassName "chosen-with-drop"
+      @search_field.writeAttribute("aria-expanded", false)
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})
 
     @results_showing = false

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,6 +29,8 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
+    #The unique_id is used to identify this chosen dropdown in the DOM for accessibility ARIA attributes
+    @unique_id = "chosen-id-#{Math.random().toString(36).substring(2,6)}"
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -84,8 +86,11 @@ class AbstractChosen
     classes.push option.classes if option.classes != ""
 
     option_el = document.createElement("li")
+    option_el.id = "#{@unique_id}-#{option.array_index}"
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
+    option_el.setAttribute("role", "option")
+    option_el.setAttribute("tabindex", "-1")
     option_el.setAttribute("data-option-array-index", option.array_index)
     option_el.innerHTML = option.search_text
 


### PR DESCRIPTION
- Added unique_id which is used for ARIA attribtues
  that require an ID. So now search_field and
  search_results have an ID
- Added the required ARIA tags for chosen to behave
  like a combobox
- Tested with Mac OSX Chrome 36 using VoiceOver,
  now the screen reader is able to read the values
  in the chosen select box, like it's a SELECT
  element

NOTE:
This is bascially what [jQueryUI Selectmenu](http://jqueryui.com/selectmenu/) does
related to #2013 
