### PR TITLE
Include SASS-Lint. Improve code standarts, code visibility and fix lint issues for chosen.scss

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'compass'
+gem 'scss-lint', '~> 0.38.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.2.8)
-    compass (0.12.2)
+    chunky_png (1.3.5)
+    compass (1.0.3)
       chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (~> 3.1)
-    fssm (0.2.10)
-    sass (3.2.9)
+      compass-core (~> 1.0.2)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.3)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    ffi (1.9.10)
+    multi_json (1.11.2)
+    rainbow (2.0.0)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    sass (3.4.20)
+    scss-lint (0.38.0)
+      rainbow (~> 2.0)
+      sass (~> 3.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   compass
+  scss-lint (~> 0.38.0)
+
+BUNDLED WITH
+   1.10.6

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -1,420 +1,517 @@
-@import "compass/css3/box-sizing";
-@import "compass/css3/images";
-@import "compass/css3/user-interface";
+// Compass dependencies
+@import 'compass/css3/box-sizing';
+@import 'compass/css3/images';
+@import 'compass/css3/user-interface';
 
+//Background image
 $chosen-sprite: image-url('chosen-sprite.png') !default;
 $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 
-/* @group Base */
+ //Colors
+$white: #fff;
+$black: #000;
+$dark-gray: #aaa;
+$mountain-mist: #999;
+$tundora: #444;
+$gallery: #eee;
+$ironside-gray: #666;
+$light-gray: #d4d4d4;
+$gray-nurse: #e8e8e8;
+$wild-sand: #f4f4f4;
+$cornflower-blue: #5897fb;
+$mine-shaft: #333;
+$dark-jungle-green: #222;
+$han-blue: #3875d7;
+$cerelean-blue: #2a62bc;
+$tapa: #777;
+$celeste: #ccc;
+$mercury: #e4e4e4;
+$black-haze: #f6f6f6;
+
+
+// @group Base
 .chosen-container {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  font-size: 13px;
   @include user-select(none);
+  display: inline-block;
+  font-size: 13px;
+  position: relative;
+  vertical-align: middle;
+
   * {
     @include box-sizing(border-box);
   }
+
   .chosen-drop {
+    background: $white;
+    border: 1px solid $dark-gray;
+    border-top: 0;
+    box-shadow: 0 4px 5px rgba($black, .15);
+    left: -9999px;
     position: absolute;
     top: 100%;
-    left: -9999px;
-    z-index: 1010;
     width: 100%;
-    border: 1px solid #aaa;
-    border-top: 0;
-    background: #fff;
-    box-shadow: 0 4px 5px rgba(#000,.15);
+    z-index: 1010;
   }
+
   &.chosen-with-drop .chosen-drop {
     left: 0;
   }
-  a{
+
+  a {
     cursor: pointer;
   }
 
-  .search-choice, .chosen-single{
-    .group-name{
+  .search-choice,
+  .chosen-single {
+    .group-name {
+      color: $mountain-mist;
+      font-weight: normal;
       margin-right: 4px;
       overflow: hidden;
-      white-space: nowrap;
       text-overflow: ellipsis;
-      font-weight: normal;
-      color: #999999;
-      &:after {
-        content: ":";
+      white-space: nowrap;
+
+      &::after {
+        content: ':';
         padding-left: 2px;
         vertical-align: top;
       }
     }
   }
-}
-/* @end */
 
-/* @group Single Chosen */
-.chosen-container-single{
-  .chosen-single {
+  // @group Results
+  .chosen-results {
+    color: $tundora;
+    margin: 0 4px 4px 0;
+    max-height: 240px;
+    -webkit-overflow-scrolling: touch;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 0 0 0 4px;
     position: relative;
+
+    li {
+      display: none;
+      line-height: 15px;
+      list-style: none;
+      margin: 0;
+      padding: 5px 6px;
+      -webkit-touch-callout: none;
+      word-wrap: break-word;
+
+      &.active-result {
+        cursor: pointer;
+        display: list-item;
+      }
+
+      &.disabled-result {
+        color: $celeste;
+        cursor: default;
+        display: list-item;
+      }
+
+      &.highlighted {
+        @include background-image(linear-gradient($han-blue 20%, $cerelean-blue 90%));
+        background-color: $han-blue;
+        color: $white;
+      }
+
+      &.no-results {
+        background: $wild-sand;
+        color: $tapa;
+        display: list-item;
+      }
+
+      &.group-result {
+        cursor: default;
+        display: list-item;
+        font-weight: bold;
+      }
+
+      &.group-option {
+        padding-left: 15px;
+      }
+
+      em {
+        font-style: normal;
+        text-decoration: underline;
+      }
+    }
+  }
+  // @end
+}
+// @end
+
+// @group Single Chosen
+.chosen-container-single {
+  .chosen-single {
+    @include background(linear-gradient($white 20%, $black-haze 50%, $gallery 52%, $wild-sand 100%));
+    background-clip: padding-box;
+    background-color: $white;
+    border: 1px solid $dark-gray;
+    border-radius: 5px;
+    box-shadow: 0 0 3px $white inset, 0 1px 1px rgba($black, .1);
+    color: $tundora;
     display: block;
+    height: 25px;
+    line-height: 24px;
     overflow: hidden;
     padding: 0 0 0 8px;
-    height: 25px;
-    border: 1px solid #aaa;
-    border-radius: 5px;
-    background-color: #fff;
-    @include background(linear-gradient(#fff 20%, #f6f6f6 50%, #eee 52%, #f4f4f4 100%));
-    background-clip: padding-box;
-    box-shadow: 0 0 3px #fff inset, 0 1px 1px rgba(#000,.1);
-    color: #444;
+    position: relative;
     text-decoration: none;
     white-space: nowrap;
-    line-height: 24px;
+
+    span {
+      display: block;
+      margin-right: 26px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    abbr {
+      background: $chosen-sprite -42px 1px no-repeat;
+      display: block;
+      font-size: 1px;
+      height: 12px;
+      position: absolute;
+      right: 26px;
+      top: 6px;
+      width: 12px;
+
+      &:hover {
+        background-position: -42px -10px;
+      }
+    }
+
+    div {
+      display: block;
+      height: 100%;
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 18px;
+
+      b {
+        background: $chosen-sprite no-repeat 0 2px;
+        display: block;
+        height: 100%;
+        width: 100%;
+      }
+    }
   }
+
   .chosen-default {
-    color: #999;
+    color: $mountain-mist;
   }
-  .chosen-single span {
-    display: block;
-    overflow: hidden;
-    margin-right: 26px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+
   .chosen-single-with-deselect span {
     margin-right: 38px;
   }
-  .chosen-single abbr {
-    position: absolute;
-    top: 6px;
-    right: 26px;
-    display: block;
-    width: 12px;
-    height: 12px;
-    background: $chosen-sprite -42px 1px no-repeat;
-    font-size: 1px;
-    &:hover {
-      background-position: -42px -10px;
-    }
-  }
+
   &.chosen-disabled .chosen-single abbr:hover {
     background-position: -42px -10px;
   }
-  .chosen-single div {
-    position: absolute;
-    top: 0;
-    right: 0;
-    display: block;
-    width: 18px;
-    height: 100%;
-    b {
-      display: block;
-      width: 100%;
-      height: 100%;
-      background: $chosen-sprite no-repeat 0px 2px;
-    }
-  }
+
   .chosen-search {
-    position: relative;
-    z-index: 1010;
     margin: 0;
     padding: 3px 4px;
-    white-space: nowrap;
-    input[type="text"] {
-      margin: 1px 0;
-      padding: 4px 20px 4px 5px;
-      width: 100%;
-      height: auto;
-      outline: 0;
-      border: 1px solid #aaa;
-      background: #fff $chosen-sprite no-repeat 100% -20px;
-      @include background($chosen-sprite no-repeat 100% -20px);
-      font-size: 1em;
-      font-family: sans-serif;
-      line-height: normal;
-      border-radius: 0;
-    }
-  }
-  .chosen-drop {
-    margin-top: -1px;
-    border-radius: 0 0 4px 4px;
-    background-clip: padding-box;
-  }
-  &.chosen-container-single-nosearch .chosen-search {
-    position: absolute;
-    left: -9999px;
-  }
-}
-/* @end */
-
-/* @group Results */
-.chosen-container .chosen-results {
-  color: #444;
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: auto;
-  margin: 0 4px 4px 0;
-  padding: 0 0 0 4px;
-  max-height: 240px;
-  -webkit-overflow-scrolling: touch;
-  li {
-    display: none;
-    margin: 0;
-    padding: 5px 6px;
-    list-style: none;
-    line-height: 15px;
-    word-wrap: break-word;
-    -webkit-touch-callout: none;
-    &.active-result {
-      display: list-item;
-      cursor: pointer;
-    }
-    &.disabled-result {
-      display: list-item;
-      color: #ccc;
-      cursor: default;
-    }
-    &.highlighted {
-      background-color: #3875d7;
-      @include background-image(linear-gradient(#3875d7 20%, #2a62bc 90%));
-      color: #fff;
-    }
-    &.no-results {
-      color: #777;
-      display: list-item;
-      background: #f4f4f4;
-    }
-    &.group-result {
-      display: list-item;
-      font-weight: bold;
-      cursor: default;
-    }
-    &.group-option {
-      padding-left: 15px;
-    }
-    em {
-      font-style: normal;
-      text-decoration: underline;
-    }
-  }
-}
-/* @end */
-
-/* @group Multi Chosen */
-.chosen-container-multi{
-  .chosen-choices {
     position: relative;
-    overflow: hidden;
-    margin: 0;
-    padding: 0 5px;
-    width: 100%;
-    height: auto !important;
-    height: 1%;
-    border: 1px solid #aaa;
-    background-color: #fff;
-    @include background-image(linear-gradient(#eee 1%, #fff 15%));
-    cursor: text;
-  }
-  .chosen-choices li {
-    float: left;
-    list-style: none;
-    &.search-field {
-      margin: 0;
-      padding: 0;
-      white-space: nowrap;
-      input[type="text"] {
-        margin: 1px 0;
-        padding: 0;
-        height: 25px;
-        outline: 0;
-        border: 0 !important;
-        background: transparent !important;
-        box-shadow: none;
-        color: #999;
-        font-size: 100%;
-        font-family: sans-serif;
-        line-height: normal;
+    white-space: nowrap;
+    z-index: 1010;
+
+    input {
+      &[type="text"] {
+        @include background($white $chosen-sprite no-repeat 100% -20px);
+        border: 1px solid $dark-gray;
         border-radius: 0;
+        font-family: sans-serif;
+        font-size: 1em;
+        height: auto;
+        line-height: normal;
+        margin: 1px 0;
+        outline: 0;
+        padding: 4px 20px 4px 5px;
+        width: 100%;
       }
     }
-    &.search-choice {
-      position: relative;
-      margin: 3px 5px 3px 0;
-      padding: 3px 20px 3px 5px;
-      border: 1px solid #aaa;
-      max-width: 100%;
-      border-radius: 3px;
-      background-color: #eeeeee;
-      @include background-image(linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%));
-      background-size: 100% 19px;
-      background-repeat: repeat-x;
-      background-clip: padding-box;
-      box-shadow: 0 0 2px #fff inset, 0 1px 0 rgba(#000,.05);
-      color: #333;
-      line-height: 13px;
-      cursor: default;
-      span {
-        word-wrap: break-word;
+  }
+
+  .chosen-drop {
+    background-clip: padding-box;
+    border-radius: 0 0 4px 4px;
+    margin-top: -1px;
+  }
+
+  &.chosen-container-single-nosearch .chosen-search {
+    left: -9999px;
+    position: absolute;
+  }
+}
+// @end
+
+// @group Multi Chosen
+.chosen-container-multi {
+  .chosen-choices {
+    @include background-image(linear-gradient($gallery 1%, $white 15%));
+    background-color: $white;
+    border: 1px solid $dark-gray;
+    cursor: text;
+    height: 1%;
+    margin: 0;
+    overflow: hidden;
+    padding: 0 5px;
+    position: relative;
+    width: 100%;
+
+    li {
+      float: left;
+      list-style: none;
+
+      &.search-field {
+        margin: 0;
+        padding: 0;
+        white-space: nowrap;
+
+        input[type="text"] {
+          background: transparent !important;
+          border: 0 !important;
+          border-radius: 0;
+          box-shadow: none;
+          color: $mountain-mist;
+          font-family: sans-serif;
+          font-size: 100%;
+          height: 25px;
+          line-height: normal;
+          margin: 1px 0;
+          outline: 0;
+          padding: 0;
+        }
       }
-      .search-choice-close {
-        position: absolute;
-        top: 4px;
-        right: 3px;
-        display: block;
-        width: 12px;
-        height: 12px;
-        background: $chosen-sprite -42px 1px no-repeat;
-        font-size: 1px;
-        &:hover {
+
+      &.search-choice {
+        @include background-image(linear-gradient($wild-sand 20%, $gallery 50%, $gray-nurse 52%, $gallery 100%));
+        background-clip: padding-box;
+        background-color: $gallery;
+        background-repeat: repeat-x;
+        background-size: 100% 19px;
+        border: 1px solid $dark-gray;
+        border-radius: 3px;
+        box-shadow: 0 0 2px $white inset, 0 1px 0 rgba($black, .05);
+        color: $mine-shaft;
+        cursor: default;
+        line-height: 13px;
+        margin: 3px 5px 3px 0;
+        max-width: 100%;
+        padding: 3px 20px 3px 5px;
+        position: relative;
+
+        span {
+          word-wrap: break-word;
+        }
+
+        .search-choice-close {
+          background: $chosen-sprite -42px 1px no-repeat;
+          display: block;
+          font-size: 1px;
+          height: 12px;
+          position: absolute;
+          right: 3px;
+          top: 4px;
+          width: 12px;
+
+          &:hover {
+            background-position: -42px -10px;
+          }
+        }
+      }
+
+      &.search-choice-disabled {
+        @include background-image(linear-gradient($wild-sand 20%, $gallery 50%, $gray-nurse 52%, $gallery 100%));
+        background-color: $mercury;
+        border: 1px solid $celeste;
+        color: $ironside-gray;
+        padding-right: 5px;
+      }
+
+      &.search-choice-focus {
+        background: $light-gray;
+
+        .search-choice-close {
           background-position: -42px -10px;
         }
       }
     }
-    &.search-choice-disabled {
-      padding-right: 5px;
-      border: 1px solid #ccc;
-      background-color: #e4e4e4;
-      @include background-image(linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%));
-      color: #666;
-    }
-    &.search-choice-focus {
-      background: #d4d4d4;
-      .search-choice-close {
-        background-position: -42px -10px;
-      }
-    }
   }
+
   .chosen-results {
     margin: 0;
     padding: 0;
   }
+
   .chosen-drop .result-selected {
-    display: list-item;
-    color: #ccc;
+    color: $celeste;
     cursor: default;
+    display: list-item;
   }
 }
-/* @end */
+// @end
 
-/* @group Active  */
-.chosen-container-active{
+// @group Active
+.chosen-container-active {
   .chosen-single {
-    border: 1px solid #5897fb;
-    box-shadow: 0 0 5px rgba(#000,.3);
+    border: 1px solid $cornflower-blue;
+    box-shadow: 0 0 5px rgba($black, .3);
   }
-  &.chosen-with-drop{
+
+  &.chosen-with-drop {
     .chosen-single {
-      border: 1px solid #aaa;
-      -moz-border-radius-bottomright: 0;
+      @include background-image(linear-gradient($gallery 20%, $white 80%));
+      border: 1px solid $dark-gray;
+      border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
       -moz-border-radius-bottomleft: 0;
-      border-bottom-left-radius: 0;
-      @include background-image(linear-gradient(#eee 20%, #fff 80%));
-      box-shadow: 0 1px 0 #fff inset;
-    }
-    .chosen-single div {
-      border-left: none;
-      background: transparent;
-      b {
-        background-position: -18px 2px;
+      -moz-border-radius-bottomright: 0;
+      box-shadow: 0 1px 0 $white inset;
+
+      div {
+        background: transparent;
+        border-left: 0;
+
+        b {
+          background-position: -18px 2px;
+        }
       }
     }
   }
+
   .chosen-choices {
-    border: 1px solid #5897fb;
-    box-shadow: 0 0 5px rgba(#000,.3);
-    li.search-field input[type="text"] {
-      color: #222 !important;
+    border: 1px solid $cornflower-blue;
+    box-shadow: 0 0 5px rgba($black, .3);
+
+    li {
+      &.search-field {
+        input[type="text"] {
+          color: $dark-jungle-green !important;
+        }
+      }
     }
   }
 }
-/* @end */
+// @end
 
-/* @group Disabled Support */
+// @group Disabled Support
 .chosen-disabled {
-  opacity: 0.5 !important;
   cursor: default;
+  opacity: .5 !important;
+
   .chosen-single {
     cursor: default;
   }
+
   .chosen-choices .search-choice .search-choice-close {
     cursor: default;
   }
 }
-/* @end */
+// @end
 
-/* @group Right to Left */
+// @group Right to Left
 .chosen-rtl {
   text-align: right;
+
   .chosen-single {
     overflow: visible;
     padding: 0 8px 0 0;
+
+    span {
+      direction: rtl;
+      margin-left: 26px;
+      margin-right: 0;
+    }
+
+    div {
+      left: 3px;
+      right: auto;
+    }
+
+    abbr {
+      left: 26px;
+      right: auto;
+    }
   }
-  .chosen-single span {
-    margin-right: 0;
-    margin-left: 26px;
-    direction: rtl;
-  }
+
   .chosen-single-with-deselect span {
     margin-left: 38px;
   }
-  .chosen-single div {
-    right: auto;
-    left: 3px;
-  }
-  .chosen-single abbr {
-    right: auto;
-    left: 26px;
-  }
+
   .chosen-choices li {
     float: right;
-    &.search-field input[type="text"] {
-      direction: rtl;
+
+    &.search-field {
+      input[type="text"] {
+        direction: rtl;
+      }
     }
+
     &.search-choice {
       margin: 3px 5px 3px 0;
       padding: 3px 5px 3px 19px;
+
       .search-choice-close {
-        right: auto;
         left: 4px;
+        right: auto;
       }
     }
   }
+
   &.chosen-container-single-nosearch .chosen-search,
   .chosen-drop {
     left: 9999px;
   }
-  &.chosen-container-single .chosen-results {
-    margin: 0 0 4px 4px;
-    padding: 0 4px 0 0;
-  }
-  .chosen-results li.group-option {
-    padding-right: 15px;
-    padding-left: 0;
-  }
-  &.chosen-container-active.chosen-with-drop .chosen-single div {
-    border-right: none;
-  }
-  .chosen-search input[type="text"] {
-    padding: 4px 5px 4px 20px;
-    background: #fff $chosen-sprite no-repeat -30px -20px;
-    @include background($chosen-sprite no-repeat -30px -20px);
-    direction: rtl;
-  }
-  &.chosen-container-single{
-    .chosen-single div b {
-      background-position: 6px 2px;
+
+  &.chosen-container-single {
+    &.chosen-results {
+      margin: 0 0 4px 4px;
+      padding: 0 4px 0 0;
+
+      div b {
+        background-position: 6px 2px;
+      }
     }
-    &.chosen-with-drop{
+
+    &.chosen-with-drop {
       .chosen-single div b {
         background-position: -12px 2px;
       }
     }
   }
+
+  .chosen-results {
+    li {
+      &.group-option {
+        padding-left: 0;
+        padding-right: 15px;
+      }
+    }
+  }
+
+  &.chosen-container-active.chosen-with-drop .chosen-single div {
+    border-right: 0;
+  }
+
+  .chosen-search {
+    input[type="text"] {
+      @include background($chosen-sprite no-repeat -30px -20px);
+      background: $white $chosen-sprite no-repeat -30px -20px;
+      direction: rtl;
+      padding: 4px 5px 4px 20px;
+    }
+  }
 }
 
-/* @end */
+// @end
 
-/* @group Retina compatibility */
+// @group Retina compatibility
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi), only screen and (min-resolution: 1.5dppx) {
   .chosen-rtl .chosen-search input[type="text"],
   .chosen-container-single .chosen-single abbr,
@@ -424,8 +521,8 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   .chosen-container .chosen-results-scroll-down span,
   .chosen-container .chosen-results-scroll-up span {
     background-image: $chosen-sprite-retina !important;
-    background-size: 52px 37px !important;
     background-repeat: no-repeat !important;
+    background-size: 52px 37px !important;
   }
 }
-/* @end */
+// @end

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -3,11 +3,11 @@
 @import 'compass/css3/images';
 @import 'compass/css3/user-interface';
 
-//Background image
+// Background image
 $chosen-sprite: image-url('chosen-sprite.png') !default;
 $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
 
- //Colors
+// Colors
 $white: #fff;
 $black: #000;
 $dark-gray: #aaa;

--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -1,0 +1,242 @@
+# Default application configuration that all configurations inherit from.
+
+scss_files: "sass/chosen.scss"
+plugin_directories: ['.scss-linters']
+
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+plugin_gems: []
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+
+  ChainedClasses:
+    enabled: false
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+    style: silent
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  ExtendDirective:
+    enabled: false
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: short # or 'long'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: true
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space # or 'tab'
+    width: 2
+
+  LeadingZero:
+    enabled: true
+    style: exclude_zero # or 'include_zero'
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
+  NestingDepth:
+    enabled: true
+    max_depth: 5
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: true
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    disabled_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%']                                     # Other
+    properties: {}
+
+  PseudoElement:
+    enabled: true
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 4
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'at_least_one_space', or 'no_space'
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space # or 'new_line'
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: single_quotes # or double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: false
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false


### PR DESCRIPTION
I've noticed a lot of issues with code standards in this file.

Initial lint results: https://gist.github.com/taracila/fa241a5e724bf7929bc3
Fixed issues (almost): https://gist.github.com/taracila/60071ce06f490a789d3a

Standarts for SASS code: https://drive.google.com/file/d/0B1AwVhsNLZHYZUo1YVZTby0xUUk/view

Run linter:
run in terminal "scss-lint -c scss-lint.yml"
