### PR TITLE
prevent bubbling of escape key

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -237,7 +237,7 @@ class Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.val @search_field.val()
+    @search_field.val this.get_search_field_value()
 
     this.winnow_results()
     @form_field_jq.trigger("chosen:showing_dropdown", {chosen: this})
@@ -312,7 +312,7 @@ class Chosen extends AbstractChosen
     if this.result_deselect( link[0].getAttribute("data-option-array-index") )
       this.show_search_field_default()
 
-      this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.val().length < 1
+      this.results_hide() if @is_multiple and this.choices_count() > 0 and this.get_search_field_value().length < 1
 
       link.parents('li').first().remove()
 
@@ -402,8 +402,11 @@ class Chosen extends AbstractChosen
     @selected_item.find("span").first().after "<abbr class=\"search-choice-close\"></abbr>" unless @selected_item.find("abbr").length
     @selected_item.addClass("chosen-single-with-deselect")
 
+  get_search_field_value: ->
+    @search_field.val()
+
   get_search_text: ->
-    $('<div/>').text($.trim(@search_field.val())).html()
+    $('<div/>').text($.trim(this.get_search_field_value())).html()
 
   winnow_results_set_highlight: ->
     selected_results = if not @is_multiple then @search_results.find(".result-selected.active-result") else []
@@ -498,7 +501,7 @@ class Chosen extends AbstractChosen
         style_block += style + ":" + @search_field.css(style) + ";"
 
       div = $('<div />', { 'style' : style_block })
-      div.text @search_field.val()
+      div.text this.get_search_field_value()
       $('body').append div
 
       w = div.width() + 25

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -460,35 +460,6 @@ class Chosen extends AbstractChosen
     @pending_backstroke.removeClass "search-choice-focus" if @pending_backstroke
     @pending_backstroke = null
 
-  keydown_checker: (evt) ->
-    stroke = evt.which ? evt.keyCode
-    this.search_field_scale()
-
-    this.clear_backstroke() if stroke != 8 and this.pending_backstroke
-
-    switch stroke
-      when 8
-        @backstroke_length = this.search_field.val().length
-        break
-      when 9
-        this.result_select(evt) if this.results_showing and not @is_multiple
-        @mouse_on_container = false
-        break
-      when 13
-        evt.preventDefault() if this.results_showing
-        break
-      when 32
-        evt.preventDefault() if @disable_search
-        break
-      when 38
-        evt.preventDefault()
-        this.keyup_arrow()
-        break
-      when 40
-        evt.preventDefault()
-        this.keydown_arrow()
-        break
-
   search_field_scale: ->
     if @is_multiple
       h = 0

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -163,7 +163,7 @@ class @Chosen extends AbstractChosen
     @container.addClassName "chosen-container-active"
     @active_field = true
 
-    @search_field.value = @search_field.value
+    @search_field.value = this.get_search_field_value()
     @search_field.focus()
 
   test_active_click: (evt) ->
@@ -228,7 +228,7 @@ class @Chosen extends AbstractChosen
     @results_showing = true
 
     @search_field.focus()
-    @search_field.value = @search_field.value
+    @search_field.value = this.get_search_field_value()
 
     this.winnow_results()
     @form_field.fire("chosen:showing_dropdown", {chosen: this})
@@ -303,7 +303,7 @@ class @Chosen extends AbstractChosen
     if this.result_deselect link.readAttribute("rel")
       this.show_search_field_default()
 
-      this.results_hide() if @is_multiple and this.choices_count() > 0 and @search_field.value.length < 1
+      this.results_hide() if @is_multiple and this.choices_count() > 0 and this.get_search_field_value().length < 1
 
       link.up('li').remove()
 
@@ -392,8 +392,11 @@ class @Chosen extends AbstractChosen
     @selected_item.down("span").insert { after: "<abbr class=\"search-choice-close\"></abbr>" } unless @selected_item.down("abbr")
     @selected_item.addClassName("chosen-single-with-deselect")
 
+  get_search_field_value: ->
+    @search_field.value
+
   get_search_text: ->
-    @search_field.value.strip().escapeHTML()
+    this.get_search_field_value().strip().escapeHTML()
 
   winnow_results_set_highlight: ->
     if not @is_multiple
@@ -492,7 +495,7 @@ class @Chosen extends AbstractChosen
       for style in styles
         style_block += style + ":" + @search_field.getStyle(style) + ";"
 
-      div = new Element('div', { 'style' : style_block }).update(@search_field.value.escapeHTML())
+      div = new Element('div', { 'style' : style_block }).update(this.get_search_field_value().escapeHTML())
       document.body.appendChild(div)
 
       w = Element.measure(div, 'width') + 25

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -455,35 +455,6 @@ class @Chosen extends AbstractChosen
     @pending_backstroke.removeClassName("search-choice-focus") if @pending_backstroke
     @pending_backstroke = null
 
-  keydown_checker: (evt) ->
-    stroke = evt.which ? evt.keyCode
-    this.search_field_scale()
-
-    this.clear_backstroke() if stroke != 8 and this.pending_backstroke
-
-    switch stroke
-      when 8
-        @backstroke_length = this.search_field.value.length
-        break
-      when 9
-        this.result_select(evt) if this.results_showing and not @is_multiple
-        @mouse_on_container = false
-        break
-      when 13
-        evt.preventDefault() if this.results_showing
-        break
-      when 32
-        evt.preventDefault() if @disable_search
-        break
-      when 38
-        evt.preventDefault()
-        this.keyup_arrow()
-        break
-      when 40
-        evt.preventDefault()
-        this.keydown_arrow()
-        break
-
   search_field_scale: ->
     if @is_multiple
       h = 0

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -271,21 +271,25 @@ class AbstractChosen
     this.search_field_scale()
 
     switch stroke
-      when 8
+      when 8 # backspace
         if @is_multiple and @backstroke_length < 1 and this.choices_count() > 0
           this.keydown_backstroke()
         else if not @pending_backstroke
           this.result_clear_highlight()
           this.results_search()
-      when 13
+        break
+      when 13 # enter
         evt.preventDefault()
         this.result_select(evt) if this.results_showing
-      when 27
+        break
+      when 27 # escape
         this.results_hide() if @results_showing
-        return true
-      when 9, 38, 40, 16, 91, 17, 18
+        break
+      when 9, 16, 17, 18, 38, 40, 91
         # don't do anything on these keys
-      else this.results_search()
+      else
+        this.results_search()
+        break
 
   clipboard_event_checker: (evt) ->
     setTimeout (=> this.results_search()), 50

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -237,6 +237,35 @@ class AbstractChosen
     evt.preventDefault()
     this.results_show() unless @results_showing or @is_disabled
 
+  keydown_checker: (evt) ->
+    stroke = evt.which ? evt.keyCode
+    this.search_field_scale()
+
+    this.clear_backstroke() if stroke != 8 and @pending_backstroke
+
+    switch stroke
+      when 8 # backspace
+        @backstroke_length = this.get_search_field_value().length
+        break
+      when 9 # tab
+        this.result_select(evt) if @results_showing and not @is_multiple
+        @mouse_on_container = false
+        break
+      when 13 # enter
+        evt.preventDefault() if @results_showing
+        break
+      when 32 # space
+        evt.preventDefault() if @disable_search
+        break
+      when 38 # up arrow
+        evt.preventDefault()
+        this.keyup_arrow()
+        break
+      when 40 # down arrow
+        evt.preventDefault()
+        this.keydown_arrow()
+        break
+
   keyup_checker: (evt) ->
     stroke = evt.which ? evt.keyCode
     this.search_field_scale()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -254,6 +254,9 @@ class AbstractChosen
       when 13 # enter
         evt.preventDefault() if @results_showing
         break
+      when 27 # escape
+        evt.preventDefault() if @results_showing
+        break
       when 32 # space
         evt.preventDefault() if @disable_search
         break


### PR DESCRIPTION
When the results are showing, pressing escape only hides the results, and then prevents bubbling.

Also introduced an extra method to retrieve the search input value, so that the `keydown_checker` can be moved to the abstract class. 
This method can also be used as an additional solution for #2370, e.g.:

```js
$('.chosen').chosen().on('chosen:no_results', function(event, data) {
  console.log(data.chosen.get_search_field_value());
});
```


fixes #1256 
fixes #2653 
