### PR TITLE
Fix issue with group labels when `group_search:false`

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -165,9 +165,9 @@ class AbstractChosen
           results += 1 if results_group.active_options is 0 and results_group.search_match
           results_group.active_options += 1
 
-        unless option.group and not @group_search
+        option.search_text = if option.group then option.label else option.html
 
-          option.search_text = if option.group then option.label else option.html
+        unless option.group and not @group_search
           option.search_match = this.search_string_match(option.search_text, regex)
           results += 1 if option.search_match and not option.group
 


### PR DESCRIPTION
This is just a rebase and squash of @k-zelenkov's #1971 which fixes #1595.

Thanks @k-zelenkov!