### PR TITLE
restore focus if chosen was activated

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -310,7 +310,10 @@ class Chosen extends AbstractChosen
 
   choice_destroy: (link) ->
     if this.result_deselect( link[0].getAttribute("data-option-array-index") )
-      this.show_search_field_default()
+      if @active_field
+        @search_field.focus()
+      else
+        this.show_search_field_default()
 
       this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.val().length < 1
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -301,7 +301,10 @@ class @Chosen extends AbstractChosen
 
   choice_destroy: (link) ->
     if this.result_deselect link.readAttribute("rel")
-      this.show_search_field_default()
+      if @active_field
+        @search_field.focus()
+      else
+        this.show_search_field_default()
 
       this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.value.length < 1
 


### PR DESCRIPTION
When the select has focus and an option is removed, restore the focus.

fixes #2429