### PR TITLE
Remove zoom:1 and *display:inline

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -11,8 +11,6 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   display: inline-block;
   vertical-align: middle;
   font-size: 13px;
-  zoom: 1;
-  *display: inline;
   @include user-select(none);
   * {
     @include box-sizing(border-box);
@@ -34,7 +32,7 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   a{
     cursor: pointer;
   }
-  
+
   .search-choice, .chosen-single{
     .group-name{
       margin-right: 4px;


### PR DESCRIPTION
@tjschuck @koenpunt @pfiller Fixes https://github.com/harvesthq/chosen/issues/2451#issuecomment-147406851

These two properties are hacks that were needed for versions of IE before 8. Chosen now currently doesn't even render for versions of IE before 8, so they are no longer needed. This also fixes Invalid Property error, as described in the Issue above.