### PR TITLE
Fixes #2095

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -8,9 +8,11 @@ $.fn.extend({
     this.each (input_field) ->
       $this = $ this
       chosen = $this.data('chosen')
-      if options is 'destroy' && chosen instanceof Chosen
-        chosen.destroy()
-      else unless chosen instanceof Chosen
+      if options is 'destroy'
+        if chosen instanceof Chosen
+          chosen.destroy()
+        return
+      unless chosen instanceof Chosen
         $this.data('chosen', new Chosen(this, options))
 
       return


### PR DESCRIPTION
If option passed is 'destroy' then only call the #destroy method and terminate.
This fixes the issue where a new chosen instance is created unintentionally. 