### PR TITLE
allow hiding selected option for single selects

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -232,7 +232,7 @@ class AbstractChosen
     return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
 
   include_option_in_results: (option) ->
-    return false if @is_multiple and (not @display_selected_options and option.selected)
+    return false if not @display_selected_options and option.selected
     return false if not @display_disabled_options and option.disabled
     return false if option.empty
 


### PR DESCRIPTION
I needed to hide selected options in the dropdown for single selects. I'm not sure why it was explicitly stated that it only works for multiple selects, because it seems like a useful option for single selects as well.

This is important for my use case because after reskinning the Chose UI, showing the selected option in the dropdown was distracting:

Before:
![screen shot 2014-09-10 at 10 18 47 am](https://cloud.githubusercontent.com/assets/188562/4221947/96c946d6-390e-11e4-82a2-8b34ab51aeac.png)

After:
![screen shot 2014-09-10 at 10 19 01 am](https://cloud.githubusercontent.com/assets/188562/4221946/96bb90f4-390e-11e4-9e89-a8b7273778b1.png)

The selected option being in the dropdown is a little distracting from a UI perspective, so it's convenient to be able to hide it.

This might warrant a new option (`display_selected_option_single` or something), but it shouldn't affect any current code, since it was ignored on single selects anywa.

