### PR TITLE
Added an offset to the calculated width to take account of the deselect button when enabled

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -255,7 +255,7 @@ class AbstractChosen
     setTimeout (=> this.results_search()), 50
 
   container_width: ->
-    return if @options.width? then @options.width else "#{@form_field.offsetWidth}px"
+    return if @options.width? then @options.width else if @options.allow_single_deselect then "#{@form_field.offsetWidth+31}px" else "#{@form_field.offsetWidth}px"
 
   include_option_in_results: (option) ->
     return false if @is_multiple and (not @display_selected_options and option.selected)


### PR DESCRIPTION
I've noticed that when you enable the deselect button the width of the button is not taken into account when calculating the width of the select box. Therefore a lot of the items are trimmed. 

In this pull request i've added an extra 31 pixels to the size of the dropdown. This is the offset in the standard CSS. We could make this dynamic, but I thought this would be a good start.