### PR TITLE
Always open mode for Chosen

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -117,7 +117,7 @@ class Chosen extends AbstractChosen
       @container.addClass 'chosen-disabled'
       @search_field[0].disabled = true
       @selected_item.unbind "focus.chosen", @activate_action if !@is_multiple
-      this.close_field()
+      this.close_field() unless @always_open
     else
       @container.removeClass 'chosen-disabled'
       @search_field[0].disabled = false
@@ -135,7 +135,7 @@ class Chosen extends AbstractChosen
           this.results_show()
         else if not @is_multiple and evt and (($(evt.target)[0] == @selected_item[0]) || $(evt.target).parents("a.chosen-single").length)
           evt.preventDefault()
-          this.results_toggle()
+          this.results_toggle() unless @always_open
 
         this.activate_field()
 
@@ -150,7 +150,7 @@ class Chosen extends AbstractChosen
       @search_results.scrollTop(delta + @search_results.scrollTop())
 
   blur_test: (evt) ->
-    this.close_field() if not @active_field and @container.hasClass "chosen-container-active"
+    this.close_field() if !@always_open and not @active_field and @container.hasClass "chosen-container-active"
 
   close_field: ->
     $(@container[0].ownerDocument).unbind "click.chosen", @click_test_action
@@ -177,7 +177,7 @@ class Chosen extends AbstractChosen
     if active_container.length and @container[0] == active_container[0]
       @active_field = true
     else
-      this.close_field()
+      this.close_field() unless @always_open
 
   results_build: ->
     @parsing = true
@@ -311,7 +311,7 @@ class Chosen extends AbstractChosen
     if this.result_deselect( link[0].getAttribute("data-option-array-index") )
       this.show_search_field_default()
 
-      this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.val().length < 1
+      this.results_hide() if !@always_open and @is_multiple and this.choices_count() > 0 and @search_field.val().length < 1
 
       link.parents('li').first().remove()
 
@@ -324,7 +324,7 @@ class Chosen extends AbstractChosen
     this.show_search_field_default()
     this.results_reset_cleanup()
     @form_field_jq.trigger "change"
-    this.results_hide() if @active_field
+    this.results_hide() if !@always_open and @active_field
 
   results_reset_cleanup: ->
     @current_selectedIndex = @form_field.selectedIndex
@@ -356,7 +356,10 @@ class Chosen extends AbstractChosen
       else
         this.single_set_selected_text(item.text)
 
-      this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
+      if (@always_open)
+        this.winnow_results()
+      else 
+        this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
 
       @search_field.val ""
 
@@ -432,7 +435,7 @@ class Chosen extends AbstractChosen
       if prev_sibs.length
         this.result_do_highlight prev_sibs.first()
       else
-        this.results_hide() if this.choices_count() > 0
+        this.results_hide() if !@always_open and this.choices_count() > 0
         this.result_clear_highlight()
 
   keydown_backstroke: ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -114,7 +114,7 @@ class @Chosen extends AbstractChosen
       @container.addClassName 'chosen-disabled'
       @search_field.disabled = true
       @selected_item.stopObserving "focus", @activate_action if !@is_multiple
-      this.close_field()
+      this.close_field() unless @always_open
     else
       @container.removeClassName 'chosen-disabled'
       @search_field.disabled = false
@@ -131,7 +131,7 @@ class @Chosen extends AbstractChosen
           @container.ownerDocument.observe "click", @click_test_action
           this.results_show()
         else if not @is_multiple and evt and (evt.target is @selected_item || evt.target.up("a.chosen-single"))
-          this.results_toggle()
+          this.results_toggle() unless @always_open
 
         this.activate_field()
 
@@ -146,7 +146,7 @@ class @Chosen extends AbstractChosen
       @search_results.scrollTop = delta + @search_results.scrollTop
 
   blur_test: (evt) ->
-    this.close_field() if not @active_field and @container.hasClassName("chosen-container-active")
+    this.close_field() if !@always_open and not @active_field and @container.hasClassName("chosen-container-active")
 
   close_field: ->
     @container.ownerDocument.stopObserving "click", @click_test_action
@@ -171,7 +171,7 @@ class @Chosen extends AbstractChosen
     if evt.target.up('.chosen-container') is @container
       @active_field = true
     else
-      this.close_field()
+      this.close_field() unless @always_open
 
   results_build: ->
     @parsing = true
@@ -304,7 +304,7 @@ class @Chosen extends AbstractChosen
     if this.result_deselect link.readAttribute("rel")
       this.show_search_field_default()
 
-      this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.value.length < 1
+      this.results_hide() if !@always_open and @is_multiple and this.choices_count() > 0 and @search_field.value.length < 1
 
       link.up('li').remove()
 
@@ -317,7 +317,7 @@ class @Chosen extends AbstractChosen
     this.show_search_field_default()
     this.results_reset_cleanup()
     @form_field.simulate("change") if typeof Event.simulate is 'function'
-    this.results_hide() if @active_field
+    this.results_hide() if !@always_open and @active_field
 
   results_reset_cleanup: ->
     @current_selectedIndex = @form_field.selectedIndex
@@ -351,7 +351,10 @@ class @Chosen extends AbstractChosen
       else
         this.single_set_selected_text(item.text)
 
-      this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
+      if (@always_open)
+        this.winnow_results()
+      else 
+        this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
 
       @search_field.value = ""
 
@@ -431,7 +434,7 @@ class @Chosen extends AbstractChosen
       if prevs.length
         this.result_do_highlight prevs.first()
       else
-        this.results_hide() if this.choices_count() > 0
+        this.results_hide() if !@always_open and this.choices_count() > 0
         this.result_clear_highlight()
 
   keydown_backstroke: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -10,8 +10,13 @@ class AbstractChosen
 
     this.set_up_html()
     this.register_observers()
+
     # instantiation done, fire ready
     this.on_ready()
+    
+    if (@always_open) 
+      # open the select box now
+      this.container_mousedown()
 
   set_default_values: ->
     @click_test_action = (evt) => this.test_active_click(evt)
@@ -20,6 +25,7 @@ class AbstractChosen
     @mouse_on_container = false
     @results_showing = false
     @result_highlighted = null
+    @always_open = @options.always_open || false
     @allow_single_deselect = if @options.allow_single_deselect? and @form_field.options[0]? and @form_field.options[0].text is "" then @options.allow_single_deselect else false
     @disable_search_threshold = @options.disable_search_threshold || 0
     @disable_search = @options.disable_search || false
@@ -31,6 +37,7 @@ class AbstractChosen
     @inherit_select_classes = @options.inherit_select_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
+
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -221,7 +228,7 @@ class AbstractChosen
         evt.preventDefault()
         this.result_select(evt) if this.results_showing
       when 27
-        this.results_hide() if @results_showing
+        this.results_hide() if @results_showing and !@always_open
         return true
       when 9, 38, 40, 16, 91, 17
         # don't do anything on these keys
@@ -271,4 +278,3 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
-

--- a/public/options.html
+++ b/public/options.html
@@ -41,6 +41,11 @@
           <td>When set to <code class="language-javascript">true</code> on a single select, Chosen adds a UI element which selects the first element (if it is blank).</td>
         </tr>
         <tr>
+          <td>always_open_mode</td>
+          <td>false</td>
+          <td>When set to <code class="language-javascript">true</code>, Chosen will always be open (open on instansiation and remain open after selecting an option).</td>
+        </tr>
+        <tr>
           <td>disable_search</td>
           <td>false</td>
           <td>When set to <code class="language-javascript">true</code>, Chosen will not display the search field (single selects only).</td>

--- a/public/options.html
+++ b/public/options.html
@@ -41,7 +41,7 @@
           <td>When set to <code class="language-javascript">true</code> on a single select, Chosen adds a UI element which selects the first element (if it is blank).</td>
         </tr>
         <tr>
-          <td>always_open_mode</td>
+          <td>always_open</td>
           <td>false</td>
           <td>When set to <code class="language-javascript">true</code>, Chosen will always be open (open on instansiation and remain open after selecting an option).</td>
         </tr>


### PR DESCRIPTION
I added an "always open" mode. By specifying "always_open: true" in the Chosen construction, it will make Chosen always open - immediately, on instansiation, and will remain open after selecting an option.