### PR TITLE
Add contributing templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!---
+Please read our [Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md) before opening this bug report or feature request.
+
+Following these guidelines will help us get back to you more quickly, and will show that you care about making Chosen better just like we do!
+-->
+
+## Bug Report Template
+
+Describe your issue here.
+
+### My environment
+A summary of the issue and the browser/OS environment in which it occurs.
+
+### Steps to reproduce
+Tell us how to reproduce this issue.
+
+1. This is the first step
+2. This is the second step
+3. Further steps, etc.
+
+Please provide a working demo, you can use [this template](https://jsfiddle.net/hyktf3he) as a base.
+
+### Expected behaviour
+Tell us what should happen.
+
+### Actual behaviour
+Tell us what happens instead.
+
+### Additional information
+Any other information you want to share that is relevant to the issue being reported. This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
+
+See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#bug-reports) for more detail on what is expected of a feature request.
+
+---
+
+## Feature Request Template
+
+A description of the problem you're trying to solve, including *why* you think this is a problem, please add as much detail as possible.
+
+### Proposed Solution
+An overview of the suggested solution and why you believe this solution is appropriate.
+
+### Additional information
+Any other information you want to share that is relevant to the feature request. This might include proposed changes to the code, a breakdown of the problem or a mockup of how the new feature should look.
+
+See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#feature-requests) for more detail on what is expected of a feature request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,46 +1,47 @@
 <!---
-Please read our [Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md) before opening this bug report or feature request.
+Please read our Contributing Guidelines before opening this issue: https://github.com/harvesthq/chosen/blob/master/contributing.md
 
-Following these guidelines will help us get back to you more quickly, and will show that you care about making Chosen better just like we do!
+Specifically, please note that the issue tracker is intended for bug reports and specific feature requests.
+
+If you have a general support or usage question, please post somewhere like StackOverflow using the `jquery-chosen` tag: http://stackoverflow.com/questions/tagged/jquery-chosen — you'll be much more likely to get a quick answer there.
 -->
 
-## Bug Report Template
-
-Describe your issue here.
-
-### My environment
-A summary of the issue and the browser/OS environment in which it occurs.
+Summarize your issue here.
 
 ### Steps to reproduce
+
 Tell us how to reproduce this issue.
 
-1. This is the first step
-2. This is the second step
-3. Further steps, etc.
+  1. This is the first step
 
-Please provide a working demo, you can use [this template](https://jsfiddle.net/hyktf3he) as a base.
+  2. This is the second step
 
-### Expected behaviour
+  3. Further steps, etc.
+
+Additionally, please link to a working demo that shows the issue so we can attempt to reproduce.  You can use [this template](https://jsfiddle.net/5v3v353z/) as a base.  Alternatively, confirm that the [Chosen demo page](http://harvesthq.github.io/chosen/) shows the issue.
+
+
+### Expected behavior
+
 Tell us what should happen.
 
-### Actual behaviour
+
+### Actual behavior
+
 Tell us what happens instead.
 
-### Additional information
-Any other information you want to share that is relevant to the issue being reported. This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
 
-See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#bug-reports) for more detail on what is expected of a feature request.
+### Environment
 
----
+  - **Chosen Version**:
 
-## Feature Request Template
+  - **jQuery or Prototype Version**:
 
-A description of the problem you're trying to solve, including *why* you think this is a problem, please add as much detail as possible.
+  - **Browser and Version**:
 
-### Proposed Solution
-An overview of the suggested solution and why you believe this solution is appropriate.
+  - **OS and Version**:
+
 
 ### Additional information
-Any other information you want to share that is relevant to the feature request. This might include proposed changes to the code, a breakdown of the problem or a mockup of how the new feature should look.
 
-See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#feature-requests) for more detail on what is expected of a feature request.
+Any other information you want to share that is relevant to the issue being reported. This might include the lines of code that you have identified as causing the bug, or potential solutions and workarounds.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,23 @@
 <!---
-Good pull requests &mdash; patches, improvements, new features &mdash; are a fantastic help.
-They should remain focused in scope and avoid containing unrelated commits.
+Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.
 
-Please follow our [code conventions](https://github.com/harvesthq/chosen/blob/master/contributing.md#code-conventions) before submitting your work. Adhering to these guidelines is the best way to get your work included in Chosen.
+Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
 -->
 
-## Pull Request Template
+### Summary
 
-Please provide: a clear title and description of the changes you've made, details of any issues these changes fix, why you believe this PR is suitable to be merged into chosen, and double check that:
+Provide a general description of the code changes in your pull request.
 
-- [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
-- [ ] You have used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files.
-- [ ] You've updated both the jQuery *and* Prototype versions
-- [ ] You haven't manually updated the version number in `package.json`.
-- [ ] If adding to, or adjusting, configuration; you've added, or updated, the [appropriate documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).
+Please double-check that:
 
-See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more detail on what is expected of a pull request.
+  - [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
+  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
+  - [ ] You've updated both the jQuery *and* Prototype versions.
+  - [ ] You haven't manually updated the version number in `package.json`.
+  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).
+
+See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.
+
+### References
+
+If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!---
+Good pull requests &mdash; patches, improvements, new features &mdash; are a fantastic help.
+They should remain focused in scope and avoid containing unrelated commits.
+
+Please follow our [code conventions](https://github.com/harvesthq/chosen/blob/master/contributing.md#code-conventions) before submitting your work. Adhering to these guidelines is the best way to get your work included in Chosen.
+-->
+
+## Pull Request Template
+
+Please provide: a clear title and description of the changes you've made, details of any issues these changes fix, why you believe this PR is suitable to be merged into chosen, and double check that:
+
+- [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
+- [ ] You have used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files.
+- [ ] You've updated both the jQuery *and* Prototype versions
+- [ ] You haven't manually updated the version number in `package.json`.
+- [ ] If adding to, or adjusting, configuration; you've added, or updated, the [appropriate documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).
+
+See [here](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more detail on what is expected of a pull request.


### PR DESCRIPTION
Last week GitHub [announced](
https://github.com/blog/2111-issue-and-pull-request-templates) support for templates for Issues and Pull Requests to projects to try and help contributors add the right details at the start of a thread.

Given the large number of issues/PRs Chosen gets, adding some templates may help make things a little more manageable. 

I've put together a proposed ISSUE_TEMPLATE and PULL_REQUEST_TEMPLATE, which were mostly based on the existing [contributing.md](https://github.com/harvesthq/chosen/blob/master/contributing.md).

Do you think these will be of value? Do you have any proposed changes to my drafts?