### PR TITLE
Fixes bug. Prevent touch events propagation.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -73,8 +73,8 @@ class Chosen extends AbstractChosen
     @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); evt.preventDefault()
     @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); evt.preventDefault()
 
-    @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
-    @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
+    @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); evt.preventDefault()
+    @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); evt.preventDefault()
     @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
     @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
 
@@ -83,9 +83,9 @@ class Chosen extends AbstractChosen
     @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
     @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
 
-    @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
+    @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); ; evt.preventDefault()
     @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
-    @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
+    @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); ; evt.preventDefault()
 
     @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
     @form_field_jq.bind "chosen:activate.chosen", (evt) => this.activate_field(evt); return


### PR DESCRIPTION
I added `evt.preventDefault()` statement to touch events to prevent
triggering events on underlying elements after touch event is
captured in chosen container.