### PR TITLE
process_results callback - PoC/WIP

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -34,6 +34,7 @@ class AbstractChosen
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
     @case_sensitive_search = @options.case_sensitive_search || false
+    @process_results = @options.process_results || false
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -150,6 +151,9 @@ class AbstractChosen
       this.results_show()
 
   winnow_results: ->
+    if @process_results
+      return this.process_results(this);
+
     this.no_results_clear()
 
     results = 0


### PR DESCRIPTION
### Summary

An alternative to #2618 that simply allows for a custom process results callback to be set.

If something like this is really going to be considered, I'll improve/work on the documentation.

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [x] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

### References

- #2618
- #536 