### PR TITLE
Don't open up chosen on option keyup.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -245,7 +245,7 @@ class AbstractChosen
       when 27
         this.results_hide() if @results_showing
         return true
-      when 9, 38, 40, 16, 91, 17
+      when 9, 38, 40, 16, 91, 17, 18
         # don't do anything on these keys
       else this.results_search()
 


### PR DESCRIPTION
Hello Chosen!

When embedding chosen in a chrome extension, the keyboard shortcut includes the option key. If a chosen instance happens to be focused at the time, releasing the option key opens it, but shouldn't. This patch ignores option keyup events.

I ran the build task after making the change like it says to in `contributing.md`, but it didn't change any git-tracked files that I could tell. Let me know if I need to do something else!