### PR TITLE
Remove "top" from linear-gradient - it's the wrong syntax

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -34,7 +34,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   a{
     cursor: pointer;
   }
-  
+
   .search-choice, .chosen-single{
     .group-name{
       margin-right: 4px;
@@ -64,7 +64,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     border: 1px solid #aaa;
     border-radius: 5px;
     background-color: #fff;
-    @include background(linear-gradient(top, #fff 20%, #f6f6f6 50%, #eee 52%, #f4f4f4 100%));
+    @include background(linear-gradient(#fff 20%, #f6f6f6 50%, #eee 52%, #f4f4f4 100%));
     background-clip: padding-box;
     box-shadow: 0 0 3px #fff inset, 0 1px 1px rgba(#000,.1);
     color: #444;
@@ -275,7 +275,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
       padding-right: 5px;
       border: 1px solid #ccc;
       background-color: #e4e4e4;
-      @include background-image(linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%));
+      @include background-image(linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%));
       color: #666;
     }
     &.search-choice-focus {


### PR DESCRIPTION
@tjschuck @pfiller @koenpunt @altras

Fixes https://github.com/harvesthq/chosen/issues/2363

Our linear gradients go from top-to-bottom, and according to the [latest syntax](http://www.w3.org/TR/css3-images/#linear-gradients) we should be using `to bottom`, but since that's the default we don't need to specify that. Having no direction will go `to bottom` anyway.