### PR TITLE
install latest git to support version sorting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
+sudo: false
+
 language: node_js
 
 node_js:
   - "0.10"
 
+addons:
+  apt:
+    sources:
+      - git-core
+    packages:
+      - git
+
 before_install:
   - npm install -g grunt-cli
   - gem install bundler
   - bundle install
+
 before_script: grunt build
 
 after_success: ./bower-publish.sh


### PR DESCRIPTION
Followup on #2527 

This enables docker based builds, and updates Git to the latest stable version, to support sorting based on version instead of alphabetically.