### PR TITLE
Add option value to chosen's option element

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -293,7 +293,7 @@ class Chosen extends AbstractChosen
     this.result_clear_highlight() if $(evt.target).hasClass "active-result" or $(evt.target).parents('.active-result').first()
 
   choice_build: (item) ->
-    choice = $('<li />', { class: "search-choice" }).html("<span>#{this.choice_label(item)}</span>")
+    choice = $('<li />', { class: "search-choice", "data-value": item.value}).html("<span>#{this.choice_label(item)}</span>")
 
     if item.disabled
       choice.addClass 'search-choice-disabled'
@@ -358,7 +358,7 @@ class Chosen extends AbstractChosen
       if @is_multiple
         this.choice_build item
       else
-        this.single_set_selected_text(this.choice_label(item))
+        this.single_set_selected_text(this.choice_label(item), item)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
       this.show_search_field_default()
@@ -370,12 +370,14 @@ class Chosen extends AbstractChosen
 
       this.search_field_scale()
 
-  single_set_selected_text: (text=@default_text) ->
+  single_set_selected_text: (text=@default_text, item) ->
     if text is @default_text
       @selected_item.addClass("chosen-default")
+      @selected_item.removeAttr("data-value")
     else
       this.single_deselect_control_build()
       @selected_item.removeClass("chosen-default")
+      @selected_item.attr("data-value", item.value)
 
     @selected_item.find("span").html(text)
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -284,7 +284,7 @@ class @Chosen extends AbstractChosen
     this.result_clear_highlight() if evt.target.hasClassName('active-result') or evt.target.up('.active-result')
 
   choice_build: (item) ->
-    choice = new Element('li', { class: "search-choice" }).update("<span>#{this.choice_label(item)}</span>")
+    choice = new Element('li', { class: "search-choice", "data-value": item.value }).update("<span>#{this.choice_label(item)}</span>")
 
     if item.disabled
       choice.addClassName 'search-choice-disabled'
@@ -349,7 +349,7 @@ class @Chosen extends AbstractChosen
       if @is_multiple
         this.choice_build item
       else
-        this.single_set_selected_text(this.choice_label(item))
+        this.single_set_selected_text(this.choice_label(item), item)
 
       this.results_hide() unless (evt.metaKey or evt.ctrlKey) and @is_multiple
       this.show_search_field_default()
@@ -361,12 +361,14 @@ class @Chosen extends AbstractChosen
 
       this.search_field_scale()
 
-  single_set_selected_text: (text=@default_text) ->
+  single_set_selected_text: (text=@default_text, item) ->
     if text is @default_text
       @selected_item.addClassName("chosen-default")
+      @selected_item.writeAttribute("data-value", false)
     else
       this.single_deselect_control_build()
       @selected_item.removeClassName("chosen-default")
+      @selected_item.writeAttribute("data-value", item.value)
 
     @selected_item.down("span").update(text)
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -84,7 +84,7 @@ class AbstractChosen
         if data.selected and @is_multiple
           this.choice_build data
         else if data.selected and not @is_multiple
-          this.single_set_selected_text(this.choice_label(data))
+          this.single_set_selected_text(this.choice_label(data), data)
 
       if shown_results >= @max_shown_results
         break

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -106,6 +106,7 @@ class AbstractChosen
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
+    option_el.setAttribute("data-value", option.value)
     option_el.innerHTML = option.search_text
     option_el.title = option.title if option.title
 


### PR DESCRIPTION
This adds each of the option values to their chosen option element, as a "data-value" attribute. It also does the same for the selected option (or options) element.
It can help target specific chosen option elements and to apply css/js on them.
For example, to highlight a special option in the results, we could do something like:
```css
li[data-value=special] {
  color:red;
}
```
(without having to relay on the array index, which is subject to changes..)