### PR TITLE
fix that touching an item in the result list will also touch the element underneath it

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -360,6 +360,9 @@ class Chosen extends AbstractChosen
 
       @form_field_jq.trigger "change", {'selected': @form_field.options[item.options_index].value} if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex
+
+      evt.preventDefault()
+
       this.search_field_scale()
 
   single_set_selected_text: (text=@default_text) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -356,6 +356,8 @@ class @Chosen extends AbstractChosen
       @form_field.simulate("change") if typeof Event.simulate is 'function' && (@is_multiple || @form_field.selectedIndex != @current_selectedIndex)
       @current_selectedIndex = @form_field.selectedIndex
 
+      evt.preventDefault()
+
       this.search_field_scale()
 
   single_set_selected_text: (text=@default_text) ->


### PR DESCRIPTION
This fixes #1816 (and fixes #1887).

Props to @jonsprague0000 for [the fix](https://github.com/harvesthq/chosen/issues/1816#issuecomment-37178481). I'm just creating the PR to finally push it into the codebase.