### PR TITLE
Fix scrolling issues

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -217,7 +217,7 @@ class Chosen extends AbstractChosen
       visible_top = @search_results.scrollTop()
       visible_bottom = maxHeight + visible_top
 
-      high_top = @result_highlight.position().top + @search_results.scrollTop()
+      high_top = @result_highlight.position().top
       high_bottom = high_top + @result_highlight.outerHeight()
 
       if high_bottom >= visible_bottom


### PR DESCRIPTION
Fix scrolling issues: high_top when scrolling long select (with option groups) could grow very fast (~ twice as fast as @result_highlight.position().top)