### PR TITLE
Update bower-chosen to use unminified versions

### DIFF
--- a/bower-publish.sh
+++ b/bower-publish.sh
@@ -12,7 +12,7 @@ git config --global user.name "bower-chosen"
 
 git clone https://pfiller:${GH_TOKEN}@github.com/harvesthq/bower-chosen.git
 rm -rf bower-chosen/*
-cp public/bower.json public/*.png public/chosen.jquery.min.js public/chosen.min.css bower-chosen/
+cp public/bower.json public/*.png public/chosen.jquery.js public/chosen.css bower-chosen/
 cd bower-chosen
 
 LATEST_VERSION=$(git diff bower.json | grep version | cut -d':' -f2 | cut -d'"' -f2 | tail -1)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "bowerJSON":{
     "main": [
-      "chosen.jquery.min.js",
+      "chosen.jquery.js",
       "chosen.css",
       "chosen-sprite@2x.png",
       "chosen-sprite.png"


### PR DESCRIPTION
@harvesthq/chosen-developers 

Though Bower itself is unopinionated about whcih version is included, the consensus amongst common libraries is to include the unminified versions of source files. People probably use build systems to minify those files for production (I hope).

Fixes #2298 and #2288 