### PR TITLE
Add dppx to Retina media query

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -401,7 +401,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 /* @end */
 
 /* @group Retina compatibility */
-@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
   .chosen-rtl .chosen-search input[type="text"],
   .chosen-container-single .chosen-single abbr,
   .chosen-container-single .chosen-single div b,

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -401,7 +401,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 /* @end */
 
 /* @group Retina compatibility */
-@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 144dpi)  {
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
   .chosen-rtl .chosen-search input[type="text"],
   .chosen-container-single .chosen-single abbr,
   .chosen-container-single .chosen-single div b,


### PR DESCRIPTION
This addresses #1771, which is now fixable because the Chrome team has 
fixed the erroneous "Consider using dppx" console message.

See also:
https://code.google.com/p/chromium/issues/detail?id=336276
http://css-tricks.com/forums/topic/chrome-console-recommends-dppx-instead-of-dpi-even-if-dppx-is-used/#post-187595