### PR TITLE
Content-Security-Policy fixes

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -476,29 +476,32 @@ class Chosen extends AbstractChosen
     @pending_backstroke = null
 
   search_field_scale: ->
-    if @is_multiple
-      h = 0
-      w = 0
+    return unless @is_multiple
 
-      style_block = "position:absolute; left: -1000px; top: -1000px; display: none; white-space: pre;"
-      styles = ['font-size', 'font-style', 'font-weight', 'font-family', 'line-height', 'text-transform', 'letter-spacing']
+    style_block =
+      position: 'absolute'
+      left: '-1000px'
+      top: '-1000px'
+      display: 'none'
+      whiteSpace: 'pre'
 
-      for style in styles
-        style_block += style + ":" + @search_field.css(style) + ";"
+    styles = ['fontSize', 'fontStyle', 'fontWeight', 'fontFamily', 'lineHeight', 'textTransform', 'letterSpacing']
 
-      div = $('<div />', { 'style' : style_block })
-      div.text this.get_search_field_value()
-      $('body').append div
+    for style in styles
+      style_block[style] = @search_field.css(style)
 
-      w = div.width() + 25
-      div.remove()
+    div = $('<div />').css(style_block)
+    div.text this.get_search_field_value()
+    $('body').append div
 
-      f_width = @container.outerWidth()
+    width = div.width() + 25
+    div.remove()
 
-      if( w > f_width - 10 )
-        w = f_width - 10
+    container_width = @container.outerWidth()
 
-      @search_field.css({'width': w + 'px'})
+    width = Math.min(container_width - 10, width)
+
+    @search_field.width(width)
 
   trigger_form_field_change: (extra) ->
     @form_field_jq.trigger "input", extra

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -33,17 +33,19 @@ class Chosen extends AbstractChosen
 
     container_props =
       'class': container_classes.join ' '
-      'style': "width: #{this.container_width()};"
       'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
     @container = ($ "<div />", container_props)
 
+    # CSP without 'unsafe-inline' doesn't allow setting the style attribute directly
+    @container.width this.container_width()
+
     if @is_multiple
-      @container.html '<ul class="chosen-choices"><li class="search-field"><input type="text" value="' + @default_text + '" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>'
+      @container.html this.get_multi_template()
     else
-      @container.html '<a class="chosen-single chosen-default"><span>' + @default_text + '</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>'
+      @container.html this.get_single_template()
 
     @form_field_jq.hide().after @container
     @dropdown = @container.find('div.chosen-drop').first()
@@ -430,9 +432,7 @@ class Chosen extends AbstractChosen
     this.result_do_highlight do_high if do_high?
 
   no_results: (terms) ->
-    no_results_html = $('<li class="no-results">' + @results_none_found + ' "<span></span>"</li>')
-    no_results_html.find("span").first().html(terms)
-
+    no_results_html = this.get_no_results_template(terms)
     @search_results.append no_results_html
     @form_field_jq.trigger("chosen:no_results", {chosen:this})
 

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -43,9 +43,9 @@ class Chosen extends AbstractChosen
     @container.width this.container_width()
 
     if @is_multiple
-      @container.html this.get_multi_template()
+      @container.html this.get_multi_html()
     else
-      @container.html this.get_single_template()
+      @container.html this.get_single_html()
 
     @form_field_jq.hide().after @container
     @dropdown = @container.find('div.chosen-drop').first()
@@ -432,7 +432,7 @@ class Chosen extends AbstractChosen
     this.result_do_highlight do_high if do_high?
 
   no_results: (terms) ->
-    no_results_html = this.get_no_results_template(terms)
+    no_results_html = this.get_no_results_html(terms)
     @search_results.append no_results_html
     @form_field_jq.trigger("chosen:no_results", {chosen:this})
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -7,7 +7,7 @@ class @Chosen extends AbstractChosen
     super()
 
     # HTML Templates
-    @no_results_temp = new Template(this.get_no_results_template('#{terms}'))
+    @no_results_temp = new Template(this.get_no_results_html('#{terms}'))
 
   set_up_html: ->
     container_classes = ["chosen-container"]
@@ -27,9 +27,9 @@ class @Chosen extends AbstractChosen
     @container.setStyle(width: this.container_width())
 
     if @is_multiple
-      @container.update this.get_multi_template()
+      @container.update this.get_multi_html()
     else
-      @container.update this.get_single_template()
+      @container.update this.get_single_html()
 
     @form_field.hide().insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -7,9 +7,7 @@ class @Chosen extends AbstractChosen
     super()
 
     # HTML Templates
-    @single_temp = new Template('<a class="chosen-single chosen-default"><span>#{default}</span><div><b></b></div></a><div class="chosen-drop"><div class="chosen-search"><input type="text" autocomplete="off" /></div><ul class="chosen-results"></ul></div>')
-    @multi_temp = new Template('<ul class="chosen-choices"><li class="search-field"><input type="text" value="#{default}" class="default" autocomplete="off" style="width:25px;" /></li></ul><div class="chosen-drop"><ul class="chosen-results"></ul></div>')
-    @no_results_temp = new Template('<li class="no-results">' + @results_none_found + ' "<span>#{terms}</span>"</li>')
+    @no_results_temp = new Template(this.get_no_results_template('#{terms}'))
 
   set_up_html: ->
     container_classes = ["chosen-container"]
@@ -19,12 +17,19 @@ class @Chosen extends AbstractChosen
 
     container_props =
       'class': container_classes.join ' '
-      'style': "width: #{this.container_width()};"
       'title': @form_field.title
 
     container_props.id = @form_field.id.replace(/[^\w]/g, '_') + "_chosen" if @form_field.id.length
 
-    @container = if @is_multiple then new Element('div', container_props).update( @multi_temp.evaluate({ "default": @default_text}) ) else new Element('div', container_props).update( @single_temp.evaluate({ "default":@default_text }) )
+    @container = new Element('div', container_props)
+
+    # CSP without 'unsafe-inline' doesn't allow setting the style attribute directly
+    @container.setStyle(width: this.container_width())
+
+    if @is_multiple
+      @container.update this.get_multi_template()
+    else
+      @container.update this.get_single_template()
 
     @form_field.hide().insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -475,28 +475,33 @@ class @Chosen extends AbstractChosen
     @pending_backstroke = null
 
   search_field_scale: ->
-    if @is_multiple
-      h = 0
-      w = 0
+    return unless @is_multiple
 
-      style_block = "position:absolute; left: -1000px; top: -1000px; display: none; white-space: pre;"
-      styles = ['font-size', 'font-style', 'font-weight', 'font-family', 'line-height', 'text-transform', 'letter-spacing']
+    style_block =
+      position: 'absolute'
+      left: '-1000px'
+      top: '-1000px'
+      display: 'none'
+      whiteSpace: 'pre'
 
-      for style in styles
-        style_block += style + ":" + @search_field.getStyle(style) + ";"
+    styles = ['fontSize', 'fontStyle', 'fontWeight', 'fontFamily', 'lineHeight', 'textTransform', 'letterSpacing']
 
-      div = new Element('div', { 'style' : style_block }).update(this.get_search_field_value().escapeHTML())
-      document.body.appendChild(div)
+    for style in styles
+      style_block[style] = @search_field.getStyle(style)
 
-      w = Element.measure(div, 'width') + 25
-      div.remove()
+    div = new Element('div').update(this.escape_html(this.get_search_field_value()))
+    # CSP without 'unsafe-inline' doesn't allow setting the style attribute directly
+    div.setStyle(style_block)
+    document.body.appendChild(div)
 
-      f_width = @container.getWidth()
+    width = div.measure('width') + 25
+    div.remove()
 
-      if( w > f_width-10 )
-        w = f_width - 10
+    container_width = @container.getWidth()
 
-      @search_field.setStyle({'width': w + 'px'})
+    width = Math.min(container_width - 10, width)
+
+    @search_field.setStyle(width: width + 'px')
 
   trigger_form_field_change:  ->
     triggerHtmlEvent @form_field, 'input'

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -333,6 +333,39 @@ class AbstractChosen
     tmp.appendChild(element)
     tmp.innerHTML
 
+  get_single_template: ->
+    """
+      <a class="chosen-single chosen-default">
+        <span>#{@default_text}</span>
+        <div><b></b></div>
+      </a>
+      <div class="chosen-drop">
+        <div class="chosen-search">
+          <input class="chosen-search-input" type="text" autocomplete="off" />
+        </div>
+        <ul class="chosen-results"></ul>
+      </div>
+    """
+
+  get_multi_template: ->
+    """
+      <ul class="chosen-choices">
+        <li class="search-field">
+          <input class="chosen-search-input" type="text" autocomplete="off" value="#{@default_text}" />
+        </li>
+      </ul>
+      <div class="chosen-drop">
+        <ul class="chosen-results"></ul>
+      </div>
+    """
+
+  get_no_results_template: (terms) ->
+    """
+      <li class="no-results">
+        #{@results_none_found} <span>#{terms}</span>
+      </li>
+    """
+
   # class methods and variables ============================================================
 
   @browser_is_supported: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -333,7 +333,7 @@ class AbstractChosen
     tmp.appendChild(element)
     tmp.innerHTML
 
-  get_single_template: ->
+  get_single_html: ->
     """
       <a class="chosen-single chosen-default">
         <span>#{@default_text}</span>
@@ -347,7 +347,7 @@ class AbstractChosen
       </div>
     """
 
-  get_multi_template: ->
+  get_multi_html: ->
     """
       <ul class="chosen-choices">
         <li class="search-field">
@@ -359,7 +359,7 @@ class AbstractChosen
       </div>
     """
 
-  get_no_results_template: (terms) ->
+  get_no_results_html: (terms) ->
     """
       <li class="no-results">
         #{@results_none_found} <span>#{terms}</span>

--- a/public/docsupport/init.js
+++ b/public/docsupport/init.js
@@ -1,0 +1,11 @@
+var config = {
+  '.chosen-select'           : {},
+  '.chosen-select-deselect'  : { allow_single_deselect: true },
+  '.chosen-select-no-single' : { disable_search_threshold: 10 },
+  '.chosen-select-no-results': { no_results_text: 'Oops, nothing found!' },
+  '.chosen-select-rtl'       : { rtl: true },
+  '.chosen-select-width'     : { width: '95%' }
+}
+for (var selector in config) {
+  $(selector).chosen(config[selector]);
+}

--- a/public/docsupport/init.proto.js
+++ b/public/docsupport/init.proto.js
@@ -1,0 +1,16 @@
+document.observe('dom:loaded', function(evt) {
+  var config = {
+    '.chosen-select'           : {},
+    '.chosen-select-deselect'  : { allow_single_deselect: true },
+    '.chosen-select-no-single' : { disable_search_threshold: 10 },
+    '.chosen-select-no-results': { no_results_text: 'Oops, nothing found!' },
+    '.chosen-select-rtl'       : { rtl: true },
+    '.chosen-select-width'     : { width: '95%' }
+  }
+  
+  for (var selector in config) {
+    $$(selector).each(function(element) {
+      new Chosen(element, config[selector]);
+    });
+  }
+});

--- a/public/docsupport/style.css
+++ b/public/docsupport/style.css
@@ -202,3 +202,18 @@ i { font-style: italic; }
   padding-left: 27px;
   text-decoration: none;
 }
+
+.select,
+.chosen-select,
+.chosen-select-no-single,
+.chosen-select-no-results,
+.chosen-select-deselect,
+.chosen-select-rtl,
+.chosen-select-width {
+  width: 350px;
+}
+
+.jquery-version-refer {
+  margin-top: 40px;
+  font-style: italic;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,20 @@
   <link rel="stylesheet" href="docsupport/style.css">
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
+
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self' 'sha256-73t6wDeox0rhIyLfISCnfM7yzITvmDhSErVn+wwjOmo='; img-src 'self' data:">
+
+  <style type="text/css" media="all">
+    .select,
+    .chosen-select,
+    .chosen-select-no-single,
+    .chosen-select-no-results,
+    .chosen-select-deselect,
+    .chosen-select-rtl,
+    .chosen-select-width {
+      width: 350px;
+    }
+  </style>
 </head>
 <body>
   <form>
@@ -26,7 +40,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" tabindex="1">
+          <select data-placeholder="Choose a Country..." class="select" tabindex="1">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -283,7 +297,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" style="width:350px;" tabindex="2">
+          <select data-placeholder="Choose a Country..." class="chosen-select" tabindex="2">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -544,7 +558,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" multiple tabindex="3">
+          <select data-placeholder="Choose a Country..." class="select" multiple tabindex="3">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -801,7 +815,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" multiple style="width:350px;" tabindex="4">
+          <select data-placeholder="Choose a Country..." class="chosen-select" multiple tabindex="4">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -1062,7 +1076,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Single Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" tabindex="5">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" tabindex="5">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1116,7 +1130,7 @@
         </div>
         <div>
           <em>Multiple Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" multiple tabindex="6">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" multiple tabindex="6">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1175,7 +1189,7 @@
         <p>Chosen automatically highlights selected options and removes disabled options.</p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select" tabindex="7">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select" tabindex="7">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1189,7 +1203,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select" tabindex="8">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="8">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1209,7 +1223,7 @@
         <pre><code class="language-javascript">$(".chosen-select").chosen({disable_search_threshold: 10});</code></pre>
         <p></p>
         <div>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-no-single" tabindex="9">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-no-single" tabindex="9">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1227,7 +1241,7 @@
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
         <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select an Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>
-        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> style="width:350px;" multiple class="chosen-select"&gt;</code></pre>
+        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> multiple class="chosen-select"&gt;</code></pre>
         <p><strong>Note:</strong> on single selects, the first element is assumed to be selected by the browser. To take advantage of the default text support, you will need to include a blank option as the first element of your select list.</p>
       </div>
 
@@ -1238,7 +1252,7 @@
         <p></p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1252,7 +1266,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1278,7 +1292,7 @@
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
         <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-deselect" tabindex="12">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1299,7 +1313,7 @@
 
         <div>
           <em>Single Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="13">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1311,7 +1325,7 @@
         </div>
         <div>
           <em>Multiple Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="14">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1384,7 +1398,7 @@
         <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" style="width:350px;" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1398,7 +1412,7 @@
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" style="width:350px;" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1455,22 +1469,10 @@
 
     </div>
   </div>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js" type="text/javascript"></script>
   <script src="chosen.jquery.js" type="text/javascript"></script>
   <script src="docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
-  <script type="text/javascript">
-    var config = {
-      '.chosen-select'           : {},
-      '.chosen-select-deselect'  : {allow_single_deselect:true},
-      '.chosen-select-no-single' : {disable_search_threshold:10},
-      '.chosen-select-no-results': {no_results_text:'Oops, nothing found!'},
-      '.chosen-select-rtl'       : {rtl: true},
-      '.chosen-select-width'     : {width:"95%"}
-    }
-    for (var selector in config) {
-      $(selector).chosen(config[selector]);
-    }
-  </script>
+  <script src="docsupport/init.js" type="text/javascript" charset="utf-8"></script>
   </form>
   <div class="oss-bar">
     <ul>

--- a/public/index.html
+++ b/public/index.html
@@ -7,19 +7,8 @@
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self' 'sha256-73t6wDeox0rhIyLfISCnfM7yzITvmDhSErVn+wwjOmo='; img-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self'; img-src 'self' data:">
 
-  <style type="text/css" media="all">
-    .select,
-    .chosen-select,
-    .chosen-select-no-single,
-    .chosen-select-no-results,
-    .chosen-select-deselect,
-    .chosen-select-rtl,
-    .chosen-select-width {
-      width: 350px;
-    }
-  </style>
 </head>
 <body>
   <form>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -6,6 +6,24 @@
   <link rel="stylesheet" href="docsupport/style.css">
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
+
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self' 'sha256-MzlZlLruPmzLm/yy8z6yCpmyo5QSe/SURdcVrrJx880='; img-src 'self' data:">
+
+  <style type="text/css" media="all">
+    .select,
+    .chosen-select,
+    .chosen-select-no-single,
+    .chosen-select-no-results,
+    .chosen-select-deselect,
+    .chosen-select-rtl,
+    .chosen-select-width {
+      width: 350px;
+    }
+    .jquery-version-refer {
+      margin-top: 40px;
+      font-style: italic;
+    }
+  </style>
 </head>
 <body>
   <div id="container">
@@ -21,13 +39,13 @@
         <a class="button" href="https://github.com/harvesthq/chosen/blob/master/contributing.md">Contribute</a>
       </p>
 
-      <p style="margin-top: 40px; font-style: italic;">Looking for the <a href="index.html">jQuery version?</a></p>
+      <p class="jquery-version-refer">Looking for the <a href="index.html">jQuery version?</a></p>
 
       <h2><a name="standard-select" class="anchor" href="#standard-select">Standard Select</a></h2>
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" tabindex="1">
+          <select data-placeholder="Choose a Country..." class="select" tabindex="1">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -284,7 +302,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" style="width:350px;" tabindex="2">
+          <select data-placeholder="Choose a Country..." class="chosen-select" tabindex="2">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -545,7 +563,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Turns This</em>
-          <select data-placeholder="Choose a Country..." style="width:350px;" multiple tabindex="3">
+          <select data-placeholder="Choose a Country..." class="select" multiple tabindex="3">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -802,7 +820,7 @@
         </div>
         <div>
           <em>Into This</em>
-          <select data-placeholder="Choose a Country..." class="chosen-select" multiple style="width:350px;" tabindex="4">
+          <select data-placeholder="Choose a Country..." class="chosen-select" multiple tabindex="4">
             <option value=""></option>
             <option value="United States">United States</option>
             <option value="United Kingdom">United Kingdom</option>
@@ -1063,7 +1081,7 @@
       <div class="side-by-side clearfix">
         <div>
           <em>Single Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" tabindex="5">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" tabindex="5">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1117,7 +1135,7 @@
         </div>
         <div>
           <em>Multiple Select with Groups</em>
-          <select data-placeholder="Your Favorite Football Team" style="width:350px;" class="chosen-select" multiple tabindex="6">
+          <select data-placeholder="Your Favorite Football Team" class="chosen-select" multiple tabindex="6">
             <option value=""></option>
             <optgroup label="NFC EAST">
               <option>Dallas Cowboys</option>
@@ -1176,7 +1194,7 @@
         <p>Chosen automatically highlights selected options and removes disabled options.</p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select" tabindex="7">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select" tabindex="7">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1190,7 +1208,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select" tabindex="8">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="8">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1210,7 +1228,7 @@
         <pre><code class="language-javascript"> new Chosen($("chosen_select_field"),{disable_search_threshold: 10}); </code></pre>
         <p></p>
         <div>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-no-single" tabindex="9">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-no-single" tabindex="9">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1228,7 +1246,7 @@
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
         <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select an Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>
-        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> style="width:350px;" multiple class="chosen-select"&gt;</code></pre>
+        <pre><code class="language-markup">&lt;select <strong>data-placeholder="Choose a country..."</strong> multiple class="chosen-select"&gt;</code></pre>
         <p><strong>Note:</strong> on single selects, the first element is assumed to be selected by the browser. To take advantage of the default text support, you will need to include a blank option as the first element of your select list.</p>
       </div>
 
@@ -1239,7 +1257,7 @@
 
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1253,7 +1271,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" style="width:350px;" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1279,7 +1297,7 @@
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
         <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-deselect" tabindex="12">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1299,7 +1317,7 @@
         <pre><code class="language-javascript"> $(".chosen-select").chosen({rtl: true}); </code></pre>
         <div>
           <em>Single Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" style="width:350px;" class="chosen-select-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="13">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1311,7 +1329,7 @@
         </div>
         <div>
           <em>Multiple Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" style="width:350px;" multiple class="chosen-select-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="14">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1388,7 +1406,7 @@ chosen.destroy();</code></pre>
         <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" style="width:350px;" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1402,7 +1420,7 @@ chosen.destroy();</code></pre>
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" style="width:350px;" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1458,26 +1476,7 @@ chosen.destroy();</code></pre>
   <script src="https://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js" type="text/javascript"></script>
   <script src="chosen.proto.js" type="text/javascript"></script>
   <script src="docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
-  <script type="text/javascript">
-  document.observe('dom:loaded', function(evt) {
-    var config = {
-      '.chosen-select'           : {},
-      '.chosen-select-deselect'  : {allow_single_deselect:true},
-      '.chosen-select-no-single' : {disable_search_threshold:10},
-      '.chosen-select-no-results': {no_results_text: "Oops, nothing found!"},
-      '.chosen-select-rtl'       : {rtl: true},
-      '.chosen-select-width'     : {width: "95%"}
-    }
-    var results = [];
-    for (var selector in config) {
-      var elements = $$(selector);
-      for (var i = 0; i < elements.length; i++) {
-        results.push(new Chosen(elements[i],config[selector]));
-      }
-    }
-    return results;
-  });
-  </script>
+  <script src="docsupport/init.proto.js" type="text/javascript" charset="utf-8"></script>
   <div class="oss-bar">
     <ul>
       <li><a class="fork" href="https://github.com/harvesthq/chosen">Fork on Github</a></li>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -7,23 +7,8 @@
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self' 'sha256-MzlZlLruPmzLm/yy8z6yCpmyo5QSe/SURdcVrrJx880='; img-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://ajax.googleapis.com; style-src 'self'; img-src 'self' data:">
 
-  <style type="text/css" media="all">
-    .select,
-    .chosen-select,
-    .chosen-select-no-single,
-    .chosen-select-no-results,
-    .chosen-select-deselect,
-    .chosen-select-rtl,
-    .chosen-select-width {
-      width: 350px;
-    }
-    .jquery-version-refer {
-      margin-top: 40px;
-      font-style: italic;
-    }
-  </style>
 </head>
 <body>
   <div id="container">

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -115,6 +115,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     margin: 0;
     padding: 3px 4px;
     white-space: nowrap;
+
     input[type="text"] {
       margin: 1px 0;
       padding: 4px 20px 4px 5px;
@@ -228,6 +229,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
         font-family: sans-serif;
         line-height: normal;
         border-radius: 0;
+        width: 25px;
       }
     }
     &.search-choice {


### PR DESCRIPTION
To make Chosen compatible with restrictive Content-Security-Policy's, I've updated the way we apply inline styles to elements.

The HTML used to build the select is now defined in AbstractChosen.

I also updated the documentation pages with a CSP header as an example.

fixes #2423 
related #2575
