### PR TITLE
Add the original option's value to the created option's EL as data-value

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -89,7 +89,7 @@ class AbstractChosen
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
-    option_el.setAttribute("data-value", option.value);
+    option_el.setAttribute("data-value", option.value)
     option_el.innerHTML = option.search_text
 
     this.outerHTML(option_el)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -89,6 +89,7 @@ class AbstractChosen
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
+    option_el.setAttribute("data-value", option.value);
     option_el.innerHTML = option.search_text
 
     this.outerHTML(option_el)


### PR DESCRIPTION
To easily know what the original option value is for each option, without having to check the real, hidden select element (this was needed for my use case) I added the original option's value to the option element under "data-value".