### PR TITLE
Added styles to chosen.scss to fix #1410 Using a chosen-element alway…

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -18,7 +18,10 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
   .chosen-drop {
     position: absolute;
     top: 100%;
-    left: -9999px;
+    left:0;
+ +  opacity:0;
+ +  height:0;
+ +  overflow: hidden;
     z-index: 1010;
     width: 100%;
     border: 1px solid #aaa;
@@ -27,7 +30,8 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png') !default;
     box-shadow: 0 4px 5px rgba(#000,.15);
   }
   &.chosen-with-drop .chosen-drop {
-    left: 0;
+    opacity:1;
+ +  height:auto;
   }
   a{
     cursor: pointer;


### PR DESCRIPTION
on clicking the chosen element always fires a horizontal shift. To fix this used the following css. It fixes the issue in IE 11 and firefox. Please refer issue #1410 

opacity is not supported by all browsers, there will by a 1px shadow-line beneath the chosen-select. We tried it with Firefox 47 and IE11, both work fine.

We disable the left:-9999 so the focus() event is to going to scroll anywhere. display: none; would disable tabbing-support, so we do not hide the element, but make it invisible by height:0 and so that the 1px shadow disappears we use opacity: 0 but this is not supported by all browsers so they have to deal with 1px shadow…

For me, this solved the issue, but i did not test it with mobile devices.