### PR TITLE
remove superfluous background mixin

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -127,7 +127,6 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
       outline: 0;
       border: 1px solid #aaa;
       background: #fff $chosen-sprite no-repeat 100% -20px;
-      @include background($chosen-sprite no-repeat 100% -20px);
       font-size: 1em;
       font-family: sans-serif;
       line-height: normal;
@@ -397,7 +396,6 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   .chosen-search input[type="text"] {
     padding: 4px 5px 4px 20px;
     background: #fff $chosen-sprite no-repeat -30px -20px;
-    @include background($chosen-sprite no-repeat -30px -20px);
     direction: rtl;
   }
   &.chosen-container-single{


### PR DESCRIPTION
@mlettini @tjschuck @pfiller 

since [we're no longer using a gradient as background](https://github.com/harvesthq/chosen/commit/698fa67c8bd6da217e87773d661be671e4f74750) for the input, the use of the background mixin is unnecessary.