### PR TITLE
Accessibility updates #264 - Add aria attributes to better support screen readers and keyboard navigation

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -91,6 +91,7 @@ class Chosen extends AbstractChosen
     @search_results.on 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
 
     @form_field_jq.on "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
+    @form_field_jq.on "chosen:buildresultslist.chosen", (evt) => this.winnow_results(); return
     @form_field_jq.on "chosen:activate.chosen", (evt) => this.activate_field(evt); return
     @form_field_jq.on "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
     @form_field_jq.on "chosen:close.chosen", (evt) => this.close_field(evt); return

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -199,6 +199,7 @@ class Chosen extends AbstractChosen
 
     @search_field.val(@search_field.val())
     @search_field.attr("aria-expanded",true);
+    this.attr("aria-busy", false);
     @search_field.focus()
 
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -182,6 +182,7 @@ class Chosen extends AbstractChosen
 
     @active_field = false
     this.results_hide()
+    @search_field.attr("aria-expanded",false);
 
     @container.removeClass "chosen-container-active"
     this.clear_backstroke()
@@ -197,6 +198,7 @@ class Chosen extends AbstractChosen
     @active_field = true
 
     @search_field.val(@search_field.val())
+    @search_field.attr("aria-expanded",true);
     @search_field.focus()
 
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -124,7 +124,7 @@ class Chosen extends AbstractChosen
       @search_field.attr "aria-label", @form_field.attributes["aria-label"]
       if @form_field.attributes["aria-labelledby"]
         @search_field.attr "aria-labelledby", @form_field.attributes["aria-labelledby"]
-    else if @form_field.hasOwnProperty('labels') && @form_field.labels.length
+    else if Object.prototype.hasOwnProperty.call(@form_field,'labels') && @form_field.labels.length
       labelledbyList = ""
       for label, i in @form_field.labels
         if label.id is ""

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -124,7 +124,7 @@ class Chosen extends AbstractChosen
       @search_field.attr "aria-label", @form_field.attributes["aria-label"]
       if @form_field.attributes["aria-labelledby"]
         @search_field.attr "aria-labelledby", @form_field.attributes["aria-labelledby"]
-    else if @form_field.labels.length
+    else if @form_field.hasOwnProperty('labels') && @form_field.labels.length
       labelledbyList = ""
       for label, i in @form_field.labels
         if label.id is ""

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -198,7 +198,7 @@ class Chosen extends AbstractChosen
 
     @search_field.val(@search_field.val())
     @search_field.attr("aria-expanded",true);
-    this.attr("aria-busy", false);
+    this.search_results.attr("aria-busy", false);
     @search_field.focus()
 
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -91,7 +91,6 @@ class Chosen extends AbstractChosen
     @search_results.on 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
 
     @form_field_jq.on "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
-    @form_field_jq.on "chosen:buildresultslist.chosen", (evt) => this.winnow_results(); return
     @form_field_jq.on "chosen:activate.chosen", (evt) => this.activate_field(evt); return
     @form_field_jq.on "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
     @form_field_jq.on "chosen:close.chosen", (evt) => this.close_field(evt); return

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -52,6 +52,7 @@ class Chosen extends AbstractChosen
 
     @search_field = @container.find('input').first()
     @search_results = @container.find('ul.chosen-results').first()
+    @search_results.attr('id', "#{@form_field.id}-chosen-search-results")
     this.search_field_scale()
 
     @search_no_results = @container.find('li.no-results').first()
@@ -63,6 +64,7 @@ class Chosen extends AbstractChosen
       @search_container = @container.find('div.chosen-search').first()
       @selected_item = @container.find('.chosen-single').first()
 
+    this.set_aria_labels()
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
@@ -115,6 +117,20 @@ class Chosen extends AbstractChosen
     @container.remove()
     @form_field_jq.removeData('chosen')
     @form_field_jq.show()
+
+  set_aria_labels: ->
+    @search_field.attr "aria-owns", @search_results.attr "id"
+    if @form_field.attributes["aria-label"]
+      @search_field.attr "aria-label", @form_field.attributes["aria-label"]
+      if @form_field.attributes["aria-labelledby"]
+        @search_field.attr "aria-labelledby", @form_field.attributes["aria-labelledby"]
+    else if @form_field.labels.length
+      labelledbyList = ""
+      for label, i in @form_field.labels
+        if label.id is ""
+          label.id = "#{@form_field.id}-chosen-label-#{i}"
+        labelledbyList += @form_field.labels[i].id + " "
+      @search_field.attr "aria-labelledby", labelledbyList
 
   search_field_disabled: ->
     @is_disabled = @form_field.disabled || @form_field_jq.parents('fieldset').is(':disabled')
@@ -221,6 +237,8 @@ class Chosen extends AbstractChosen
 
       @result_highlight = el
       @result_highlight.addClass "highlighted"
+
+      @search_field.attr("aria-activedescendant", @result_highlight.attr("id"))
 
       maxHeight = parseInt @search_results.css("maxHeight"), 10
       visible_top = @search_results.scrollTop()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -203,7 +203,7 @@ class @Chosen extends AbstractChosen
 
     @search_field.value = this.get_search_field_value()
     @search_field.attr "aria-expanded", true
-    this.attr "aria-busy", false
+    this.search_results.attr "aria-busy", false
     @search_field.focus()
 
   test_active_click: (evt) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -79,7 +79,6 @@ class @Chosen extends AbstractChosen
     @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
 
     @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
-    @form_field.observe "chosen:buildresultslist", (evt) => this.winnow_results()
     @form_field.observe "chosen:activate", (evt) => this.activate_field(evt)
     @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
     @form_field.observe "chosen:close", (evt) => this.close_field(evt)

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -8,8 +8,8 @@ class @Chosen extends AbstractChosen
     super()
 
     # HTML Templates
-    @single_temp = new Template('<a class="chosen-single chosen-default"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" /></div><ul class="chosen-results"></ul></div>')
-    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
+    @single_temp = new Template('<a class="chosen-single chosen-default"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" /></div><ul class="chosen-results" role="listbox" aria-busy="true"></ul></div>')
+    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results" role="listbox" aria-busy="true"></ul></div>')
     @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_up_html: ->
@@ -204,6 +204,7 @@ class @Chosen extends AbstractChosen
 
     @search_field.value = this.get_search_field_value()
     @search_field.attr "aria-expanded", true
+    this.attr "aria-busy", false
     @search_field.focus()
 
   test_active_click: (evt) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -187,6 +187,7 @@ class @Chosen extends AbstractChosen
 
     @active_field = false
     this.results_hide()
+    @search_field.attr "aria-expanded", false
 
     @container.removeClassName "chosen-container-active"
     this.clear_backstroke()
@@ -202,6 +203,7 @@ class @Chosen extends AbstractChosen
     @active_field = true
 
     @search_field.value = this.get_search_field_value()
+    @search_field.attr "aria-expanded", true
     @search_field.focus()
 
   test_active_click: (evt) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -2,6 +2,15 @@ class @Chosen extends AbstractChosen
 
   setup: ->
     @current_selectedIndex = @form_field.selectedIndex
+    @is_rtl = @form_field.hasClassName "chosen-rtl"
+
+  set_default_values: ->
+    super()
+
+    # HTML Templates
+    @single_temp = new Template('<a class="chosen-single chosen-default"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" /></div><ul class="chosen-results"></ul></div>')
+    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
+    @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
 
   set_up_html: ->
     container_classes = ["chosen-container"]
@@ -30,6 +39,7 @@ class @Chosen extends AbstractChosen
 
     @search_field = @container.down('input')
     @search_results = @container.down('ul.chosen-results')
+    @search_results.writeAttribute('id', "#{@form_field.id}-chosen-search-results")
     this.search_field_scale()
 
     @search_no_results = @container.down('li.no-results')
@@ -41,6 +51,7 @@ class @Chosen extends AbstractChosen
       @search_container = @container.down('div.chosen-search')
       @selected_item = @container.down('.chosen-single')
 
+    this.set_aria_labels()
     this.results_build()
     this.set_tab_index()
     this.set_label_behavior()
@@ -107,6 +118,21 @@ class @Chosen extends AbstractChosen
 
     @container.remove()
     @form_field.show()
+
+  set_aria_labels: ->
+    @search_field.writeAttribute "aria-owns", @search_results.readAttribute "id"
+    if @form_field.attributes["aria-label"]
+      @search_field.writeAttribute "aria-label", @form_field.attributes["aria-label"]
+
+    if @form_field.attributes["aria-labelledby"]
+      @search_field.writeAttribute "aria-labelledby", @form_field.attributes["aria-labelledby"]
+    else if @form_field.labels.length
+      labelledbyList = ""
+      for label, i in @form_field.labels
+        if label.id is ""
+          label.id = "#{@form_field.id}-chosen-label-#{i}"
+        labelledbyList += @form_field.labels[i].id + " "
+      @search_field.writeAttribute "aria-labelledby", labelledbyList
 
   search_field_disabled: ->
     @is_disabled = @form_field.disabled || @form_field.up('fieldset')?.disabled || false
@@ -213,6 +239,8 @@ class @Chosen extends AbstractChosen
 
       @result_highlight = el
       @result_highlight.addClassName "highlighted"
+
+      @search_field.attr("aria-activedescendant", @result_highlight.attr("id"))
 
       maxHeight = parseInt @search_results.getStyle('maxHeight'), 10
       visible_top = @search_results.scrollTop

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -186,7 +186,7 @@ class @Chosen extends AbstractChosen
 
     @active_field = false
     this.results_hide()
-    @search_field.attr "aria-expanded", false
+    @search_field.writeAttribute("aria-expanded", "false")
 
     @container.removeClassName "chosen-container-active"
     this.clear_backstroke()
@@ -202,8 +202,8 @@ class @Chosen extends AbstractChosen
     @active_field = true
 
     @search_field.value = this.get_search_field_value()
-    @search_field.attr "aria-expanded", true
-    this.search_results.attr "aria-busy", false
+    @search_field.writeAttribute("aria-expanded", "true")
+    this.search_results.writeAttribute("aria-busy", "false")
     @search_field.focus()
 
   test_active_click: (evt) ->
@@ -243,7 +243,7 @@ class @Chosen extends AbstractChosen
       @result_highlight = el
       @result_highlight.addClassName "highlighted"
 
-      @search_field.attr("aria-activedescendant", @result_highlight.attr("id"))
+      @search_field.writeAttribute("aria-activedescendant", @result_highlight.attr("id"))
 
       maxHeight = parseInt @search_results.getStyle('maxHeight'), 10
       visible_top = @search_results.scrollTop

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -126,7 +126,7 @@ class @Chosen extends AbstractChosen
 
     if @form_field.attributes["aria-labelledby"]
       @search_field.writeAttribute "aria-labelledby", @form_field.attributes["aria-labelledby"]
-    else if @form_field.hasOwnProperty('labels') && @form_field.labels.length
+    else if Object.prototype.hasOwnProperty.call(@form_field,'labels') && @form_field.labels.length
       labelledbyList = ""
       for label, i in @form_field.labels
         if label.id is ""

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -79,6 +79,7 @@ class @Chosen extends AbstractChosen
     @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
 
     @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
+    @form_field.observe "chosen:buildresultslist", (evt) => this.winnow_results()
     @form_field.observe "chosen:activate", (evt) => this.activate_field(evt)
     @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
     @form_field.observe "chosen:close", (evt) => this.close_field(evt)

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -243,7 +243,7 @@ class @Chosen extends AbstractChosen
       @result_highlight = el
       @result_highlight.addClassName "highlighted"
 
-      @search_field.writeAttribute("aria-activedescendant", @result_highlight.attr("id"))
+      @search_field.writeAttribute("aria-activedescendant", @result_highlight.readAttribute("id"))
 
       maxHeight = parseInt @search_results.getStyle('maxHeight'), 10
       visible_top = @search_results.scrollTop

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -126,7 +126,7 @@ class @Chosen extends AbstractChosen
 
     if @form_field.attributes["aria-labelledby"]
       @search_field.writeAttribute "aria-labelledby", @form_field.attributes["aria-labelledby"]
-    else if @form_field.labels.length
+    else if @form_field.hasOwnProperty('labels') && @form_field.labels.length
       labelledbyList = ""
       for label, i in @form_field.labels
         if label.id is ""

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -117,6 +117,8 @@ class AbstractChosen
     option_el.style.cssText = option.style if option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
     option_el.innerHTML = option.highlighted_html or option.html
+    option_el.setAttribute("role", "option")
+    option_el.id = "#{@form_field.id}-chosen-search-result-#{option.array_index}"
     option_el.title = option.title if option.title
 
     this.outerHTML(option_el)
@@ -337,7 +339,7 @@ class AbstractChosen
       </a>
       <div class="chosen-drop">
         <div class="chosen-search">
-          <input class="chosen-search-input" type="text" autocomplete="off" />
+          <input class="chosen-search-input" type="text" autocomplete="off" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" autocomplete="off" role="listbox" />
         </div>
         <ul class="chosen-results"></ul>
       </div>
@@ -347,11 +349,11 @@ class AbstractChosen
     """
       <ul class="chosen-choices">
         <li class="search-field">
-          <input class="chosen-search-input" type="text" autocomplete="off" value="#{@default_text}" />
+          <input class="chosen-search-input" type="text" autocomplete="off" value="#{@default_text}" aria-expanded="false" aria-haspopup="true" role="combobox" aria-autocomplete="list" />
         </li>
       </ul>
       <div class="chosen-drop">
-        <ul class="chosen-results"></ul>
+        <ul class="chosen-results" role="listbox"></ul>
       </div>
     """
 


### PR DESCRIPTION
<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->
### Summary

This adds a good chunk of ARIA attributes and other related attributes to the chosen elements to move towards making Chosen more accessible. 

**ARIA Labels and Other Helpful Attributes**
- Adds the following aria elements to the search input box
  - [role="combobox"](https://www.w3.org/TR/wai-aria/roles#combobox)
  - [aria-haspopup](https://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup) (implicit when using the combobox role)
  - [aria-expanded](https://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded)
  - [aria-activedescendant="id_of_highlighted_option"](https://www.w3.org/TR/wai-aria/states_and_properties#aria-activedescendant)
  - [aria-owns="id_of_list_of_options"](https://www.w3.org/TR/wai-aria/states_and_properties#aria-owns)
  - [aria-autocomplete="list"](https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete)
  - [aria-labeledby="id_of_field_label"](https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby)
- Adds the following attributes to the list of options
  - id
  - [role="listbox"](https://www.w3.org/TR/wai-aria/roles#listbox)
- Adds the following attributes to each individual option in the list of options
  - id
  - [role="option"](https://www.w3.org/TR/wai-aria/roles#option)
  - [aria-busy](https://www.w3.org/TR/wai-aria/states_and_properties#aria-busy)

**Managing State**
- Managing the aria-expanded attribute
  - In order to indicate when the search results should be relevant to assitive technology, we need to toggle the aria-expanded attribute as fields are activated/deactivated.
  - The easiest way to do this (AFAIK) is to adjust the attribute during the `close_field` and `activate_field` methods.
  - A simple switch from true to false or false to true in each of these methods is sufficient enough to keep the state updated

A complete description of the changes made, with the reasoning behind each attribute is available here: 
- https://github.com/harvesthq/chosen/issues/264#issuecomment-215124540
### References
- [Accessibility issues with chosen #264](https://github.com/harvesthq/chosen/issues/264) 
