### PR TITLE
Issue #2075: Fix client-side validation

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -46,7 +46,7 @@ class Chosen extends AbstractChosen
     else
       @container.html '<a class="chosen-single chosen-default"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
 
-    @form_field_jq.hide().after @container
+    @form_field_jq.css('position', 'absolute').css('opacity', 0).after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -27,7 +27,10 @@ class @Chosen extends AbstractChosen
 
     @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
 
-    @form_field.hide().insert({ after: @container })
+    @form_field.setStyle({
+      position: 'absolute',
+      opacity: '0'
+    }).insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
 
     @search_field = @container.down('input')


### PR DESCRIPTION
<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->
### Summary

Fixes issue #2075 by not setting `display: none` and instead leaves the element focusable for browsers that implement client-side validation.

Please double-check that:
- [x] All changes were made in CoffeeScript files, **not** JavaScript files.
- [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
- [x] You've updated both the jQuery _and_ Prototype versions.
- [x] You haven't manually updated the version number in `package.json`.
- [x] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).
