### PR TITLE
Add native placeholder option

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -40,7 +40,13 @@ class Chosen extends AbstractChosen
     @container = ($ "<div />", container_props)
 
     if @is_multiple
-      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
+      if @native_placeholder
+        style = ''
+        default_text_attribute = 'placeholder'
+      else
+        style = ' style="width:25px;"'
+        default_text_attribute = 'value'
+      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" ' + default_text_attribute + '="' + @default_text + '" class="default" autocomplete="off"' + style + ' /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
     else
       @container.html '<a class="chosen-single chosen-default"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
@@ -487,9 +493,6 @@ class Chosen extends AbstractChosen
 
   search_field_scale: ->
     if @is_multiple
-      h = 0
-      w = 0
-
       style_block = "position:absolute; left: -1000px; top: -1000px; display:none;"
       styles = ['font-size','font-style', 'font-weight', 'font-family','line-height', 'text-transform', 'letter-spacing']
 
@@ -497,7 +500,10 @@ class Chosen extends AbstractChosen
         style_block += style + ":" + @search_field.css(style) + ";"
 
       div = $('<div />', { 'style' : style_block })
-      div.text @search_field.val()
+      if @native_placeholder
+        div.text $(this.search_field).attr('placeholder')
+      else
+        div.text @search_field.val()
       $('body').append div
 
       w = div.width() + 25

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -33,6 +33,9 @@ class AbstractChosen
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
+    @native_placeholder = @options.native_placeholder || false
+
+    return
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")

--- a/public/index.html
+++ b/public/index.html
@@ -1410,6 +1410,40 @@
         </div>
       </div>
 
+      <h2><a name="native-placeholder" class="anchor" href="#native-placeholder">Native placeholder</a></h2>
+      <div class="side-by-side clearfix">
+        <p>Use native placeholder instead of default input value. It will be visible if input is empty. Useful for multiple select to display what is expected from user when something is already selected.</p>
+        <pre><code class="language-javascript"> $(".chosen-select").chosen({native_placeholder: true}); </code></pre>
+        <div>
+          <em><label for="single-label-example">Click to Highlight Single Select</label></em>
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-placeholder" style="width:350px;" tabindex="19" id="single-label-example">
+            <option value=""></option>
+            <option>American Black Bear</option>
+            <option>Asiatic Black Bear</option>
+            <option>Brown Bear</option>
+            <option>Giant Panda</option>
+            <option>Sloth Bear</option>
+            <option>Sun Bear</option>
+            <option>Polar Bear</option>
+            <option>Spectacled Bear</option>
+          </select>
+        </div>
+        <div>
+          <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
+          <select data-placeholder="Type in Bear Name" multiple class="chosen-select-placeholder" style="width:350px;" tabindex="20" id="multiple-label-example">
+            <option value=""></option>
+            <option>American Black Bear</option>
+            <option>Asiatic Black Bear</option>
+            <option>Brown Bear</option>
+            <option>Giant Panda</option>
+            <option>Sloth Bear</option>
+            <option>Sun Bear</option>
+            <option>Polar Bear</option>
+            <option>Spectacled Bear</option>
+          </select>
+        </div>
+      </div>
+
       <h2><a name="setup" class="anchor" href="#setup">Setup</a></h2>
       <p>Using Chosen is easy as can be.</p>
       <ol>
@@ -1458,11 +1492,12 @@
   <script src="docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
   <script type="text/javascript">
     var config = {
-      '.chosen-select'           : {},
-      '.chosen-select-deselect'  : {allow_single_deselect:true},
-      '.chosen-select-no-single' : {disable_search_threshold:10},
-      '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},
-      '.chosen-select-width'     : {width:"95%"}
+      '.chosen-select'              : {},
+      '.chosen-select-deselect'     : {allow_single_deselect:true},
+      '.chosen-select-no-single'    : {disable_search_threshold:10},
+      '.chosen-select-no-results'   : {no_results_text:'Oops, nothing found!'},
+      '.chosen-select-width'        : {width:"95%"},
+      '.chosen-select-placeholder'  : {native_placeholder:true, allow_single_deselect: true}
     }
     for (var selector in config) {
       $(selector).chosen(config[selector]);

--- a/public/options.html
+++ b/public/options.html
@@ -123,6 +123,13 @@
             <p>Only show the first (n) matching options in the results. This can be used to increase performance for selects with very many options.</p>
           </td>
         </tr>
+        <tr>
+          <td>native_placeholder</td>
+          <td>false</td>
+          <td>
+            <p>When set to <code class="language-javascript">true</code>, in multiple selects default text will be shown as placeholder and will be displayed even when there are already selected options.</p>
+          </td>
+        </tr>
       </table>
 
       <h2><a name="attributes" class="anchor" href="#attributes">Attributes</a></h2>


### PR DESCRIPTION
Main benefit is that placeholder is shown when search input is in focus but there's nothing entered yet, so in case of multiple selects when there is at least one option already selected search input will stil show what information user should input:
![default text as placeholder](http://oi62.tinypic.com/9ko45l.jpg)