### PR TITLE
fixed CSS file name in generated bower.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "bowerJSON":{
     "main": [
       "chosen.jquery.js",
-      "chosen.css",
+      "chosen.min.css",
       "chosen-sprite@2x.png",
       "chosen-sprite.png"
     ]


### PR DESCRIPTION
The file in the generated bower repository is named `chosen.min.css`, but the generated bower.json references a (not existing) `chosen.css`.