### PR TITLE
Contributing: add grunt command for tests [ci-skip]

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -175,7 +175,7 @@ license your work under the [MIT License](http://en.wikipedia.org/wiki/MIT_Licen
 4. Don't manually update the version number in `package.json`. This is done using a Grunt task on deployment.
 
 <a name="grunt"></a>
-#### Grunt tasks: Running Tests and using CoffeeScript
+#### Grunt tasks: Running Tests and building Chosen
 
 
 To install all development dependencies, in the project's root directory, run

--- a/contributing.md
+++ b/contributing.md
@@ -186,7 +186,7 @@ Once you're configured, `grunt` tasks are available:
 
     grunt test                 # run the tests in spec/
 
-    grunt build                # build Chosen from CoffeeScript source
+    grunt build                # build Chosen from source
 
     grunt watch                # watch coffee/ for changes and build Chosen
 

--- a/contributing.md
+++ b/contributing.md
@@ -175,16 +175,19 @@ license your work under the [MIT License](http://en.wikipedia.org/wiki/MIT_Licen
 4. Don't manually update the version number in `package.json`. This is done using a Grunt task on deployment.
 
 <a name="grunt"></a>
-#### Using CoffeeScript and Grunt
+#### Grunt tasks: Running Tests and using CoffeeScript
 
 
 To install all development dependencies, in the project's root directory, run
 
     npm install
 
-Once you're configured, building the JavaScript from the command line is easy:
+Once you're configured, `grunt` tasks are available:
 
-    grunt build                # build Chosen from source
+    grunt test                 # run the tests in spec/
+
+    grunt build                # build Chosen from CoffeeScript source
+
     grunt watch                # watch coffee/ for changes and build Chosen
 
 If you're interested, you can find the task in [Gruntfile.coffee](https://github.com/harvesthq/chosen/blob/master/Gruntfile.coffee).


### PR DESCRIPTION
A small edit to the 'grunt' section of the `Contributing` to list the important `grunt test` command.

As an experienced dev, the **only thing** I really need to know when wanting to write a PR is how to run the tests, and that was missing.