### PR TITLE
Remove forced widths in order to get responsive dropdown menus

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -32,7 +32,6 @@ class Chosen extends AbstractChosen
 
     container_props =
       'class': container_classes.join ' '
-      'style': "width: #{this.container_width()};"
       'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -20,7 +20,6 @@ class @Chosen extends AbstractChosen
 
     container_props =
       'class': container_classes.join ' '
-      'style': "width: #{this.container_width()};"
       'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -228,9 +228,6 @@ class AbstractChosen
   clipboard_event_checker: (evt) ->
     setTimeout (=> this.results_search()), 50
 
-  container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
-
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)
     return false if not @display_disabled_options and option.disabled

--- a/public/docsupport/style.css
+++ b/public/docsupport/style.css
@@ -14,7 +14,7 @@ hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin:
 input, select { vertical-align: middle; }
 
 body { font:13px/1.231 sans-serif; *font-size:small; } /* Hack retained to preserve specificity */
-select, input, textarea, button { font:99% sans-serif; }
+select, input, textarea, button { font:99% sans-serif; width: 100%; }
 pre, code, kbd, samp { font-family: monospace, sans-serif; }
 
 
@@ -23,7 +23,7 @@ body { background: #EEE; color: #444; line-height: 1.4em; }
 header h1 { color: black; font-size: 2em; line-height: 1.1em; display: inline-block; height: 27px; margin: 20px 0 25px; }
 header h1 small { font-size: 0.6em; }
 
-div#content { background: white; border: 1px solid #ccc; border-width: 0 1px 1px; margin: 0 auto; padding: 40px 50px 40px; width: 738px; }
+div#content { background: white; border: 1px solid #ccc; border-width: 0 1px 1px; margin: 0 auto; padding: 40px 50px 40px; max-width: 738px; }
 
 footer { color: #999; padding-top: 40px; font-size: 0.8em; text-align: center; }
 
@@ -45,7 +45,10 @@ ol ul li, ul ul li { list-style-type: circle; margin: 0 0 .25em 1em; }
 li > p { margin-top: .25em; }
 
 div.side-by-side { width: 100%; margin-bottom: 1em; }
-div.side-by-side > div { float: left; width: 49%; }
+div.side-by-side > div { float: left; width: 48%; }
+div.side-by-side > div:nth-of-type(2n) {
+  margin-left: 2%;
+}
 div.side-by-side > div > em { margin-bottom: 10px; display: block; }
 
 .faqs em { display: block; }
@@ -201,4 +204,17 @@ i { font-style: italic; }
   margin-left: -27px;
   padding-left: 27px;
   text-decoration: none;
+}
+
+/* Let the text fields occupy the entire width
+of the screen in medium and small devices. */
+@media (max-width: 768px) {
+  div.side-by-side > div {
+    float: none;
+    width: 100%;
+    margin-bottom: 15px;
+  }
+  div.side-by-side > div:nth-of-type(2n) {
+    margin-left: 0;
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" tabindex="1">
+          <select data-placeholder="Choose a Country..." tabindex="1">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -287,7 +287,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" style="width:350px;" tabindex="2">
+          <select data-placeholder="Choose a Country..." class="chosen-select" tabindex="2">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -548,7 +548,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" multiple tabindex="3">
+          <select data-placeholder="Choose a Country..." multiple tabindex="3">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -805,7 +805,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" multiple style="width:350px;" tabindex="4">
+          <select data-placeholder="Choose a Country..." class="chosen-select" multiple tabindex="4">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -1066,7 +1066,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Single Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" tabindex="5">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" tabindex="5">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1120,7 +1120,7 @@
         </div>
         <div>
           <em>Multiple Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" multiple tabindex="6">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" multiple tabindex="6">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1179,7 +1179,7 @@
         <p>Chosen automatically highlights selected options and removes disabled options.</p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select" tabindex="7">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select" tabindex="7">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1193,7 +1193,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select" tabindex="8">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="8">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1212,8 +1212,8 @@
         <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer than (n) options.</p>
         <pre><code class="language-javascript">$(".chosen-select").chosen({disable_search_threshold: 10});</code></pre>
         <p></p>
-        <div>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-no-single" tabindex="9">
+        <div style="width: 100%">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-no-single" tabindex="9">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1231,7 +1231,7 @@
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
         <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select an Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>
-        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> style="width:350px;" multiple class="chosen-select"&gt;</code></pre>
+        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> multiple class="chosen-select"&gt;</code></pre>
         <p><strong>Note:</strong> on single selects, the first element is assumed to be selected by the browser. To take advantage of the default text support, you will need to include a blank option as the first element of your select list.</p>
       </div>
 
@@ -1242,7 +1242,7 @@
         <p></p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1256,7 +1256,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1281,8 +1281,8 @@
       <h2><a name="allow-deselect-on-single-selects" class="anchor" href="#allow-deselect-on-single-selects">Allow Deselect on Single Selects</a></h2>
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
-        <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-deselect" tabindex="12">
+        <div class="clearfix">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1302,7 +1302,7 @@
         <pre><code class="language-markup">&lt;select class="chosen-select <strong>chosen-rtl</strong>"&gt;</code></pre>
         <div>
           <em>Single right to left select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select chosen-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select chosen-rtl" tabindex="13">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1314,7 +1314,7 @@
         </div>
         <div>
           <em>Multiple right to left select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select  chosen-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select  chosen-rtl" tabindex="14">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1344,8 +1344,8 @@
 
       <h2><a name="custom-width-support" class="anchor" href="#custom-width-support">Custom Width Support</a></h2>
       <div class="side-by-side clearfix">
-        <p>Using a custom width with Chosen is as easy as passing an option when you create Chosen:</p>
-        <pre><code class="language-javascript"> $(".chosen-select").chosen({width: "95%"}); </code></pre>
+        <p>Chosen is fully responsive and its size only depends on its wrapper size.</p>
+        <p>Try yourself! Resize this window to see how the select boxes are also resized</p>
         <div>
           <em>Single Select</em>
           <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="15">
@@ -1379,10 +1379,9 @@
       <h2><a name="labels-work-too" class="anchor" href="#labels-work-too">Labels work, too</a></h2>
       <div class="side-by-side clearfix">
         <p>Use labels just like you would a standard select</p>
-        <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" style="width:350px;" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1396,7 +1395,7 @@
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" style="width:350px;" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1462,7 +1461,7 @@
       '.chosen-select-deselect'  : {allow_single_deselect:true},
       '.chosen-select-no-single' : {disable_search_threshold:10},
       '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},
-      '.chosen-select-width'     : {width:"95%"}
+      '.chosen-select-width'     : {}
     }
     for (var selector in config) {
       $(selector).chosen(config[selector]);

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -31,7 +31,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" tabindex="1">
+          <select data-placeholder="Choose a Country..." tabindex="1">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -288,7 +288,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" style="width:350px;" tabindex="2">
+          <select data-placeholder="Choose a Country..." class="chosen-select" tabindex="2">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -549,7 +549,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" multiple tabindex="3">
+          <select data-placeholder="Choose a Country..." multiple tabindex="3">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -806,7 +806,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" multiple style="width:350px;" tabindex="4">
+          <select data-placeholder="Choose a Country..." class="chosen-select" multiple tabindex="4">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -1067,7 +1067,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Single Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" tabindex="5">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" tabindex="5">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1121,7 +1121,7 @@
         </div>
         <div>
           <em>Multiple Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" multiple tabindex="6">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" multiple tabindex="6">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1180,7 +1180,7 @@
         <p>Chosen automatically highlights selected options and removes disabled options.</p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select" tabindex="7">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select" tabindex="7">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1194,7 +1194,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select" tabindex="8">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="8">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1213,8 +1213,8 @@
         <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer than (n) options.</p>
         <pre><code class="language-javascript"> new Chosen($("chosen_select_field"),{disable_search_threshold: 10}); </code></pre>
         <p></p>
-        <div>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-no-single" tabindex="9">
+        <div style="width:100%">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-no-single" tabindex="9">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1232,7 +1232,7 @@
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
         <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select an Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>
-        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> style="width:350px;" multiple class="chosen-select"&gt;</code></pre>
+        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> multiple class="chosen-select"&gt;</code></pre>
         <p><strong>Note:</strong> on single selects, the first element is assumed to be selected by the browser. To take advantage of the default text support, you will need to include a blank option as the first element of your select list.</p>
       </div>
 
@@ -1243,7 +1243,7 @@
 
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1257,7 +1257,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1282,8 +1282,8 @@
       <h2><a name="allow-deselect-on-single-selects" class="anchor" href="#allow-deselect-on-single-selects">Allow Deselect on Single Selects</a></h2>
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
-        <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-deselect" tabindex="12">
+        <div class="clearfix">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1303,7 +1303,7 @@
         <pre><code class="language-markup">&lt;select class="chosen-select <strong>chosen-rtl</strong>"&gt;</code></pre>
         <div>
           <em>Single right to left select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select chosen-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select chosen-rtl" tabindex="13">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1315,7 +1315,7 @@
         </div>
         <div>
           <em>Multiple right to left select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select  chosen-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select  chosen-rtl" tabindex="14">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1346,8 +1346,8 @@
 
       <h2><a name="custom-width-support" class="anchor" href="#custom-width-support">Custom Width Support</a></h2>
       <div class="side-by-side clearfix">
-        <p>Using a custom width with Chosen is as easy as passing an option when you create Chosen:</p>
-        <pre><code class="language-javascript">new Chosen($("chosen_select_field"),{width: "95%"}); </code></pre>
+        <p>Chosen is fully responsive and its size only depends on its wrapper size.</p>
+        <p>Try yourself! Resize this window to see how the select boxes are also resized</p>
         <div>
           <em>Single Select</em>
           <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="15">
@@ -1384,7 +1384,7 @@
         <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" style="width:350px;" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1398,7 +1398,7 @@
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" style="width:350px;" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1461,7 +1461,7 @@
       '.chosen-select-deselect'  : {allow_single_deselect:true},
       '.chosen-select-no-single' : {disable_search_threshold:10},
       '.chosen-select-no-results': {no_results_text: "Oops, nothing found!"},
-      '.chosen-select-width'     : {width: "95%"}
+      '.chosen-select-width'     : {}
     }
     var results = [];
     for (var selector in config) {

--- a/public/options.html
+++ b/public/options.html
@@ -26,8 +26,7 @@
 <pre>
   <code class="language-javascript">$(".my_select_box").chosen({
     disable_search_threshold: 10,
-    no_results_text: "Oops, nothing found!",
-    width: "95%"
+    no_results_text: "Oops, nothing found!"
   });</code>
 </pre>
 
@@ -90,11 +89,6 @@
           <td>single_backstroke_delete</td>
           <td>true</td>
           <td>By default, pressing delete/backspace on multiple selects will remove a selected choice. When <code class="language-javascript">false</code>, pressing delete/backspace will highlight the last choice, and a second press deselects it.</td>
-        </tr>
-        <tr>
-          <td>width</td>
-          <td>Original select width.</td>
-          <td>The width of the Chosen select box. By default, Chosen attempts to match the width of the select box you are replacing. If your select is hidden when Chosen is instantiated, you must specify a width or the select will show up with a width of 0.</td>
         </tr>
         <tr>
           <td>display_disabled_options</td>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -44,7 +44,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     display: block;
     overflow: hidden;
     padding: 0 0 0 8px;
-    // height: 25px;
+    height: 25px;
     border: 1px solid #aaa;
     border-radius: 5px;
     background-color: #fff;

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -8,7 +8,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 /* @group Base */
 .chosen-container {
   position: relative;
-  display: inline-block;
+  display: block;
   vertical-align: middle;
   font-size: 13px;
   zoom: 1;
@@ -44,7 +44,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     display: block;
     overflow: hidden;
     padding: 0 0 0 8px;
-    height: 25px;
+    // height: 25px;
     border: 1px solid #aaa;
     border-radius: 5px;
     background-color: #fff;


### PR DESCRIPTION
As the title suggests, I've removed the forced widths used when creating chosen objects. Now the width of the select menus depends on their wrapper.

I've uploaded it to `gh-pages` so you can see it working: http://elboletaire.github.io/chosen/

Obviously, resize the window to see it in action :smiley: 