### PR TITLE
Fix scroll issue

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -217,7 +217,7 @@ class Chosen extends AbstractChosen
       visible_top = @search_results.scrollTop()
       visible_bottom = maxHeight + visible_top
 
-      high_top = @result_highlight.position().top + @search_results.scrollTop()
+      high_top = @result_highlight.position().top
       high_bottom = high_top + @result_highlight.outerHeight()
 
       if high_bottom >= visible_bottom


### PR DESCRIPTION
### Summary
I removed scrollTop added to the result element top. It was making the result list scrolling crazy and going to the bottom.

Replicate bug here:
https://jsfiddle.net/7L9w067o/1/

I checked and it exists in Chrome & Firefox (both windows & mac)
With removed scrollTop everything is fine.

PS. This exists since 1.0 so I dunno why anybody spot that :P