### PR TITLE
Allow activated instance to be programatically opened

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -130,7 +130,7 @@ class Chosen extends AbstractChosen
         evt.preventDefault()
 
       if not (evt? and ($ evt.target).hasClass "search-choice-close")
-        if not @active_field
+        if not @results_showing
           @search_field.val "" if @is_multiple
           $(@container[0].ownerDocument).bind 'click.chosen', @click_test_action
           this.results_show()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -125,7 +125,7 @@ class @Chosen extends AbstractChosen
         evt.stop()
 
       if not (evt? and evt.target.hasClassName "search-choice-close")
-        if not @active_field
+        if not @results_showing
           @search_field.clear() if @is_multiple
           @container.ownerDocument.observe "click", @click_test_action
           this.results_show()


### PR DESCRIPTION
### Summary

Fix for bug #2689 

Currently the `chosen:open` trigger piggybacks off the `container_mousedown` function. There was a check in here to prevent trying to open an instance two times if there were two clicks (by checking if the instance is already active), however this created this issue.

This check was changed to check if the instance was _showing_ instead, which seems to work.
