### PR TITLE
Custom Container Tags for Inter-plugin Compatability

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -40,22 +40,22 @@ class Chosen extends AbstractChosen
     @container = ($ "<div />", container_props)
 
     if @is_multiple
-      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
+      @container.html '<' + @outer_container + ' class="chosen-choices"><' + @inner_container + ' class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></' + @inner_container + '></' + @outer_container + '><div class="chosen-drop"><' + @outer_container + ' class="chosen-results"></' + @outer_container + '></div>'
     else
-      @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
+      @container.html '<a class="chosen-single chosen-default" tabindex="-1"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><' + @outer_container + ' class="chosen-results"></' + @outer_container + '></div>'
 
     @form_field_jq.hide().after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()
-    @search_results = @container.find('ul.chosen-results').first()
+    @search_results = @container.find(@outer_container + '.chosen-results').first()
     this.search_field_scale()
 
-    @search_no_results = @container.find('li.no-results').first()
+    @search_no_results = @container.find(@inner_container +'.no-results').first()
 
     if @is_multiple
-      @search_choices = @container.find('ul.chosen-choices').first()
-      @search_container = @container.find('li.search-field').first()
+      @search_choices = @container.find(@outer_container + '.chosen-choices').first()
+      @search_container = @container.find(@inner_container +'.search-field').first()
     else
       @search_container = @container.find('div.chosen-search').first()
       @selected_item = @container.find('.chosen-single').first()
@@ -184,7 +184,7 @@ class Chosen extends AbstractChosen
     @results_data = SelectParser.select_to_array @form_field
 
     if @is_multiple
-      @search_choices.find("li.search-choice").remove()
+      @search_choices.find(@inner_container + ".search-choice").remove()
     else if not @is_multiple
       this.single_set_selected_text()
       if @disable_search or @form_field.options.length <= @disable_search_threshold
@@ -289,7 +289,7 @@ class Chosen extends AbstractChosen
     this.result_clear_highlight() if $(evt.target).hasClass "active-result" or $(evt.target).parents('.active-result').first()
 
   choice_build: (item) ->
-    choice = $('<li />', { class: "search-choice" }).html("<span>#{item.html}</span>")
+    choice = $('<' + @inner_container + ' />', { class: "search-choice" }).html("<span>#{item.html}</span>")
 
     if item.disabled
       choice.addClass 'search-choice-disabled'
@@ -311,7 +311,7 @@ class Chosen extends AbstractChosen
 
       this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.val().length < 1
 
-      link.parents('li').first().remove()
+      link.parents(@inner_container).first().remove()
 
       this.search_field_scale()
 
@@ -405,7 +405,7 @@ class Chosen extends AbstractChosen
     this.result_do_highlight do_high if do_high?
 
   no_results: (terms) ->
-    no_results_html = $('<li class="no-results">' + @results_none_found + ' "<span></span>"</li>')
+    no_results_html = $('<' + @inner_container + ' class="no-results">' + @results_none_found + ' "<span></span>"</li>')
     no_results_html.find("span").first().html(terms)
 
     @search_results.append no_results_html
@@ -416,7 +416,7 @@ class Chosen extends AbstractChosen
 
   keydown_arrow: ->
     if @results_showing and @result_highlight
-      next_sib = @result_highlight.nextAll("li.active-result").first()
+      next_sib = @result_highlight.nextAll(@inner_container + ".active-result").first()
       this.result_do_highlight next_sib if next_sib
     else
       this.results_show()
@@ -425,7 +425,7 @@ class Chosen extends AbstractChosen
     if not @results_showing and not @is_multiple
       this.results_show()
     else if @result_highlight
-      prev_sibs = @result_highlight.prevAll("li.active-result")
+      prev_sibs = @result_highlight.prevAll(@inner_container + ".active-result")
 
       if prev_sibs.length
         this.result_do_highlight prev_sibs.first()
@@ -438,7 +438,7 @@ class Chosen extends AbstractChosen
       this.choice_destroy @pending_backstroke.find("a").first()
       this.clear_backstroke()
     else
-      next_available_destroy = @search_container.siblings("li.search-choice").last()
+      next_available_destroy = @search_container.siblings(@inner_container + ".search-choice").last()
       if next_available_destroy.length and not next_available_destroy.hasClass("search-choice-disabled")
         @pending_backstroke = next_available_destroy
         if @single_backstroke_delete

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -8,9 +8,9 @@ class @Chosen extends AbstractChosen
     super()
 
     # HTML Templates
-    @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>')
-    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
-    @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
+    @single_temp = new Template('<a class="chosen-single chosen-default" tabindex="-1"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><' + @outer_container + ' class="chosen-results"></' + @outer_container + '></div>')
+    @multi_temp = new Template('<' + @outer_container + ' class="chosen-choices"><' + @inner_container + ' class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></' + @inner_container + '></' + @outer_container + '><div class="chosen-drop"><' + @outer_container + ' class="chosen-results"></' + @outer_container + '></div>')
+    @no_results_temp = new Template('<' + @inner_container + ' class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</' + @inner_container + '>')
 
   set_up_html: ->
     container_classes = ["chosen-container"]
@@ -31,14 +31,14 @@ class @Chosen extends AbstractChosen
     @dropdown = @container.down('div.chosen-drop')
 
     @search_field = @container.down('input')
-    @search_results = @container.down('ul.chosen-results')
+    @search_results = @container.down(@outer_container + '.chosen-results')
     this.search_field_scale()
 
-    @search_no_results = @container.down('li.no-results')
+    @search_no_results = @container.down(@inner_container + '.no-results')
 
     if @is_multiple
-      @search_choices = @container.down('ul.chosen-choices')
-      @search_container = @container.down('li.search-field')
+      @search_choices = @container.down(@outer_container + '.chosen-choices')
+      @search_container = @container.down(@inner_container + '.search-field')
     else
       @search_container = @container.down('div.chosen-search')
       @selected_item = @container.down('.chosen-single')
@@ -178,7 +178,7 @@ class @Chosen extends AbstractChosen
     @results_data = SelectParser.select_to_array @form_field
 
     if @is_multiple
-      @search_choices.select("li.search-choice").invoke("remove")
+      @search_choices.select(@inner_container + '.search-choice").invoke("remove")
     else if not @is_multiple
       this.single_set_selected_text()
       if @disable_search or @form_field.options.length <= @disable_search_threshold
@@ -282,7 +282,7 @@ class @Chosen extends AbstractChosen
     this.result_clear_highlight() if evt.target.hasClassName('active-result') or evt.target.up('.active-result')
 
   choice_build: (item) ->
-    choice = new Element('li', { class: "search-choice" }).update("<span>#{item.html}</span>")
+    choice = new Element(@inner_container, { class: "search-choice" }).update("<span>#{item.html}</span>")
 
     if item.disabled
       choice.addClassName 'search-choice-disabled'
@@ -304,7 +304,7 @@ class @Chosen extends AbstractChosen
 
       this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.value.length < 1
 
-      link.up('li').remove()
+      link.up(@inner_container).remove()
 
       this.search_field_scale()
 
@@ -423,7 +423,7 @@ class @Chosen extends AbstractChosen
       this.results_show()
     else if @result_highlight
       sibs = @result_highlight.previousSiblings()
-      actives = @search_results.select("li.active-result")
+      actives = @search_results.select(@inner_container + ".active-result")
       prevs = sibs.intersect(actives)
 
       if prevs.length

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -29,6 +29,8 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
+    @outer_container = if @options.outer_container? then @options.outer_container else "ul"
+    @inner_container = if @options.inner_container? then @options.inner_container else "li"
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -83,7 +85,7 @@ class AbstractChosen
     classes.push "group-option" if option.group_array_index?
     classes.push option.classes if option.classes != ""
 
-    option_el = document.createElement("li")
+    option_el = document.createElement(@inner_container)
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
@@ -95,7 +97,7 @@ class AbstractChosen
     return '' unless group.search_match || group.group_match
     return '' unless group.active_options > 0
 
-    group_el = document.createElement("li")
+    group_el = document.createElement(@inner_container)
     group_el.className = "group-result"
     group_el.innerHTML = group.search_text
 

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -141,7 +141,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   padding: 0 0 0 4px;
   max-height: 240px;
   -webkit-overflow-scrolling: touch;
-  li {
+  > * {
     display: none;
     margin: 0;
     padding: 5px 6px;
@@ -200,7 +200,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     @include background-image(linear-gradient(#eee 1%, #fff 15%));
     cursor: text;
   }
-  .chosen-choices li {
+  .chosen-choices > * {
     float: left;
     list-style: none;
     &.search-field {
@@ -310,7 +310,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   .chosen-choices {
     border: 1px solid #5897fb;
     box-shadow: 0 0 5px rgba(#000,.3);
-    li.search-field input[type="text"] {
+    .search-field input[type="text"] {
       color: #222 !important;
     }
   }
@@ -353,7 +353,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     right: auto;
     left: 26px;
   }
-  .chosen-choices li {
+  .chosen-choices > * {
     float: right;
     &.search-field input[type="text"] {
       direction: rtl;
@@ -375,7 +375,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     margin: 0 0 4px 4px;
     padding: 0 4px 0 0;
   }
-  .chosen-results li.group-option {
+  .chosen-results .group-option {
     padding-right: 15px;
     padding-left: 0;
   }


### PR DESCRIPTION
Using the plugins Chosen and NestedSortable together produces a
collision and breaks NestedSortable.  This collision is because of the
rendered tags of Chosen hooked by NestedSortable.  Given the choice
between patching jQuery UI and Chosen, Chosen was patched to use a set
of customizable tags.  The following options are now available:

- outer_container -- default value = 'ul'

- inner_container -- default value = 'li'

The stylesheet has no references to the HTML tags (e.g. li.search-
choice is now .search-choice) including the stand-alone tags through
clever use of wildcards.  The styling will apply to all tags used.
This is naturally dangerous, as a set of inappropriate tags could be
forced.  However, the ability to change 'ul' and 'li' to 'div' and
'span' respectively, thus resolving the conflict between libraries
without affecting either's functionality far outweighs the fact that
an individual can break his or her markup.