### PR TITLE
only prevent default on touchevents when results are not showing

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -69,8 +69,8 @@ class Chosen extends AbstractChosen
     @form_field_jq.trigger("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); evt.preventDefault()
-    @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); evt.preventDefault()
+    @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); return
+    @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); return
 
     @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
     @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
@@ -129,7 +129,7 @@ class Chosen extends AbstractChosen
   container_mousedown: (evt) ->
     return if @is_disabled
 
-    if evt and evt.type is "mousedown" and not @results_showing
+    if evt and evt.type in ['mousedown', 'touchstart'] and not @results_showing
       evt.preventDefault()
 
     if not (evt? and ($ evt.target).hasClass "search-choice-close")

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -50,8 +50,8 @@ class @Chosen extends AbstractChosen
     @form_field.fire("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.observe "touchstart", (evt) => this.container_mousedown(evt); evt.preventDefault()
-    @container.observe "touchend", (evt) => this.container_mouseup(evt); evt.preventDefault()
+    @container.observe "touchstart", (evt) => this.container_mousedown(evt)
+    @container.observe "touchend", (evt) => this.container_mouseup(evt)
 
     @container.observe "mousedown", (evt) => this.container_mousedown(evt)
     @container.observe "mouseup", (evt) => this.container_mouseup(evt)
@@ -124,7 +124,7 @@ class @Chosen extends AbstractChosen
   container_mousedown: (evt) ->
     return if @is_disabled
 
-    if evt and evt.type is "mousedown" and not @results_showing
+    if evt and evt.type in ['mousedown', 'touchstart'] and not @results_showing
       evt.stop()
 
     if not (evt? and evt.target.hasClassName "search-choice-close")

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -125,7 +125,7 @@ class @Chosen extends AbstractChosen
     return if @is_disabled
 
     if evt and evt.type in ['mousedown', 'touchstart'] and not @results_showing
-      evt.stop()
+      evt.preventDefault()
 
     if not (evt? and evt.target.hasClassName "search-choice-close")
       if not @active_field


### PR DESCRIPTION
The fix introduced in #2119 prevented all further touch interaction with Chosen like scrolling or selecting options.

I don't know how that has been in there for so long...

I've now updated that to only `preventDefault` the events when the results are not showing.

fixes #2289
fixes #2443