### PR TITLE
Make search match against text instead of html

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -403,7 +403,7 @@ class Chosen extends AbstractChosen
     @selected_item.addClass("chosen-single-with-deselect")
 
   get_search_text: ->
-    $('<div/>').text($.trim(@search_field.val())).html()
+    $.trim(@search_field.val())
 
   winnow_results_set_highlight: ->
     selected_results = if not @is_multiple then @search_results.find(".result-selected.active-result") else []

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -405,6 +405,9 @@ class Chosen extends AbstractChosen
   get_search_text: ->
     $.trim(@search_field.val())
 
+  get_escaped_text: (text) ->
+  	$('<div>').text(text).html()
+
   winnow_results_set_highlight: ->
     selected_results = if not @is_multiple then @search_results.find(".result-selected.active-result") else []
     do_high = if selected_results.length then selected_results.first() else @search_results.find(".active-result").first()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -393,7 +393,7 @@ class @Chosen extends AbstractChosen
     @selected_item.addClassName("chosen-single-with-deselect")
 
   get_search_text: ->
-    @search_field.value.strip().escapeHTML()
+    @search_field.value.strip()
 
   winnow_results_set_highlight: ->
     if not @is_multiple

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -395,6 +395,9 @@ class @Chosen extends AbstractChosen
   get_search_text: ->
     @search_field.value.strip()
 
+  get_escaped_text: (text) ->
+    text.escapeHTML()
+
   winnow_results_set_highlight: ->
     if not @is_multiple
       do_high = @search_results.down(".result-selected.active-result")

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -177,7 +177,7 @@ class AbstractChosen
           results += 1 if results_group.active_options is 0 and results_group.search_match
           results_group.active_options += 1
 
-        option.search_text = if option.group then option.label else option.html
+        option.search_text = if option.group then option.label else option.text
 
         unless option.group and not @group_search
           option.search_match = this.search_string_match(option.search_text, regex)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -178,6 +178,7 @@ class AbstractChosen
           results_group.active_options += 1
 
         option.search_text = if option.group then option.label else option.text
+        escaped = false
 
         unless option.group and not @group_search
           option.search_match = this.search_string_match(option.search_text, regex)
@@ -186,13 +187,22 @@ class AbstractChosen
           if option.search_match
             if searchText.length
               startpos = option.search_text.search highlightRegex
-              text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
-              option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
+              #text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
+              textstart = option.search_text.substr(0, startpos + searchText.length)
+              text = [
+	              this.get_escaped_text(textstart.substr(0, startpos))
+	              this.get_escaped_text(textstart.substr(startpos))
+	              this.get_escaped_text(option.search_text.substr(startpos + searchText.length))
+              ]
+              #option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
+              option.search_text = text[0] + '<em>' + text[1] + '</em>' + text[2]
+              escaped = true
 
             results_group.group_match = true if results_group?
-
           else if option.group_array_index? and @results_data[option.group_array_index].search_match
             option.search_match = true
+        if not escaped
+          option.search_text = this.get_escaped_text(option.search_text)
 
     this.result_clear_highlight()
 

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -15,7 +15,7 @@ class SelectParser
     @parsed.push
       array_index: group_position
       group: true
-      label: this.escapeExpression(group.label)
+      label: group.label
       title: group.title if group.title
       children: 0
       disabled: group.disabled,
@@ -37,7 +37,7 @@ class SelectParser
           selected: option.selected
           disabled: if group_disabled is true then group_disabled else option.disabled
           group_array_index: group_position
-          group_label: if group_position? then @parsed[group_position].label else null
+          group_label: if group_position? then this.escapeExpression(@parsed[group_position].label) else null
           classes: option.className
           style: option.style.cssText
       else


### PR DESCRIPTION
### Summary

This is a fix for #2548.

With `search_contains` enabled, the search was matching the HTML. For example, if an optgroup had the name "This & that", a search for "m" would match the the m in &amp;.

This commit ensures searches are done against the raw text instead of the HTML value.
