### PR TITLE
Fix broken Bower-Chosen process

### DIFF
--- a/bower-publish.sh
+++ b/bower-publish.sh
@@ -9,7 +9,7 @@ if [ $CURRENT_BRANCH != 'master' ] ; then
   exit 0
 fi
 
-CHOSEN_VERSION=`git tag --sort=v:refname | tail -1`
+CHOSEN_VERSION=`git tag -l | tail -1`
 
 git config --global user.email "notmyemail@bower-chosen.lol"
 git config --global user.name "bower-chosen"
@@ -19,7 +19,7 @@ rm -rf bower-chosen/*
 cp public/bower.json public/*.png public/chosen.jquery.js public/chosen.css bower-chosen/
 cd bower-chosen
 
-LATEST_VERSION=`git tag --sort=v:refname | tail -1`
+LATEST_VERSION=`git tag -l | tail -1`
 
 if [ "$LATEST_VERSION" = "$CHOSEN_VERSION" ] ; then
   echo "No Chosen version change. Skipped tagging"


### PR DESCRIPTION
@harvesthq/chosen-developers 

In #2449, the line that grabs our latest tag was changed to `git tag --sort=v:refname | tail -1`. Unfortunately, that line errors out on Travis.

![See?](http://take.ms/jnybs)

Fortunately, we don't really need it. `git tag -l` lists all tags in alphabetical order. As long as we're
consistent (that's the key) with our tagging, the last alphabetical version will also be the most recent version. That should be true going forward.

```
chosen patrickfiller$ git tag -l
0.12.1
0.13.0
0.14.0
0.9
1.0.0
1.4.0
1.4.2
semver
v0.10.0
v0.10.1
v0.11.1
v0.12.0
v0.9
v0.9.1
v0.9.10
v0.9.11
v0.9.12
v0.9.13
v0.9.14
v0.9.15
v0.9.2
v0.9.3
v0.9.4
v0.9.5
v0.9.6
v0.9.7
v0.9.8
v0.9.9
v1.1.0
v1.2.0
v1.3.0
v1.4.0
v1.4.1
v1.5.0
```

Simple change. What say you?