### PR TITLE
Fix opt group label not appearing when triggering "chosen:updated" event

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -77,7 +77,7 @@ class AbstractChosen
         if data.selected and @is_multiple
           this.choice_build data
         else if data.selected and not @is_multiple
-          this.single_set_selected_text(data.text)
+          this.single_set_selected_text(this.choice_label(data))
 
     content
 


### PR DESCRIPTION
If you changed the selection from code and triggered chosen:updated, the label for the optgroup wouldn't appear with `include_group_label_in_selected`. It only appears when clicked on manually by an user.