### PR TITLE
Update title and classnames (when option enabled) from select on update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   compass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86-mingw32
 
 DEPENDENCIES
   compass

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -25,15 +25,19 @@ class Chosen extends AbstractChosen
     @is_rtl = @form_field_jq.hasClass "chosen-rtl"
 
   set_up_html: ->
+    container_classes = ["chosen-container"]
+    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
+    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
+    container_classes.push "chosen-rtl" if @is_rtl
 
     container_props =
+      'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
+      'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = ($ "<div />", container_props)
-    this.update_inherited_classes();
-    this.update_title_from_form_field();
 
     if @is_multiple
       @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
@@ -59,17 +63,6 @@ class Chosen extends AbstractChosen
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
-
-  update_inherited_classes: ->
-    container_classes = ["chosen-container"]
-    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
-    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
-    container_classes.push "chosen-rtl" if @is_rtl
-
-    @container.attr('class', container_classes.join ' ')
-
-  update_title_from_form_field: ->
-    @container.attr('title', @form_field.title)
 
   on_ready: ->
     @form_field_jq.trigger("chosen:ready", {chosen: this})
@@ -192,8 +185,6 @@ class Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
 
-    this.update_inherited_classes();
-
     if @is_multiple
       @search_choices.find("li.search-choice").remove()
     else if not @is_multiple
@@ -207,7 +198,6 @@ class Chosen extends AbstractChosen
 
     this.update_results_content this.results_option_build({first:true})
 
-    this.update_title_from_form_field();
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -25,19 +25,15 @@ class Chosen extends AbstractChosen
     @is_rtl = @form_field_jq.hasClass "chosen-rtl"
 
   set_up_html: ->
-    container_classes = ["chosen-container"]
-    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
-    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
-    container_classes.push "chosen-rtl" if @is_rtl
 
     container_props =
-      'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
-      'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = ($ "<div />", container_props)
+    this.update_inherited_classes();
+    this.update_title_from_form_field();
 
     if @is_multiple
       @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
@@ -63,6 +59,17 @@ class Chosen extends AbstractChosen
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
+
+  update_inherited_classes: ->
+    container_classes = ["chosen-container"]
+    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
+    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
+    container_classes.push "chosen-rtl" if @is_rtl
+
+    @container.attr('class', container_classes.join ' ')
+
+  update_title_from_form_field: ->
+    @container.attr('title', @form_field.title)
 
   on_ready: ->
     @form_field_jq.trigger("chosen:ready", {chosen: this})
@@ -185,6 +192,8 @@ class Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
 
+    this.update_inherited_classes();
+
     if @is_multiple
       @search_choices.find("li.search-choice").remove()
     else if not @is_multiple
@@ -198,6 +207,7 @@ class Chosen extends AbstractChosen
 
     this.update_results_content this.results_option_build({first:true})
 
+    this.update_title_from_form_field();
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -13,16 +13,11 @@ class @Chosen extends AbstractChosen
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_up_html: ->
-    container_classes = ["chosen-container"]
-    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
-    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
-    container_classes.push "chosen-rtl" if @is_rtl
-
     container_props =
       'style': "width: #{this.container_width()};"
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
-
+    
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
     this.update_inherited_classes();
     this.update_title_from_form_field();

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -19,13 +19,13 @@ class @Chosen extends AbstractChosen
     container_classes.push "chosen-rtl" if @is_rtl
 
     container_props =
-      'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
-      'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
+    this.update_inherited_classes();
+    this.update_title_from_form_field();
 
     @form_field.hide().insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
@@ -46,6 +46,17 @@ class @Chosen extends AbstractChosen
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
+
+  update_inherited_classes: ->
+    container_classes = ["chosen-container"]
+    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
+    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
+    container_classes.push "chosen-rtl" if @is_rtl
+
+    @container.writeAttribute('class', container_classes.join ' ')
+
+  update_title_from_form_field: ->
+    @container.writeAttribute('title', @form_field.title)
 
   on_ready: ->
     @form_field.fire("chosen:ready", {chosen: this})
@@ -179,6 +190,8 @@ class @Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
 
+    this.update_inherited_classes();
+
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")
     else if not @is_multiple
@@ -192,6 +205,7 @@ class @Chosen extends AbstractChosen
 
     this.update_results_content this.results_option_build({first:true})
 
+    this.update_title_from_form_field();
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -19,13 +19,13 @@ class @Chosen extends AbstractChosen
     container_classes.push "chosen-rtl" if @is_rtl
 
     container_props =
+      'class': container_classes.join ' '
       'style': "width: #{this.container_width()};"
+      'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
-    this.update_inherited_classes();
-    this.update_title_from_form_field();
 
     @form_field.hide().insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
@@ -46,17 +46,6 @@ class @Chosen extends AbstractChosen
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
-
-  update_inherited_classes: ->
-    container_classes = ["chosen-container"]
-    container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
-    container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
-    container_classes.push "chosen-rtl" if @is_rtl
-
-    @container.writeAttribute('class', container_classes.join ' ')
-
-  update_title_from_form_field: ->
-    @container.writeAttribute('title', @form_field.title)
 
   on_ready: ->
     @form_field.fire("chosen:ready", {chosen: this})
@@ -190,8 +179,6 @@ class @Chosen extends AbstractChosen
 
     @results_data = SelectParser.select_to_array @form_field
 
-    this.update_inherited_classes();
-
     if @is_multiple
       @search_choices.select("li.search-choice").invoke("remove")
     else if not @is_multiple
@@ -205,7 +192,6 @@ class @Chosen extends AbstractChosen
 
     this.update_results_content this.results_option_build({first:true})
 
-    this.update_title_from_form_field();
     this.search_field_disabled()
     this.show_search_field_default()
     this.search_field_scale()

--- a/spec/jquery/basic.spec.coffee
+++ b/spec/jquery/basic.spec.coffee
@@ -1,33 +1,88 @@
-describe "Basic setup", ->
+describe "Existential Validation", ->
   it "should add chosen to jQuery object", ->
     expect(jQuery.fn.chosen).toBeDefined()
 
-  it "should create very basic chosen", ->
+describe "Basic Functionality", ->
+
+  beforeEach ->
     tmpl = "
-      <select data-placeholder='Choose a Country...'>
+      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
         <option value=''></option>
         <option value='United States'>United States</option>
         <option value='United Kingdom'>United Kingdom</option>
         <option value='Afghanistan'>Afghanistan</option>
       </select>
     "
-    div = $("<div>").html(tmpl)
-    select = div.find("select")
-    expect(select.size()).toBe(1)
-    select.chosen()
+    @div = $("<div>").html(tmpl)
+    @select = @div.find('select')
+    @select.chosen()
+    @container = @div.find(".chosen-container")
+
+  afterEach ->
+    @select.chosen('destroy')
+    @div.remove()
+
+  it "should contain all of the necessary elements", ->
+
+    div = @div
+
     # very simple check that the necessary elements have been created
     ["container", "container-single", "single", "default"].forEach (clazz)->
       el = div.find(".chosen-#{clazz}")
       expect(el.size()).toBe(1)
 
+  it "should copy the title attribute from the select to the container", ->
+    expect(@container.attr('title')).toBe 'Initial Title'
+
+  it "should be initialized with no value", ->
     # test a few interactions
-    expect(select.val()).toBe ""
+    expect(@select.val()).toBe ""
 
-    container = div.find(".chosen-container")
-    container.trigger("mousedown") # open the drop
-    expect(container.hasClass("chosen-container-active")).toBe true
+  it "should open the dropdown when the container is clicked", ->
+    @container.trigger("mousedown") # open the drop
+    expect(@container.hasClass("chosen-container-active")).toBe true
+
+  it "should update the select's value when an option is clicked", ->
+    @container.trigger("mousedown") # open the drop
     #select an item
-    container.find(".active-result").last().trigger("mouseup")
+    @container.find(".active-result").last().trigger("mouseup")
 
-    expect(select.val()).toBe "Afghanistan"
+    expect(@select.val()).toBe "Afghanistan"
+
+  it "should re-copy the title from the select to the container on update", ->
+    @select.attr('title', 'new title')
+    @select.trigger("chosen:updated")
+    expect(@container.attr('title')).toBe 'new title'
+
+describe "When inherit selected classes is enabled", ->
+
+  beforeEach ->
+    tmpl = "
+      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
+        <option value=''></option>
+        <option value='United States'>United States</option>
+        <option value='United Kingdom'>United Kingdom</option>
+        <option value='Afghanistan'>Afghanistan</option>
+      </select>
+    "
+    @div = $("<div>").html(tmpl)
+    @select = @div.find('select')
+    @select.chosen({inherit_select_classes: true})
+    @container = @div.find(".chosen-container")
+
+  afterEach ->
+    @select.chosen('destroy')
+    @div.remove()
+
+  it "should copy all classes from the select to the container", ->
+    expect(@container.hasClass('TestClass')).toBe true
+
+  it "should re-copy all classes from the select to the container on update", ->
+    @select.addClass('SecondClass')
+    @select.trigger("chosen:updated")
+    expect(@container.hasClass('TestClass')).toBe true
+    expect(@container.hasClass('SecondClass')).toBe true
+
+
+
 

--- a/spec/jquery/basic.spec.coffee
+++ b/spec/jquery/basic.spec.coffee
@@ -2,7 +2,12 @@ describe "Existential Validation", ->
   it "should add chosen to jQuery object", ->
     expect(jQuery.fn.chosen).toBeDefined()
 
-describe "Basic Functionality", ->
+describe "Initialization and Interactions", ->
+
+  div = null
+  select = null
+  chosen = null
+  container = null
 
   beforeEach ->
     tmpl = "
@@ -13,76 +18,58 @@ describe "Basic Functionality", ->
         <option value='Afghanistan'>Afghanistan</option>
       </select>
     "
-    @div = $("<div>").html(tmpl)
-    @select = @div.find('select')
-    @select.chosen()
-    @container = @div.find(".chosen-container")
+    div = $("<div>").html(tmpl)
+    select = div.find('select')
+    select.chosen({inherit_select_classes: true})
+    container = div.find(".chosen-container")
 
   afterEach ->
-    @select.chosen('destroy')
-    @div.remove()
+    select.chosen('destroy')
+    div.remove()
 
-  it "should contain all of the necessary elements", ->
+  describe "On initialization", ->
 
-    div = @div
+    it "should contain all of the necessary elements", ->
+      # very simple check that the necessary elements have been created
+      ["container", "container-single", "single", "default"].forEach (clazz)->
+        el = div.find(".chosen-#{clazz}")
+        expect(el.size()).toBe(1)
 
-    # very simple check that the necessary elements have been created
-    ["container", "container-single", "single", "default"].forEach (clazz)->
-      el = div.find(".chosen-#{clazz}")
-      expect(el.size()).toBe(1)
+    it "should copy the title attribute from the select to the container", ->
+      expect(container.attr('title')).toBe 'Initial Title'
 
-  it "should copy the title attribute from the select to the container", ->
-    expect(@container.attr('title')).toBe 'Initial Title'
+    it "should be initialized with no value", ->
+      # test a few interactions
+      expect(select.val()).toBe ""
 
-  it "should be initialized with no value", ->
-    # test a few interactions
-    expect(@select.val()).toBe ""
+    it "should open the dropdown when the container is clicked", ->
+      container.trigger("mousedown") # open the drop
+      expect(container.hasClass("chosen-container-active")).toBe true
 
-  it "should open the dropdown when the container is clicked", ->
-    @container.trigger("mousedown") # open the drop
-    expect(@container.hasClass("chosen-container-active")).toBe true
+    it "should update the select's value when an option is clicked", ->
+      container.trigger("mousedown") # open the drop
+      #select an item
+      container.find(".active-result").last().trigger("mouseup")
 
-  it "should update the select's value when an option is clicked", ->
-    @container.trigger("mousedown") # open the drop
-    #select an item
-    @container.find(".active-result").last().trigger("mouseup")
+      expect(select.val()).toBe "Afghanistan"
 
-    expect(@select.val()).toBe "Afghanistan"
+    describe "When inherit_select_classes option is enabled", ->
 
-  it "should re-copy the title from the select to the container on update", ->
-    @select.attr('title', 'new title')
-    @select.trigger("chosen:updated")
-    expect(@container.attr('title')).toBe 'new title'
-
-describe "When inherit selected classes is enabled", ->
-
-  beforeEach ->
-    tmpl = "
-      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
-        <option value=''></option>
-        <option value='United States'>United States</option>
-        <option value='United Kingdom'>United Kingdom</option>
-        <option value='Afghanistan'>Afghanistan</option>
-      </select>
-    "
-    @div = $("<div>").html(tmpl)
-    @select = @div.find('select')
-    @select.chosen({inherit_select_classes: true})
-    @container = @div.find(".chosen-container")
-
-  afterEach ->
-    @select.chosen('destroy')
-    @div.remove()
-
-  it "should copy all classes from the select to the container", ->
-    expect(@container.hasClass('TestClass')).toBe true
-
-  it "should re-copy all classes from the select to the container on update", ->
-    @select.addClass('SecondClass')
-    @select.trigger("chosen:updated")
-    expect(@container.hasClass('TestClass')).toBe true
-    expect(@container.hasClass('SecondClass')).toBe true
+      it "should copy all classes from the select to the container", ->
+        expect(container.hasClass('TestClass')).toBe true
 
 
+  describe "On update", ->
 
+    it "should re-copy the title from the select to the container", ->
+      select.attr('title', 'new title')
+      select.trigger("chosen:updated")
+      expect(container.attr('title')).toBe 'new title'    
 
+    describe "When inherit_select_classes option is enabled", ->
+
+      it "should re-copy all classes from the select to the container", ->
+        select.addClass('SecondClass')
+        select.trigger("chosen:updated")
+        expect(container.hasClass('TestClass')).toBe true
+        expect(container.hasClass('SecondClass')).toBe true

--- a/spec/jquery/basic.spec.coffee
+++ b/spec/jquery/basic.spec.coffee
@@ -1,88 +1,33 @@
-describe "Existential Validation", ->
+describe "Basic setup", ->
   it "should add chosen to jQuery object", ->
     expect(jQuery.fn.chosen).toBeDefined()
 
-describe "Basic Functionality", ->
-
-  beforeEach ->
+  it "should create very basic chosen", ->
     tmpl = "
-      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
+      <select data-placeholder='Choose a Country...'>
         <option value=''></option>
         <option value='United States'>United States</option>
         <option value='United Kingdom'>United Kingdom</option>
         <option value='Afghanistan'>Afghanistan</option>
       </select>
     "
-    @div = $("<div>").html(tmpl)
-    @select = @div.find('select')
-    @select.chosen()
-    @container = @div.find(".chosen-container")
-
-  afterEach ->
-    @select.chosen('destroy')
-    @div.remove()
-
-  it "should contain all of the necessary elements", ->
-
-    div = @div
-
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    expect(select.size()).toBe(1)
+    select.chosen()
     # very simple check that the necessary elements have been created
     ["container", "container-single", "single", "default"].forEach (clazz)->
       el = div.find(".chosen-#{clazz}")
       expect(el.size()).toBe(1)
 
-  it "should copy the title attribute from the select to the container", ->
-    expect(@container.attr('title')).toBe 'Initial Title'
-
-  it "should be initialized with no value", ->
     # test a few interactions
-    expect(@select.val()).toBe ""
+    expect(select.val()).toBe ""
 
-  it "should open the dropdown when the container is clicked", ->
-    @container.trigger("mousedown") # open the drop
-    expect(@container.hasClass("chosen-container-active")).toBe true
-
-  it "should update the select's value when an option is clicked", ->
-    @container.trigger("mousedown") # open the drop
+    container = div.find(".chosen-container")
+    container.trigger("mousedown") # open the drop
+    expect(container.hasClass("chosen-container-active")).toBe true
     #select an item
-    @container.find(".active-result").last().trigger("mouseup")
+    container.find(".active-result").last().trigger("mouseup")
 
-    expect(@select.val()).toBe "Afghanistan"
-
-  it "should re-copy the title from the select to the container on update", ->
-    @select.attr('title', 'new title')
-    @select.trigger("chosen:updated")
-    expect(@container.attr('title')).toBe 'new title'
-
-describe "When inherit selected classes is enabled", ->
-
-  beforeEach ->
-    tmpl = "
-      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
-        <option value=''></option>
-        <option value='United States'>United States</option>
-        <option value='United Kingdom'>United Kingdom</option>
-        <option value='Afghanistan'>Afghanistan</option>
-      </select>
-    "
-    @div = $("<div>").html(tmpl)
-    @select = @div.find('select')
-    @select.chosen({inherit_select_classes: true})
-    @container = @div.find(".chosen-container")
-
-  afterEach ->
-    @select.chosen('destroy')
-    @div.remove()
-
-  it "should copy all classes from the select to the container", ->
-    expect(@container.hasClass('TestClass')).toBe true
-
-  it "should re-copy all classes from the select to the container on update", ->
-    @select.addClass('SecondClass')
-    @select.trigger("chosen:updated")
-    expect(@container.hasClass('TestClass')).toBe true
-    expect(@container.hasClass('SecondClass')).toBe true
-
-
-
+    expect(select.val()).toBe "Afghanistan"
 

--- a/spec/proto/basic.spec.coffee
+++ b/spec/proto/basic.spec.coffee
@@ -2,7 +2,12 @@ describe "Existential Validation", ->
   it "should add expose a Chosen global", ->
     expect(Chosen).toBeDefined()
 
-describe "Basic Functionality", ->
+describe "Initialization and Interactions", ->
+
+  div = null
+  select = null
+  chosen = null
+  container = null
 
   beforeEach ->
     tmpl = "
@@ -13,80 +18,63 @@ describe "Basic Functionality", ->
         <option value='Afghanistan'>Afghanistan</option>
       </select>
     "
-
-    @div = new Element("div")
-    document.body.insert(@div)
-    @div.update(tmpl)
-    @select = @div.down("select")
-    @chosen = new Chosen(@select)
-    @container = @div.down(".chosen-container")
+    div = new Element("div")
+    document.body.insert(div)
+    div.update(tmpl)
+    select = div.down("select")
+    chosen = new Chosen(select, {inherit_select_classes: true})
+    container = div.down(".chosen-container")
 
   afterEach ->
-    @chosen.destroy()
-    @div.remove()
+    chosen.destroy()
+    div.remove()
 
-  it "should contain all of the necessary elements", ->
-    
-    div = @div
+  describe "On initialization", ->
 
-    expect(@select).toBeDefined()
-    
-    # very simple check that the necessary elements have been created
-    ["container", "container-single", "single", "default"].forEach (clazz)->
-      el = div.down(".chosen-#{clazz}")
-      expect(el).toBeDefined()
+    it "should contain all of the necessary elements", ->
+      expect(select).toBeDefined()
+      
+      # very simple check that the necessary elements have been created
+      ["container", "container-single", "single", "default"].forEach (clazz)->
+        el = div.down(".chosen-#{clazz}")
+        expect(el).toBeDefined()
 
-  it "should copy the title attribute from the select to the container", ->
-    expect(@container.readAttribute('title')).toBe 'Initial Title'
+    it "should copy the title attribute from the select to the container", ->
+      expect(container.readAttribute('title')).toBe 'Initial Title'
 
-  it "should be initialized with no value", ->
-    # test a few interactions
-    expect($F(@select)).toBe ""
+    it "should be initialized with no value", ->
+      # test a few interactions
+      expect($F(select)).toBe ""
 
-  it "should open the dropdown when the container is clicked", ->
-    @container.simulate("mousedown") # open the drop
-    expect(@container.hasClassName("chosen-container-active")).toBe true
+    it "should open the dropdown when the container is clicked", ->
+      container.simulate("mousedown") # open the drop
+      expect(container.hasClassName("chosen-container-active")).toBe true
 
-  it "should update the select's value when an option is clicked", ->
-    @container.simulate("mousedown") # open the drop
-    @container.select(".active-result").last().simulate("mouseup")
-    value = $F(@select)
-    expect(value).toBe "Afghanistan"
+    it "should update the select's value when an option is clicked", ->
+      container.simulate("mousedown") # open the drop
+      container.select(".active-result").last().simulate("mouseup")
+      value = $F(select)
+      expect(value).toBe "Afghanistan"
 
-  it "should re-copy the title from the select to the container on update", ->
-    @select.writeAttribute('title', 'new title')
-    @select.fire("chosen:updated")
-    expect(@container.readAttribute('title')).toBe 'new title'
+    describe "When inherit_select_classes option is enabled", ->
 
-  describe "When inherit selected classes is enabled", ->
+      it "should copy all classes from the select to the container", ->
+        expect(container.readAttribute('class')).toBe 'chosen-container chosen-container-single TestClass'
+        expect(container.hasClassName('TestClass')).toBe true
 
-    beforeEach ->
-      tmpl = "
-        <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
-          <option value=''></option>
-          <option value='United States'>United States</option>
-          <option value='United Kingdom'>United Kingdom</option>
-          <option value='Afghanistan'>Afghanistan</option>
-        </select>
-      "
 
-      @div = new Element("div")
-      document.body.insert(@div)
-      @div.update(tmpl)
-      @select = @div.down("select")
-      @chosen = new Chosen(@select, {inherit_select_classes: true})
-      @container = @div.down(".chosen-container")
+  describe "On update", ->
 
-    afterEach ->
-      @chosen.destroy()
-      @div.remove()
+    it "should re-copy the title from the select to the container", ->
+      select.writeAttribute('title', 'new title')
+      select.fire("chosen:updated")
+      expect(container.readAttribute('title')).toBe 'new title'
 
-    it "should copy all classes from the select to the container", ->
-      expect(@container.hasClassName('TestClass')).toBe true
+    describe "When inherit selected classes is enabled", ->
 
-    it "should re-copy all classes from the select to the container on update", ->
-      @select.addClassName('SecondClass')
-      @select.fire("chosen:updated")
-      # expect(@container.hasClassName('TestClass')).toBe true
-      expect(@container.hasClassName('SecondClass')).toBe true
+      it "should re-copy all classes from the select to the container on update", ->
+        select.addClassName('SecondClass')
+        select.fire("chosen:updated")
+        expect(container.readAttribute('class')).toBe 'chosen-container chosen-container-single TestClass SecondClass'
+        expect(container.hasClassName('SecondClass')).toBe true
 

--- a/spec/proto/basic.spec.coffee
+++ b/spec/proto/basic.spec.coffee
@@ -1,12 +1,10 @@
-describe "Existential Validation", ->
+describe "Basic setup", ->
   it "should add expose a Chosen global", ->
     expect(Chosen).toBeDefined()
 
-describe "Basic Functionality", ->
-
-  beforeEach ->
+  it "should create very basic chosen", ->
     tmpl = "
-      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
+      <select data-placeholder='Choose a Country...'>
         <option value=''></option>
         <option value='United States'>United States</option>
         <option value='United Kingdom'>United Kingdom</option>
@@ -14,79 +12,26 @@ describe "Basic Functionality", ->
       </select>
     "
 
-    @div = new Element("div")
-    document.body.insert(@div)
-    @div.update(tmpl)
-    @select = @div.down("select")
-    @chosen = new Chosen(@select)
-    @container = @div.down(".chosen-container")
-
-  afterEach ->
-    @chosen.destroy()
-    @div.remove()
-
-  it "should contain all of the necessary elements", ->
-    
-    div = @div
-
-    expect(@select).toBeDefined()
-    
+    div = new Element("div")
+    document.body.insert(div)
+    div.update(tmpl)
+    select = div.down("select")
+    expect(select).toBeDefined()
+    new Chosen(select)
     # very simple check that the necessary elements have been created
     ["container", "container-single", "single", "default"].forEach (clazz)->
       el = div.down(".chosen-#{clazz}")
       expect(el).toBeDefined()
 
-  it "should copy the title attribute from the select to the container", ->
-    expect(@container.readAttribute('title')).toBe 'Initial Title'
-
-  it "should be initialized with no value", ->
     # test a few interactions
-    expect($F(@select)).toBe ""
+    expect($F(select)).toBe ""
 
-  it "should open the dropdown when the container is clicked", ->
-    @container.simulate("mousedown") # open the drop
-    expect(@container.hasClassName("chosen-container-active")).toBe true
+    container = div.down(".chosen-container")
+    container.simulate("mousedown") # open the drop
+    expect(container.hasClassName("chosen-container-active")).toBe true
 
-  it "should update the select's value when an option is clicked", ->
-    @container.simulate("mousedown") # open the drop
-    @container.select(".active-result").last().simulate("mouseup")
-    value = $F(@select)
-    expect(value).toBe "Afghanistan"
+    #select an item
+    container.select(".active-result").last().simulate("mouseup")
 
-  it "should re-copy the title from the select to the container on update", ->
-    @select.writeAttribute('title', 'new title')
-    @select.fire("chosen:updated")
-    expect(@container.readAttribute('title')).toBe 'new title'
-
-  describe "When inherit selected classes is enabled", ->
-
-    beforeEach ->
-      tmpl = "
-        <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
-          <option value=''></option>
-          <option value='United States'>United States</option>
-          <option value='United Kingdom'>United Kingdom</option>
-          <option value='Afghanistan'>Afghanistan</option>
-        </select>
-      "
-
-      @div = new Element("div")
-      document.body.insert(@div)
-      @div.update(tmpl)
-      @select = @div.down("select")
-      @chosen = new Chosen(@select, {inherit_select_classes: true})
-      @container = @div.down(".chosen-container")
-
-    afterEach ->
-      @chosen.destroy()
-      @div.remove()
-
-    it "should copy all classes from the select to the container", ->
-      expect(@container.hasClassName('TestClass')).toBe true
-
-    it "should re-copy all classes from the select to the container on update", ->
-      @select.addClassName('SecondClass')
-      @select.fire("chosen:updated")
-      # expect(@container.hasClassName('TestClass')).toBe true
-      expect(@container.hasClassName('SecondClass')).toBe true
-
+    expect($F(select)).toBe "Afghanistan"
+    div.remove()

--- a/spec/proto/basic.spec.coffee
+++ b/spec/proto/basic.spec.coffee
@@ -1,10 +1,12 @@
-describe "Basic setup", ->
+describe "Existential Validation", ->
   it "should add expose a Chosen global", ->
     expect(Chosen).toBeDefined()
 
-  it "should create very basic chosen", ->
+describe "Basic Functionality", ->
+
+  beforeEach ->
     tmpl = "
-      <select data-placeholder='Choose a Country...'>
+      <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
         <option value=''></option>
         <option value='United States'>United States</option>
         <option value='United Kingdom'>United Kingdom</option>
@@ -12,26 +14,79 @@ describe "Basic setup", ->
       </select>
     "
 
-    div = new Element("div")
-    document.body.insert(div)
-    div.update(tmpl)
-    select = div.down("select")
-    expect(select).toBeDefined()
-    new Chosen(select)
+    @div = new Element("div")
+    document.body.insert(@div)
+    @div.update(tmpl)
+    @select = @div.down("select")
+    @chosen = new Chosen(@select)
+    @container = @div.down(".chosen-container")
+
+  afterEach ->
+    @chosen.destroy()
+    @div.remove()
+
+  it "should contain all of the necessary elements", ->
+    
+    div = @div
+
+    expect(@select).toBeDefined()
+    
     # very simple check that the necessary elements have been created
     ["container", "container-single", "single", "default"].forEach (clazz)->
       el = div.down(".chosen-#{clazz}")
       expect(el).toBeDefined()
 
+  it "should copy the title attribute from the select to the container", ->
+    expect(@container.readAttribute('title')).toBe 'Initial Title'
+
+  it "should be initialized with no value", ->
     # test a few interactions
-    expect($F(select)).toBe ""
+    expect($F(@select)).toBe ""
 
-    container = div.down(".chosen-container")
-    container.simulate("mousedown") # open the drop
-    expect(container.hasClassName("chosen-container-active")).toBe true
+  it "should open the dropdown when the container is clicked", ->
+    @container.simulate("mousedown") # open the drop
+    expect(@container.hasClassName("chosen-container-active")).toBe true
 
-    #select an item
-    container.select(".active-result").last().simulate("mouseup")
+  it "should update the select's value when an option is clicked", ->
+    @container.simulate("mousedown") # open the drop
+    @container.select(".active-result").last().simulate("mouseup")
+    value = $F(@select)
+    expect(value).toBe "Afghanistan"
 
-    expect($F(select)).toBe "Afghanistan"
-    div.remove()
+  it "should re-copy the title from the select to the container on update", ->
+    @select.writeAttribute('title', 'new title')
+    @select.fire("chosen:updated")
+    expect(@container.readAttribute('title')).toBe 'new title'
+
+  describe "When inherit selected classes is enabled", ->
+
+    beforeEach ->
+      tmpl = "
+        <select data-placeholder='Choose a Country...' title='Initial Title' class='TestClass'>
+          <option value=''></option>
+          <option value='United States'>United States</option>
+          <option value='United Kingdom'>United Kingdom</option>
+          <option value='Afghanistan'>Afghanistan</option>
+        </select>
+      "
+
+      @div = new Element("div")
+      document.body.insert(@div)
+      @div.update(tmpl)
+      @select = @div.down("select")
+      @chosen = new Chosen(@select, {inherit_select_classes: true})
+      @container = @div.down(".chosen-container")
+
+    afterEach ->
+      @chosen.destroy()
+      @div.remove()
+
+    it "should copy all classes from the select to the container", ->
+      expect(@container.hasClassName('TestClass')).toBe true
+
+    it "should re-copy all classes from the select to the container on update", ->
+      @select.addClassName('SecondClass')
+      @select.fire("chosen:updated")
+      # expect(@container.hasClassName('TestClass')).toBe true
+      expect(@container.hasClassName('SecondClass')).toBe true
+


### PR DESCRIPTION
This Fixes #2232 and Fixes #2311.
I simply extracted the logic that determines which classnames to apply to the container into a separate method, did the same for the logic that copies the title attribute, then replaced the original logic with calls to those two methods and added the same calls to the `results_build` method in the appropriate places so that classes and the title will be updated from the select on update.

I also significantly reorganized the spec files to make them more granular.  I originally had the whole virtual DOM being reconstructed and torn down before and after each test, but ran into some issues in prototype when using that approach that I was unable to figure out.  Since none of the current tests (or the tests I added) actually conflict with each other, I just organized the tests so that the virtual DOM and the chosen instance are only created once before any test and then destroyed after all tests.

Both prototype and jQuery versions were updated, and all tests are passing.
