### PR TITLE
Make results_search run after keyup of Cmd key

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -254,7 +254,7 @@ class AbstractChosen
       when 27
         this.results_hide() if @results_showing
         return true
-      when 9, 38, 40, 16, 91, 17, 18
+      when 9, 38, 40, 16, 17, 18
         # don't do anything on these keys
       else this.results_search()
 


### PR DESCRIPTION
### Summary

This is a fix for #2521 

Because of a [known behaviour](http://stackoverflow.com/questions/27380018/when-cmd-key-is-kept-pressed-keyup-is-not-triggered-for-any-other-key) on OSX, `keyup` events are not triggered for a key pressed while Cmd is being held down.

This lead to an issue when pushing Cmd-Delete on Mac to clear the search field. The `keyup` event handler ignores any pushes of (amongst others) modifier keys, including Ctrl, Alt, and Cmd.

This commit simply lets the search function continue to run after Cmd is released, so behaviour is closer to expected.
### References
