### PR TITLE
Fix code execution vulnerabilities.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -77,7 +77,7 @@ class AbstractChosen
         if data.selected and @is_multiple
           this.choice_build data
         else if data.selected and not @is_multiple
-          this.single_set_selected_text(data.text)
+          this.single_set_selected_text(data.html)
 
     content
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -167,7 +167,7 @@ class AbstractChosen
                 
         unless option.group and not @group_search
 
-          option.search_text = if option.group then option.label else option.text
+          option.search_text = if option.group then option.label else option.html
           option.search_match = this.search_string_match(option.search_text, regex)
           results += 1 if option.search_match and not option.group
 


### PR DESCRIPTION
I noticed a scripting vulnerability just now in `1.3.0` when rendering results — and upon checking `master`, not only is that one present, but there’s also another when rendering a single select’s selected option. 

Demo of the issue using [chosen@`501568a`](https://github.com/harvesthq/chosen/tree/501568a69376c7df2e8db803006f94ff74bcc9f5) (current master): http://jsfiddle.net/hpv4La79/3/.

Fixes #2132, replaces #2209, #1806. Effectively undoes #1638.