### PR TITLE
Added event chosen:search

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -138,6 +138,7 @@ class AbstractChosen
       this.winnow_results()
     else
       this.results_show()
+    @form_field_jq.trigger("chosen:search", {chosen: this})
 
   winnow_results: ->
     this.no_results_clear()

--- a/public/options.html
+++ b/public/options.html
@@ -218,6 +218,10 @@
           <td>Triggered when Chosen’s dropdown is closed.</td>
         </tr>
         <tr>
+          <td>chosen:search</td>
+          <td>Triggered when Chosen has performed search.</td>
+        </tr>
+        <tr>
           <td>chosen:no_results</td>
           <td>Triggered when a search returns no matching results.</td>
         </tr>


### PR DESCRIPTION
This event is needed when styling options (adding classes), because on every search the options are rebuild from scratch.
