### PR TITLE
Adjust doc to actual code: disable_search_threshold

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1209,7 +1209,7 @@
 
       <h2><a name="hide-search-on-single-select" class="anchor" href="#hide-search-on-single-select">Hide Search on Single Select</a></h2>
       <div class="side-by-side clearfix">
-        <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer than (n) options.</p>
+        <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer or equal (n) options.</p>
         <pre><code class="language-javascript">$(".chosen-select").chosen({disable_search_threshold: 10});</code></pre>
         <p></p>
         <div>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -1210,7 +1210,7 @@
 
       <h2><a name="hide-search-on-single-select" class="anchor" href="#hide-search-on-single-select">Hide Search on Single Select</a></h2>
       <div class="side-by-side clearfix">
-        <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer than (n) options.</p>
+        <p>The disable_search_threshold option can be specified to hide the search input on single selects if there are fewer or equal (n) options.</p>
         <pre><code class="language-javascript"> new Chosen($("chosen_select_field"),{disable_search_threshold: 10}); </code></pre>
         <p></p>
         <div>

--- a/public/options.html
+++ b/public/options.html
@@ -48,7 +48,7 @@
         <tr>
           <td>disable_search_threshold</td>
           <td>0</td>
-          <td>Hide the search input on single selects if there are fewer than (n) options.</td>
+          <td>Hide the search input on single selects if there are fewer or equal (n) options.</td>
         </tr>
         <tr>
           <td>enable_split_word_search</td>


### PR DESCRIPTION
Contrary to what the documentation currently states, the search input is actually hidden if there are fewer **or equal** number of options compared to disable_search_threshold .

See the current code for reference: https://github.com/harvesthq/chosen/blob/9a1a59f15a9a50b38a2aeafc0bb0f95c7ca9348a/coffee/chosen.jquery.coffee#L192