### PR TITLE
Adding case keycode 36 for enabling POS1 selection for win users

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -478,6 +478,10 @@ class Chosen extends AbstractChosen
       when 32
         evt.preventDefault() if @disable_search
         break
+      when 36
+        this.result_deselect(this.current_selectedIndex)
+        this.search_results.scrollTop(0)
+        break
       when 38
         evt.preventDefault()
         this.keyup_arrow()


### PR DESCRIPTION
It's just a little feature for windows users who are normally using html dropdown boxes with the pos1 key on their win keyboard to jump directly to the first item. For chosen I simulated it by deselecting the current item and scrolling to the top of the dropdown box.