### PR TITLE
Extend mobile browser detection

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -282,12 +282,20 @@ class AbstractChosen
   # class methods and variables ============================================================
 
   @browser_is_supported: ->
-    if window.navigator.appName == "Microsoft Internet Explorer"
-      return document.documentMode >= 8
     if /iP(od|hone)/i.test(window.navigator.userAgent)
       return false
     if /Android/i.test(window.navigator.userAgent)
       return false if /Mobile/i.test(window.navigator.userAgent)
+    if /IEMobile/i.test(window.navigator.userAgent)
+      return false
+    if /Windows Phone/i.test(window.navigator.userAgent)
+      return false
+    if /BlackBerry/i.test(window.navigator.userAgent)
+      return false
+    if /BB10/i.test(window.navigator.userAgent)
+      return false
+    if window.navigator.appName is "Microsoft Internet Explorer"
+      return document.documentMode >= 8
     return true
 
   @default_multiple_text: "Select Some Options"


### PR DESCRIPTION
On top of the existing detections of Android and IOS, detect Windows Phone, IE Mobile, Blackberry and BB10.

As discussed in https://github.com/harvesthq/chosen/issues/1848 and https://github.com/harvesthq/chosen/issues/2439