### PR TITLE
Remove class chosen-single-with-deselect on deselect

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -125,7 +125,9 @@ class AbstractChosen
 
   reset_single_select_options: () ->
     for result in @results_data
-      result.selected = false if result.selected
+      if result.selected    
+        result.selected = false
+        @selected_item.removeClassName("chosen-single-with-deselect")
 
   results_toggle: ->
     if @results_showing


### PR DESCRIPTION
This class gets added when an option gets selected, but does not get removed when the option is deselected.