### PR TITLE
Input events

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -324,7 +324,7 @@ class Chosen extends AbstractChosen
     this.single_set_selected_text()
     this.show_search_field_default()
     this.results_reset_cleanup()
-    @form_field_jq.trigger "change"
+    this.trigger_form_field_change()
     this.results_hide() if @active_field
 
   results_reset_cleanup: ->
@@ -362,7 +362,7 @@ class Chosen extends AbstractChosen
       this.results_hide() unless @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
       this.show_search_field_default()
 
-      @form_field_jq.trigger "change", {'selected': @form_field.options[item.options_index].value} if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
+      this.trigger_form_field_change selected: @form_field.options[item.options_index].value  if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex
 
       evt.preventDefault()
@@ -390,7 +390,7 @@ class Chosen extends AbstractChosen
       this.result_clear_highlight()
       this.winnow_results() if @results_showing
 
-      @form_field_jq.trigger "change", {deselected: @form_field.options[result_data.options_index].value}
+      this.trigger_form_field_change deselected: @form_field.options[result_data.options_index].value
       this.search_field_scale()
 
       return true
@@ -510,3 +510,7 @@ class Chosen extends AbstractChosen
         w = f_width - 10
 
       @search_field.css({'width': w + 'px'})
+
+  trigger_form_field_change: (extra) ->
+    @form_field_jq.trigger "input", extra
+    @form_field_jq.trigger "change", extra

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -315,7 +315,7 @@ class @Chosen extends AbstractChosen
     this.single_set_selected_text()
     this.show_search_field_default()
     this.results_reset_cleanup()
-    @form_field.simulate("change") if typeof Event.simulate is 'function'
+    this.trigger_form_field_change()
     this.results_hide() if @active_field
 
   results_reset_cleanup: ->
@@ -353,7 +353,7 @@ class @Chosen extends AbstractChosen
       this.results_hide() unless @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
       this.show_search_field_default()
 
-      @form_field.simulate("change") if typeof Event.simulate is 'function' && (@is_multiple || @form_field.selectedIndex != @current_selectedIndex)
+      this.trigger_form_field_change() if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex
 
       evt.preventDefault()
@@ -381,7 +381,7 @@ class @Chosen extends AbstractChosen
       this.result_clear_highlight()
       this.winnow_results() if @results_showing
 
-      @form_field.simulate("change") if typeof Event.simulate is 'function'
+      this.trigger_form_field_change()
       this.search_field_scale()
       return true
     else
@@ -504,3 +504,6 @@ class @Chosen extends AbstractChosen
         w = f_width - 10
 
       @search_field.setStyle({'width': w + 'px'})
+
+  trigger_form_field_change:  ->
+    @form_field.simulate("change") if typeof Event.simulate is 'function'

--- a/spec/jquery/events.spec.coffee
+++ b/spec/jquery/events.spec.coffee
@@ -1,0 +1,30 @@
+describe "Events", ->
+  it "chosen should fire the right events", ->
+    tmpl = "
+      <select data-placeholder='Choose a Country...'>
+        <option value=''></option>
+        <option value='United States'>United States</option>
+        <option value='United Kingdom'>United Kingdom</option>
+        <option value='Afghanistan'>Afghanistan</option>
+      </select>
+    "
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    expect(select.size()).toBe(1)
+    select.chosen()
+    # very simple check that the necessary elements have been created
+    ["container", "container-single", "single", "default"].forEach (clazz)->
+      el = div.find(".chosen-#{clazz}")
+      expect(el.size()).toBe(1)
+
+    # test a few interactions
+    event_sequence = []
+    div.on 'input change', (evt) -> event_sequence.push evt.type
+
+    container = div.find(".chosen-container")
+    container.trigger("mousedown") # open the drop
+    expect(container.hasClass("chosen-container-active")).toBe true
+    #select an item
+    container.find(".active-result").last().trigger("mouseup")
+
+    expect(event_sequence).toEqual ['input', 'change']


### PR DESCRIPTION
While not widely known, the `input` event is triggered before all `change` events for inputs and selects (see [the spec here](https://www.w3.org/TR/html5/forms.html#send-select-update-notifications))

This PR fixes this. Also adds a blurb on how to run tests...

I haven't changed the prototype version because it uses an old library that does not support the `input` event. Last commit was 4 years ago, looks like abandonware.

FWIW, `Parsley` relies on the `input` event, so the current code is [causing bad interactions](https://github.com/guillaumepotier/Parsley.js/issues/1134).

Thanks