### PR TITLE
Allows searching for & and other special characters

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -398,7 +398,7 @@ class Chosen extends AbstractChosen
     @selected_item.addClass("chosen-single-with-deselect")
 
   get_search_text: ->
-    if @search_field.val() is @default_text then "" else $('<div/>').text($.trim(@search_field.val())).html()
+    if @search_field.val() is @default_text then "" else $('<div/>').text($.trim(@search_field.val())).text()
 
   winnow_results_set_highlight: ->
     selected_results = if not @is_multiple then @search_results.find(".result-selected.active-result") else []

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -393,7 +393,7 @@ class @Chosen extends AbstractChosen
     @selected_item.addClassName("chosen-single-with-deselect")
 
   get_search_text: ->
-    if @search_field.value is @default_text then "" else @search_field.value.strip().escapeHTML()
+    if @search_field.value is @default_text then "" else @search_field.value.strip()
 
   winnow_results_set_highlight: ->
     if not @is_multiple


### PR DESCRIPTION
This allows me to search for special characters like ampersand in select boxes. I have a client which has trouble without this as they have large selects and a few options are only findable via ampersands. (i.e. `a&b` will not be found easily as `a` and `b` are far too common).

I don't know if this might break something (why the `html()` was needed), but for me it seems to work.