### PR TITLE
[Travis] Allow detached head when parsing master ref.

### DIFF
--- a/bower-publish.sh
+++ b/bower-publish.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+CURRENT_BRANCH=`git name-rev --name-only HEAD`
 
 if [ $CURRENT_BRANCH != 'master' ] ; then
   echo "Build not on master. Skipped bower-chosen release"


### PR DESCRIPTION
@harvesthq/chosen-developers 

If we have checked out a commit instead of a branch name, git is in what’s known as “detached head” state.

This is what Travis does all the time — see [the latest build output](https://travis-ci.org/harvesthq/chosen/builds/56181856).

This means that we were never considered to be on the branch “master”, and therefore were never publishing bower-chosen.

We can tweak the git command we’re calling to support either checked out branch names or detached heads — as long as we’re at the commit for a commit that is the head of master, we’re peachykeen!