### PR TITLE
Fixed typo on options page.

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -231,7 +231,7 @@
       </table>
 
       <p>
-        <strong>Note:</strong> all custom Chosen events (those that being with <code class="language-javascript">chosen:</code>) also include the <code class="language-javascript">chosen</code> object as a parameter.
+        <strong>Note:</strong> all custom Chosen events (those that begin with <code class="language-javascript">chosen:</code>) also include the <code class="language-javascript">chosen</code> object as a parameter.
       </p>
 
       <h2><a name="triggerable-events" class="anchor" href="#triggerable-events">Triggerable Events</a></h2>


### PR DESCRIPTION
Just fixed a minor typo in the "options" documentation.