### PR TITLE
use inherit for width when offsetWidth is 0

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -253,7 +253,9 @@ class AbstractChosen
     setTimeout (=> this.results_search()), 50
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    return @options.width if @options.width?
+    return "#{@form_field.offsetWidth}px" if @form_field.offsetWidth > 0
+    return "inherit"
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
This to accommodate for times the Chosen select is initially hidden, as is the case in bootstrap modals and panels

To verify this, checkout this branch; `inherit-width`, build using `grunt`, open `public/index.html` and run the following in the developer console

``` js
$('.chosen-select').first().chosen('destroy')
  .parent().hide()
  .find('select').chosen()
  .parent().show()
```

Thanks to @pierre-alain-b for this solution!

fixes #92
fixes #1272 
fixes #1329 
fixes #2309 

cc: @pfiller @tjschuck @stof 
