### PR TITLE
set_selection method for allowing programmatic selection.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -332,6 +332,29 @@ class Chosen extends AbstractChosen
     @current_selectedIndex = @form_field.selectedIndex
     @selected_item.find("abbr").remove()
 
+  set_selection: (value) ->
+    contains = (arr, wanted) ->
+      (item for item in arr when item == wanted).length > 0
+
+    if @is_multiple
+      values = value
+      items = (data for data in @results_data when contains(values, data.value))
+      @search_choices.find("li.search-choice").remove()
+      for option in @form_field.options
+        option.selected = false
+      @choice_build item for item in items
+      for item in items
+        @form_field.options[item.options_index].selected = true
+    else
+      item = @results_data.filter((data) ->
+        data.value == value
+      )[0]
+      if (!item)
+        throw new Error('Invalid value: ' + value)
+      @single_set_selected_text(item.text)
+      @form_field.options[item.options_index].selected = true
+    return
+
   result_select: (evt) ->
     if @result_highlight
       high = @result_highlight

--- a/spec/jquery/set_selection.spec.coffee
+++ b/spec/jquery/set_selection.spec.coffee
@@ -1,0 +1,63 @@
+describe "set_selection", ->
+  it "allows setting single selection programmatically", ->
+    tmpl = "
+        <select data-placeholder='Choose a Country...'>
+          <option value=''></option>
+          <option value='United States'>United States</option>
+          <option value='United Kingdom'>United Kingdom</option>
+          <option value='Afghanistan'>Afghanistan</option>
+        </select>
+      "
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    select.chosen()
+
+    expect(select.val()).toEqual('')
+    chosen = select.data('chosen')
+    chosen.set_selection('United Kingdom')
+    expect(select.val()).toEqual('United Kingdom')
+
+    displayValue = select.next('.chosen-container').find('.chosen-single').text()
+    expect(displayValue).toEqual('United Kingdom')
+
+  it "throws Invalid Value if trying to select non-existent item", ->
+    tmpl = "
+        <select data-placeholder='Choose a Country...'>
+          <option value=''></option>
+          <option value='United States'>United States</option>
+          <option value='United Kingdom'>United Kingdom</option>
+          <option value='Afghanistan'>Afghanistan</option>
+        </select>
+      "
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    select.chosen()
+
+    expect(select.val()).toEqual('')
+    chosen = select.data('chosen')
+    expect(->
+      chosen.set_selection('Blarg')).toThrow('Invalid value: Blarg')
+    
+  it "allows setting multiple selections programmatically", ->
+    tmpl = "
+        <select multiple data-placeholder='Choose a Country...'>
+          <option value=''></option>
+          <option value='United States'>United States</option>
+          <option value='United Kingdom'>United Kingdom</option>
+          <option value='Afghanistan'>Afghanistan</option>
+        </select>
+      "
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    select.chosen()
+
+    chosen = select.data('chosen')
+    chosen.set_selection(['United States', 'United Kingdom'])
+    expect(select.val()).toEqual(['United States', 'United Kingdom'])
+
+    displayValues = select
+      .next('.chosen-container')
+      .find('.chosen-choices li.search-choice').map(->
+        $(this).text()).toArray()
+    expect(displayValues).toEqual(['United States', 'United Kingdom'])
+


### PR DESCRIPTION
This change allows the programmatic selection of the currently selected value for both single and multiple selection. Detailed tests are included. Example:

``` html
<select data-placeholder='Choose a Country...'>
  <option value=''></option>
  <option value='United States'>United States</option>
  <option value='United Kingdom'>United Kingdom</option>
  <option value='Afghanistan'>Afghanistan</option>
</select>
```
``` js
$('select').chosen();
var chosen = $('select').data('chosen');
chosen.set_selection('United States');
$('select').val() // => 'United States'
```