### PR TITLE
Add tagname checker

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -295,4 +295,3 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
-  

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -284,11 +284,13 @@ class AbstractChosen
     
   @tagname_is_valid: : (@form_field) ->
   if @form_field.tagName.toUpperCase() != 'SELECT'
-    console.error 'Chosen error: invalid tagName ' + @form_field + ' is not a select'
+    if window.console
+      console.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select'
     return false
 
-  if @form_field.getElementsByTagName('option').length == 0
-    console.error 'Chosen error: ' + @form_field + ' has no options\'s childs '
+  if @form_field.options.length == 0
+      if  window.console
+       console.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
     return false
   return true
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -281,16 +281,15 @@ class AbstractChosen
     if /Android/i.test(window.navigator.userAgent)
       return false if /Mobile/i.test(window.navigator.userAgent)
     return true
-    
-  @tagname_is_valid: (@form_field) ->
-  if @form_field.tagName.toUpperCase() != 'SELECT'
-    console?.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select'
-    return false
 
-  if @form_field.options.length == 0
-    console?.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
-    return false
-  return true
+  @tagname_is_valid: (@form_field) ->
+    if @form_field.tagName.toUpperCase() != 'SELECT'
+      console?.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select' 
+      return false
+    if @form_field.options.length == 0
+      console?.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
+      return false
+    return true
 
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -284,13 +284,11 @@ class AbstractChosen
     
   @tagname_is_valid: : (@form_field) ->
   if @form_field.tagName.toUpperCase() != 'SELECT'
-    if window.console
-      console.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select'
+    console?.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select'
     return false
 
   if @form_field.options.length == 0
-      if  window.console
-       console.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
+    console?.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
     return false
   return true
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -282,7 +282,7 @@ class AbstractChosen
       return false if /Mobile/i.test(window.navigator.userAgent)
     return true
     
-  @tagname_is_valid: : (@form_field) ->
+  @tagname_is_valid: (@form_field) ->
   if @form_field.tagName.toUpperCase() != 'SELECT'
     console?.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select'
     return false

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -294,3 +294,4 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
+  

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -296,4 +296,3 @@ class AbstractChosen
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
   
-

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -294,4 +294,3 @@ class AbstractChosen
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
-  

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -2,6 +2,7 @@ class AbstractChosen
 
   constructor: (@form_field, @options={}) ->
     return unless AbstractChosen.browser_is_supported()
+    return unless AbstractChosen.tagname_is_valid(@form_field)
     @is_multiple = @form_field.multiple
     this.set_default_text()
     this.set_default_values()
@@ -280,8 +281,19 @@ class AbstractChosen
     if /Android/i.test(window.navigator.userAgent)
       return false if /Mobile/i.test(window.navigator.userAgent)
     return true
+    
+  @tagname_is_valid: : (@form_field) ->
+  if @form_field.tagName.toUpperCase() != 'SELECT'
+    console.error 'Chosen error: invalid tagName ' + @form_field + ' is not a select'
+    return false
+
+  if @form_field.getElementsByTagName('option').length == 0
+    console.error 'Chosen error: ' + @form_field + ' has no options\'s childs '
+    return false
+  return true
 
   @default_multiple_text: "Select Some Options"
   @default_single_text: "Select an Option"
   @default_no_result_text: "No results match"
+  
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -287,7 +287,7 @@ class AbstractChosen
       console?.error 'Chosen error: invalid tagName ' + @form_field.selector + ' is not a select' 
       return false
     if @form_field.options.length == 0
-      console?.error 'Chosen error: ' + @form_field.selector + ' has no options\'s childs '
+      console?.error 'Chosen error: ' + @form_field.selector + ' has no options children '
       return false
     return true
 


### PR DESCRIPTION
Using class name as selector can provoque bug if the selector is not a `select` or if the select hasn't `option` child.