### PR TITLE
clip results instead of moving them

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,6 @@
   <link rel="stylesheet" href="docsupport/style.css">
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
-  <style type="text/css" media="all">
-    /* fix rtl for demo */
-    .chosen-rtl .chosen-drop { left: -9000px; }
-  </style>
 </head>
 <body>
   <form>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -6,10 +6,6 @@
   <link rel="stylesheet" href="docsupport/style.css">
   <link rel="stylesheet" href="docsupport/prism.css">
   <link rel="stylesheet" href="chosen.css">
-  <style type="text/css" media="all">
-    /* fix rtl for demo */
-    .chosen-rtl .chosen-drop { left: -9000px; }
-  </style>
 </head>
 <body>
   <div id="container">

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -14,16 +14,16 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
   .chosen-drop {
     position: absolute;
     top: 100%;
-    left: -9999px;
     z-index: 1010;
     width: 100%;
     border: 1px solid #aaa;
     border-top: 0;
     background: #fff;
     box-shadow: 0 4px 5px rgba(#000,.15);
+    clip: rect(0,0,0,0);
   }
   &.chosen-with-drop .chosen-drop {
-    left: 0;
+    clip: auto;
   }
   a{
     cursor: pointer;

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -373,10 +373,6 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
       }
     }
   }
-  &.chosen-container-single-nosearch .chosen-search,
-  .chosen-drop {
-    left: 9999px;
-  }
   &.chosen-container-single .chosen-results {
     margin: 0 0 4px 4px;
     padding: 0 4px 0 0;

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -136,7 +136,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
   }
   &.chosen-container-single-nosearch .chosen-search {
     position: absolute;
-    left: -9999px;
+    clip: rect(0,0,0,0);
   }
 }
 /* @end */


### PR DESCRIPTION
I have tested this in the following browsers:

| Windows 7 | macOS Sierra |
 --- | ---
Latest Chrome | Latest Chrome
Latest Firefox | Latest Firefox
IE8 | Latest Safari
IE9 | 

There's only 1 issue on iOS, and that's that the cursor is visible, even when clipped:
![image](https://cloud.githubusercontent.com/assets/351038/19416896/851045b6-939d-11e6-9410-3d40359f5270.png)


fixes #1413
fixes #1410
fixes #1686
fixes #2402
fixes #2445
fixes #2185
