### PR TITLE
Use ‘dppx’ units instead of ‘dpi’

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -417,7 +417,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 /* @end */
 
 /* @group Retina compatibility */
-@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dppx), only screen and (min-resolution: 1.5dppx) {
   .chosen-rtl .chosen-search input[type="text"],
   .chosen-container-single .chosen-single abbr,
   .chosen-container-single .chosen-single div b,


### PR DESCRIPTION
Getting this error in Chrome:

"Consider using ‘dppx’ units instead of ‘dpi’, as in CSS ‘dpi’ means dots-per-CSS-inch, not dots-per-physical-inch, so does not correspond to the actual ‘dpi’ of a screen. In media query expression: (-webkit-min-device-pixel-ratio: 1.5), not all, (min-resolution: 144dpi)"

![selection_285](https://cloud.githubusercontent.com/assets/1504756/7007342/fc180f86-dc56-11e4-90c1-fd71b0fbedab.png)
