### PR TITLE
Add ability to set images for select options

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -29,6 +29,7 @@ class Chosen extends AbstractChosen
     container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
     container_classes.push @form_field.className if @inherit_select_classes && @form_field.className
     container_classes.push "chosen-rtl" if @is_rtl
+    container_classes.push "chosen-image-container" if @option_images
 
     container_props =
       'class': container_classes.join ' '
@@ -291,7 +292,11 @@ class Chosen extends AbstractChosen
     this.result_clear_highlight() if $(evt.target).hasClass "active-result" or $(evt.target).parents('.active-result').first()
 
   choice_build: (item) ->
-    choice = $('<li />', { class: "search-choice" }).html("<span>#{this.choice_label(item)}</span>")
+    if @option_images
+      attributes = if item.img_src then ' class="image" style="background-image: url(' + item.img_src + ');"' else ' style="background-image: none;"'
+    else
+      attributes = ''
+    choice = $('<li />', { class: "search-choice" }).html("<span#{attributes}>#{this.choice_label(item)}</span>")
 
     if item.disabled
       choice.addClass 'search-choice-disabled'
@@ -356,6 +361,7 @@ class Chosen extends AbstractChosen
       if @is_multiple
         this.choice_build item
       else
+        this.single_set_selected_image(item.img_src) if @option_images
         this.single_set_selected_text(this.choice_label(item))
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
@@ -367,6 +373,12 @@ class Chosen extends AbstractChosen
       evt.preventDefault()
 
       this.search_field_scale()
+
+  single_set_selected_image: (img_src) ->
+    if img_src
+      @selected_item.find("span").addClass('image').css("background-image", "url(#{img_src})")
+    else
+      @selected_item.find("span").removeClass('image').css("background-image", "none")
 
   single_set_selected_text: (text=@default_text) ->
     if text is @default_text

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -33,6 +33,7 @@ class AbstractChosen
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
+    @option_images = @options.option_images || false
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -83,6 +84,7 @@ class AbstractChosen
         if data.selected and @is_multiple
           this.choice_build data
         else if data.selected and not @is_multiple
+          this.single_set_selected_image(data.img_src) if @option_images
           this.single_set_selected_text(this.choice_label(data))
 
       if shown_results >= @max_shown_results
@@ -104,6 +106,8 @@ class AbstractChosen
     option_el = document.createElement("li")
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
+    if @option_images && option.img_src
+      option_el.style.cssText += "background-image: url(#{option.img_src});"
     option_el.setAttribute("data-option-array-index", option.array_index)
     option_el.innerHTML = option.search_text
     option_el.title = option.title if option.title

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -39,6 +39,7 @@ class SelectParser
           group_array_index: group_position
           group_label: if group_position? then @parsed[group_position].label else null
           classes: option.className
+          img_src: option.getAttribute("data-img-src")
           style: option.style.cssText
       else
         @parsed.push

--- a/public/index.html
+++ b/public/index.html
@@ -1410,6 +1410,41 @@
         </div>
       </div>
 
+      <h2><a name="option-image-support" class="anchor" href="#option-image-support">Option Image Support</a></h2>
+      <div class="side-by-side clearfix">
+        <p>Set chosen options like this:</p>
+        <pre><code class="language-javascript"> $(".chosen-select").chosen({option_images: true}); </code></pre>
+        <p>Specify image src on needed option elements with attribute <code class="language-html">data-img-src</code> like this:</p>
+        <pre><code class="language-markup">&lt;select data-placeholder="Choose a country..." class="chosen-select"&gt;
+  &lt;option data-img-src="http://www.example.com/images/be.png">Belgium&lt;/option&gt;
+  &lt;option data-img-src="http://www.example.com/images/lv.png" selected>Latvia&lt;/option&gt;
+  &lt;option data-img-src="http://www.example.com/images/us.png">USA&lt;/option&gt;
+  &lt;option data-img-src="http://www.example.com/images/jp.png">Japan&lt;/option&gt;
+  &lt;option>Neverland&lt;/option&gt;
+&lt;/select&gt;</code></pre>
+        <div>
+          <em>Single Select</em>
+
+          <select data-placeholder="Choose a country..." class="chosen-select-images" style="width:350px;" tabindex="19">
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/be.svg">Belgium</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/lv.svg" selected>Latvia</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/us.svg">USA</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/jp.svg">Japan</option>
+            <option>Neverland</option>
+          </select>
+        </div>
+        <div>
+          <em>Multiple Select</em>
+          <select data-placeholder="Choose a country..." class="chosen-select-images" style="width:350px;" tabindex="20" multiple>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/be.svg">Belgium</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/lv.svg" selected>Latvia</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/us.svg">USA</option>
+            <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/jp.svg">Japan</option>
+            <option selected>Neverland</option>
+          </select>
+        </div>
+      </div>
+
       <h2><a name="setup" class="anchor" href="#setup">Setup</a></h2>
       <p>Using Chosen is easy as can be.</p>
       <ol>
@@ -1462,7 +1497,8 @@
       '.chosen-select-deselect'  : {allow_single_deselect:true},
       '.chosen-select-no-single' : {disable_search_threshold:10},
       '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},
-      '.chosen-select-width'     : {width:"95%"}
+      '.chosen-select-width'     : {width:"95%"},
+      '.chosen-select-images'    : {option_images: true}
     }
     for (var selector in config) {
       $(selector).chosen(config[selector]);

--- a/public/options.html
+++ b/public/options.html
@@ -123,6 +123,13 @@
             <p>Only show the first (n) matching options in the results. This can be used to increase performance for selects with very many options.</p>
           </td>
         </tr>
+        <tr>
+          <td>option_images</td>
+          <td>false</td>
+          <td>
+            <p>Add class <code class="language-markup">chosen-image-container</code> on chosen container to apply styling for images. If select options have <code class="language-markup">data-img-src</code> attribute, it would be added to both result and choice items.</p>
+          </td>
+        </tr>
       </table>
 
       <h2><a name="attributes" class="anchor" href="#attributes">Attributes</a></h2>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -469,10 +469,11 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     }
   }
 
-
-
   .chosen-results li {
     background-repeat: no-repeat;
+    &.highlighted {
+      background-size: 19px;
+    }
   }
 }
 

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -416,6 +416,68 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 
 /* @end */
 
+/* @group Right to Left */
+
+.chosen-image-container {
+
+  .chosen-results li,
+  .chosen-single span.image {
+    background-position: 3px 45%;
+    background-size: 19px 19px;
+    padding-left: 27px;
+    height: 25px;
+  }
+
+  .chosen-single {
+    padding: 0 0 0 4px;
+
+    span.image {
+      background-position: 3px 40%;
+      background-repeat: no-repeat;
+      padding-left: 27px;
+    }
+  }
+
+  .chosen-choices {
+    padding: 3px 3px 0;
+    min-height: 27px;
+
+    li.search-field input[type="text"] {
+      height: 28px;
+      margin: 0;
+      padding-bottom: 2px;
+    }
+
+    li.search-choice {
+      height: 25px;
+      margin: 0 3px 3px 0;
+      padding: 2px 24px 2px 5px;
+      line-height: 19px;
+      border-radius: 2px;
+
+      span.image {
+        background-repeat: no-repeat;
+        padding-left: 25px;
+        background-size: 19px 19px;
+        display: inline-block;
+      }
+
+      .search-choice-close {
+        top: 6px;
+        right: 5px;
+      }
+    }
+  }
+
+
+
+  .chosen-results li {
+    background-repeat: no-repeat;
+  }
+}
+
+/* @end */
+
 /* @group Retina compatibility */
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
   .chosen-rtl .chosen-search input[type="text"],


### PR DESCRIPTION
If following markup:
```
<select data-placeholder="Choose a country..." class="chosen-select-images" style="width:350px;" tabindex="19">
  <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/be.svg">Belgium</option>
  <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/lv.svg" selected>Latvia</option>
  <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/us.svg">USA</option>
  <option data-img-src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.7.1/flags/4x3/jp.svg">Japan</option>
  <option>Neverland</option>
</select>
```
and setup is in place:
```
$(".chosen-select").chosen({option_images: true});
```

it's possible to display images next to options in results dropdown and selected choices:
![chosen-options-image](http://oi62.tinypic.com/ax0byc.jpg)