### PR TITLE
Correct css file used in bower main declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "bowerJSON":{
     "main": [
       "chosen.jquery.min.js",
-      "chosen.css",
+      "chosen.min.css",
       "chosen-sprite@2x.png",
       "chosen-sprite.png"
     ]


### PR DESCRIPTION
When installed via bower, the file 'chosen.css' is not installed, only 'chosen.min.css'. This change means that the main declaration doesn't need to be overridden manually in bower.json.