### PR TITLE
Wraps label's for attribute with double quote.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -263,7 +263,7 @@ class Chosen extends AbstractChosen
   set_label_behavior: ->
     @form_field_label = @form_field_jq.parents("label") # first check for a parent label
     if not @form_field_label.length and @form_field.id.length
-      @form_field_label = $("label[for='#{@form_field.id}']") #next check for a for=#{id}
+      @form_field_label = $("label[for=\"#{@form_field.id}\"]") #next check for a for=#{id}
 
     if @form_field_label.length > 0
       @form_field_label.bind 'click.chosen', (evt) => if @is_multiple then this.container_mousedown(evt) else this.activate_field()


### PR DESCRIPTION
Hi,

Today I faced a problem while trying to apply chosen to some HTML inputs with `'` _(single quote)_ into its `id`s.

Besides the fact that isn't appropriate to use single quotes into HTML's `id` attributes, was wondering, if perhaps that small contribution could be accepted.

Thanks.