### PR TITLE
always close on chosen:close event

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -89,7 +89,7 @@ class Chosen extends AbstractChosen
     @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
     @form_field_jq.bind "chosen:activate.chosen", (evt) => this.activate_field(evt); return
     @form_field_jq.bind "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
-    @form_field_jq.bind "chosen:close.chosen", (evt) => this.input_blur(evt); return
+    @form_field_jq.bind "chosen:close.chosen", (evt) => this.close_field(evt); return
 
     @search_field.bind 'blur.chosen', (evt) => this.input_blur(evt); return
     @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
@@ -164,6 +164,7 @@ class Chosen extends AbstractChosen
 
     this.show_search_field_default()
     this.search_field_scale()
+    @search_field.blur()
 
   activate_field: ->
     @container.addClass "chosen-container-active"

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -71,7 +71,7 @@ class @Chosen extends AbstractChosen
     @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
     @form_field.observe "chosen:activate", (evt) => this.activate_field(evt)
     @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
-    @form_field.observe "chosen:close", (evt) => this.input_blur(evt)
+    @form_field.observe "chosen:close", (evt) => this.close_field(evt)
 
     @search_field.observe "blur", (evt) => this.input_blur(evt)
     @search_field.observe "keyup", (evt) => this.keyup_checker(evt)
@@ -158,6 +158,7 @@ class @Chosen extends AbstractChosen
 
     this.show_search_field_default()
     this.search_field_scale()
+    @search_field.blur()
 
   activate_field: ->
     @container.addClassName "chosen-container-active"


### PR DESCRIPTION
Triggering `chosen:close` didn't had any effect when the mouse was hovering the instance. This fixes that to use `close_field` instead of `input_blur` as the associated action.

fixes #2340