### PR TITLE
General touchup

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -110,7 +110,7 @@ class Chosen extends AbstractChosen
     @form_field_label.unbind 'click.chosen' if @form_field_label.length > 0
 
     if @search_field[0].tabIndex
-      @form_field_jq[0].tabIndex = @search_field[0].tabIndex
+      @form_field.tabIndex = @search_field[0].tabIndex
 
     @container.remove()
     @form_field_jq.removeData('chosen')
@@ -264,12 +264,11 @@ class Chosen extends AbstractChosen
 
     @results_showing = false
 
-
-  set_tab_index: (el) ->
+  set_tab_index: ->
     if @form_field.tabIndex
-      ti = @form_field.tabIndex
+      tabIndex = @form_field.tabIndex
       @form_field.tabIndex = -1
-      @search_field[0].tabIndex = ti
+      @search_field[0].tabIndex = tabIndex
 
   set_label_behavior: ->
     @form_field_label = @form_field_jq.parents("label") # first check for a parent label

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -71,37 +71,37 @@ class Chosen extends AbstractChosen
     @form_field_jq.trigger("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.bind 'touchstart.chosen', (evt) => this.container_mousedown(evt); return
-    @container.bind 'touchend.chosen', (evt) => this.container_mouseup(evt); return
+    @container.bind 'touchstart.chosen', this.container_mousedown
+    @container.bind 'touchend.chosen', this.container_mouseup
 
-    @container.bind 'mousedown.chosen', (evt) => this.container_mousedown(evt); return
-    @container.bind 'mouseup.chosen', (evt) => this.container_mouseup(evt); return
-    @container.bind 'mouseenter.chosen', (evt) => this.mouse_enter(evt); return
-    @container.bind 'mouseleave.chosen', (evt) => this.mouse_leave(evt); return
+    @container.bind 'mousedown.chosen', this.container_mousedown
+    @container.bind 'mouseup.chosen', this.container_mouseup
+    @container.bind 'mouseenter.chosen', this.mouse_enter
+    @container.bind 'mouseleave.chosen', this.mouse_leave
 
-    @search_results.bind 'mouseup.chosen', (evt) => this.search_results_mouseup(evt); return
-    @search_results.bind 'mouseover.chosen', (evt) => this.search_results_mouseover(evt); return
-    @search_results.bind 'mouseout.chosen', (evt) => this.search_results_mouseout(evt); return
-    @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', (evt) => this.search_results_mousewheel(evt); return
+    @search_results.bind 'mouseup.chosen', this.search_results_mouseup
+    @search_results.bind 'mouseover.chosen', this.search_results_mouseover
+    @search_results.bind 'mouseout.chosen', this.search_results_mouseout
+    @search_results.bind 'mousewheel.chosen DOMMouseScroll.chosen', this.search_results_mousewheel
 
-    @search_results.bind 'touchstart.chosen', (evt) => this.search_results_touchstart(evt); return
-    @search_results.bind 'touchmove.chosen', (evt) => this.search_results_touchmove(evt); return
-    @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
+    @search_results.bind 'touchstart.chosen', this.search_results_touchstart
+    @search_results.bind 'touchmove.chosen', this.search_results_touchmove
+    @search_results.bind 'touchend.chosen', this.search_results_touchend
 
-    @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
-    @form_field_jq.bind "chosen:activate.chosen", this.activate_field
-    @form_field_jq.bind "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
-    @form_field_jq.bind "chosen:close.chosen", (evt) => this.close_field(evt); return
+    @form_field_jq.bind 'chosen:updated.chosen', this.results_update_field
+    @form_field_jq.bind 'chosen:activate.chosen', this.activate_field
+    @form_field_jq.bind 'chosen:open.chosen', this.container_mousedown
+    @form_field_jq.bind 'chosen:close.chosen', this.close_field
 
-    @search_field.bind 'blur.chosen', (evt) => this.input_blur(evt); return
-    @search_field.bind 'keyup.chosen', (evt) => this.keyup_checker(evt); return
-    @search_field.bind 'keydown.chosen', (evt) => this.keydown_checker(evt); return
-    @search_field.bind 'focus.chosen', (evt) => this.input_focus(evt); return
-    @search_field.bind 'cut.chosen', (evt) => this.clipboard_event_checker(evt); return
-    @search_field.bind 'paste.chosen', (evt) => this.clipboard_event_checker(evt); return
+    @search_field.bind 'blur.chosen', this.input_blur
+    @search_field.bind 'keyup.chosen', this.keyup_checker
+    @search_field.bind 'keydown.chosen', this.keydown_checker
+    @search_field.bind 'focus.chosen', this.input_focus
+    @search_field.bind 'cut.chosen', this.clipboard_event_checker
+    @search_field.bind 'paste.chosen', this.clipboard_event_checker
 
     if @is_multiple
-      @search_choices.bind 'click.chosen', (evt) => this.choices_click(evt); return
+      @search_choices.bind 'click.chosen', this.choices_click
     else
       @container.bind 'click.chosen', (evt) -> evt.preventDefault(); return # gobble click of anchor
 
@@ -130,7 +130,7 @@ class Chosen extends AbstractChosen
     else unless @is_multiple
       @selected_item.bind 'focus.chosen', this.activate_field
 
-  container_mousedown: (evt) ->
+  container_mousedown: (evt) =>
     return if @is_disabled
 
     if evt and evt.type in ['mousedown', 'touchstart'] and not @results_showing
@@ -147,10 +147,10 @@ class Chosen extends AbstractChosen
 
       this.activate_field()
 
-  container_mouseup: (evt) ->
+  container_mouseup: (evt) =>
     this.results_reset(evt) if evt.target.nodeName is "ABBR" and not @is_disabled
 
-  search_results_mousewheel: (evt) ->
+  search_results_mousewheel: (evt) =>
     delta = evt.originalEvent.deltaY or -evt.originalEvent.wheelDelta or evt.originalEvent.detail if evt.originalEvent
     if delta?
       evt.preventDefault()
@@ -160,7 +160,7 @@ class Chosen extends AbstractChosen
   blur_test: ->
     this.close_field() if not @active_field and @container.hasClass "chosen-container-active"
 
-  close_field: ->
+  close_field: =>
     $(@container[0].ownerDocument).unbind 'click.chosen', this.test_active_click
 
     @active_field = false
@@ -286,18 +286,18 @@ class Chosen extends AbstractChosen
       @search_field.val("")
       @search_field.removeClass "default"
 
-  search_results_mouseup: (evt) ->
+  search_results_mouseup: (evt) =>
     target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
     if target.length
       @result_highlight = target
       this.result_select(evt)
       @search_field.focus()
 
-  search_results_mouseover: (evt) ->
+  search_results_mouseover: (evt) =>
     target = if $(evt.target).hasClass "active-result" then $(evt.target) else $(evt.target).parents(".active-result").first()
     this.result_do_highlight( target ) if target
 
-  search_results_mouseout: (evt) ->
+  search_results_mouseout: (evt) =>
     this.result_clear_highlight() if $(evt.target).hasClass "active-result" or $(evt.target).parents('.active-result').first()
 
   choice_build: (item) ->

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -89,7 +89,7 @@ class Chosen extends AbstractChosen
     @search_results.bind 'touchend.chosen', (evt) => this.search_results_touchend(evt); return
 
     @form_field_jq.bind "chosen:updated.chosen", (evt) => this.results_update_field(evt); return
-    @form_field_jq.bind "chosen:activate.chosen", (evt) => this.activate_field(evt); return
+    @form_field_jq.bind "chosen:activate.chosen", this.activate_field
     @form_field_jq.bind "chosen:open.chosen", (evt) => this.container_mousedown(evt); return
     @form_field_jq.bind "chosen:close.chosen", (evt) => this.close_field(evt); return
 
@@ -173,7 +173,7 @@ class Chosen extends AbstractChosen
     this.search_field_scale()
     @search_field.blur()
 
-  activate_field: ->
+  activate_field: =>
     return if @is_disabled
 
     @container.addClass "chosen-container-active"

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -106,7 +106,7 @@ class Chosen extends AbstractChosen
       @container.bind 'click.chosen', (evt) -> evt.preventDefault(); return # gobble click of anchor
 
   destroy: ->
-    $(@container[0].ownerDocument).unbind 'click.chosen', @click_test_action
+    $(@container[0].ownerDocument).unbind 'click.chosen', this.test_active_click
     @form_field_label.unbind 'click.chosen' if @form_field_label.length > 0
 
     if @search_field[0].tabIndex
@@ -139,7 +139,7 @@ class Chosen extends AbstractChosen
     if not (evt? and ($ evt.target).hasClass "search-choice-close")
       if not @active_field
         @search_field.val "" if @is_multiple
-        $(@container[0].ownerDocument).bind 'click.chosen', @click_test_action
+        $(@container[0].ownerDocument).bind 'click.chosen', this.test_active_click
         this.results_show()
       else if not @is_multiple and evt and (($(evt.target)[0] == @selected_item[0]) || $(evt.target).parents("a.chosen-single").length)
         evt.preventDefault()
@@ -161,7 +161,7 @@ class Chosen extends AbstractChosen
     this.close_field() if not @active_field and @container.hasClass "chosen-container-active"
 
   close_field: ->
-    $(@container[0].ownerDocument).unbind "click.chosen", @click_test_action
+    $(@container[0].ownerDocument).unbind 'click.chosen', this.test_active_click
 
     @active_field = false
     this.results_hide()
@@ -183,7 +183,7 @@ class Chosen extends AbstractChosen
     @search_field.focus()
 
 
-  test_active_click: (evt) ->
+  test_active_click: (evt) =>
     active_container = $(evt.target).closest('.chosen-container')
     if active_container.length and @container[0] == active_container[0]
       @active_field = true

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -157,7 +157,7 @@ class Chosen extends AbstractChosen
       delta = delta * 40 if evt.type is 'DOMMouseScroll'
       @search_results.scrollTop(delta + @search_results.scrollTop())
 
-  blur_test: (evt) ->
+  blur_test: ->
     this.close_field() if not @active_field and @container.hasClass "chosen-container-active"
 
   close_field: ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -74,7 +74,7 @@ class @Chosen extends AbstractChosen
     @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
 
     @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
-    @form_field.observe "chosen:activate", (evt) => this.activate_field(evt)
+    @form_field.observe "chosen:activate", this.activate_field
     @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
     @form_field.observe "chosen:close", (evt) => this.close_field(evt)
 
@@ -174,7 +174,7 @@ class @Chosen extends AbstractChosen
     this.search_field_scale()
     @search_field.blur()
 
-  activate_field: ->
+  activate_field: =>
     return if @is_disabled
 
     @container.addClassName "chosen-container-active"

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -91,7 +91,7 @@ class @Chosen extends AbstractChosen
       @container.observe "click", (evt) => evt.preventDefault() # gobble click of anchor
 
   destroy: ->
-    @container.ownerDocument.stopObserving "click", @click_test_action
+    @container.ownerDocument.stopObserving 'click', this.test_active_click
 
     for event in ['chosen:updated', 'chosen:activate', 'chosen:open', 'chosen:close']
       @form_field.stopObserving(event)
@@ -141,7 +141,7 @@ class @Chosen extends AbstractChosen
     if not (evt? and evt.target.hasClassName "search-choice-close")
       if not @active_field
         @search_field.clear() if @is_multiple
-        @container.ownerDocument.observe "click", @click_test_action
+        @container.ownerDocument.observe 'click', this.test_active_click
         this.results_show()
       else if not @is_multiple and evt and (evt.target is @selected_item || evt.target.up("a.chosen-single"))
         this.results_toggle()
@@ -162,7 +162,7 @@ class @Chosen extends AbstractChosen
     this.close_field() if not @active_field and @container.hasClassName("chosen-container-active")
 
   close_field: ->
-    @container.ownerDocument.stopObserving "click", @click_test_action
+    @container.ownerDocument.stopObserving 'click', this.test_active_click
 
     @active_field = false
     this.results_hide()
@@ -183,7 +183,7 @@ class @Chosen extends AbstractChosen
     @search_field.value = this.get_search_field_value()
     @search_field.focus()
 
-  test_active_click: (evt) ->
+  test_active_click: (evt) =>
     if evt.target.up('.chosen-container') is @container
       @active_field = true
     else

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -55,40 +55,40 @@ class @Chosen extends AbstractChosen
     @form_field.fire("chosen:ready", {chosen: this})
 
   register_observers: ->
-    @container.observe "touchstart", (evt) => this.container_mousedown(evt)
-    @container.observe "touchend", (evt) => this.container_mouseup(evt)
+    @container.observe 'touchstart', this.container_mousedown
+    @container.observe 'touchend', this.container_mouseup
 
-    @container.observe "mousedown", (evt) => this.container_mousedown(evt)
-    @container.observe "mouseup", (evt) => this.container_mouseup(evt)
-    @container.observe "mouseenter", (evt) => this.mouse_enter(evt)
-    @container.observe "mouseleave", (evt) => this.mouse_leave(evt)
+    @container.observe 'mousedown', this.container_mousedown
+    @container.observe 'mouseup', this.container_mouseup
+    @container.observe 'mouseenter', this.mouse_enter
+    @container.observe 'mouseleave', this.mouse_leave
 
-    @search_results.observe "mouseup", (evt) => this.search_results_mouseup(evt)
-    @search_results.observe "mouseover", (evt) => this.search_results_mouseover(evt)
-    @search_results.observe "mouseout", (evt) => this.search_results_mouseout(evt)
-    @search_results.observe "mousewheel", (evt) => this.search_results_mousewheel(evt)
-    @search_results.observe "DOMMouseScroll", (evt) => this.search_results_mousewheel(evt)
+    @search_results.observe 'mouseup', this.search_results_mouseup
+    @search_results.observe 'mouseover', this.search_results_mouseover
+    @search_results.observe 'mouseout', this.search_results_mouseout
+    @search_results.observe 'mousewheel', this.search_results_mousewheel
+    @search_results.observe 'DOMMouseScroll', this.search_results_mousewheel
 
-    @search_results.observe "touchstart", (evt) => this.search_results_touchstart(evt)
-    @search_results.observe "touchmove", (evt) => this.search_results_touchmove(evt)
-    @search_results.observe "touchend", (evt) => this.search_results_touchend(evt)
+    @search_results.observe 'touchstart', this.search_results_touchstart
+    @search_results.observe 'touchmove', this.search_results_touchmove
+    @search_results.observe 'touchend', this.search_results_touchend
 
-    @form_field.observe "chosen:updated", (evt) => this.results_update_field(evt)
-    @form_field.observe "chosen:activate", this.activate_field
-    @form_field.observe "chosen:open", (evt) => this.container_mousedown(evt)
-    @form_field.observe "chosen:close", (evt) => this.close_field(evt)
+    @form_field.observe 'chosen:updated', this.results_update_field
+    @form_field.observe 'chosen:activate', this.activate_field
+    @form_field.observe 'chosen:open', this.container_mousedown
+    @form_field.observe 'chosen:close', this.close_field
 
-    @search_field.observe "blur", (evt) => this.input_blur(evt)
-    @search_field.observe "keyup", (evt) => this.keyup_checker(evt)
-    @search_field.observe "keydown", (evt) => this.keydown_checker(evt)
-    @search_field.observe "focus", (evt) => this.input_focus(evt)
-    @search_field.observe "cut", (evt) => this.clipboard_event_checker(evt)
-    @search_field.observe "paste", (evt) => this.clipboard_event_checker(evt)
+    @search_field.observe 'blur', this.input_blur
+    @search_field.observe 'keyup', this.keyup_checker
+    @search_field.observe 'keydown', this.keydown_checker
+    @search_field.observe 'focus', this.input_focus
+    @search_field.observe 'cut', this.clipboard_event_checker
+    @search_field.observe 'paste', this.clipboard_event_checker
 
     if @is_multiple
-      @search_choices.observe "click", (evt) => this.choices_click(evt)
+      @search_choices.observe 'click', this.choices_click
     else
-      @container.observe "click", (evt) => evt.preventDefault() # gobble click of anchor
+      @container.observe 'click', (evt) => evt.preventDefault() # gobble click of anchor
 
   destroy: ->
     @container.ownerDocument.stopObserving 'click', this.test_active_click
@@ -132,7 +132,7 @@ class @Chosen extends AbstractChosen
     else unless @is_multiple
       @selected_item.observe 'focus', this.activate_field
 
-  container_mousedown: (evt) ->
+  container_mousedown: (evt) =>
     return if @is_disabled
 
     if evt and evt.type in ['mousedown', 'touchstart'] and not @results_showing
@@ -148,10 +148,10 @@ class @Chosen extends AbstractChosen
 
       this.activate_field()
 
-  container_mouseup: (evt) ->
+  container_mouseup: (evt) =>
     this.results_reset(evt) if evt.target.nodeName is "ABBR" and not @is_disabled
 
-  search_results_mousewheel: (evt) ->
+  search_results_mousewheel: (evt) =>
     delta = evt.deltaY or -evt.wheelDelta or evt.detail
     if delta?
       evt.preventDefault()
@@ -161,7 +161,7 @@ class @Chosen extends AbstractChosen
   blur_test: ->
     this.close_field() if not @active_field and @container.hasClassName("chosen-container-active")
 
-  close_field: ->
+  close_field: =>
     @container.ownerDocument.stopObserving 'click', this.test_active_click
 
     @active_field = false
@@ -285,18 +285,18 @@ class @Chosen extends AbstractChosen
       @search_field.value = ""
       @search_field.removeClassName "default"
 
-  search_results_mouseup: (evt) ->
+  search_results_mouseup: (evt) =>
     target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     if target
       @result_highlight = target
       this.result_select(evt)
       @search_field.focus()
 
-  search_results_mouseover: (evt) ->
+  search_results_mouseover: (evt) =>
     target = if evt.target.hasClassName("active-result") then evt.target else evt.target.up(".active-result")
     this.result_do_highlight( target ) if target
 
-  search_results_mouseout: (evt) ->
+  search_results_mouseout: (evt) =>
     this.result_clear_highlight() if evt.target.hasClassName('active-result') or evt.target.up('.active-result')
 
   choice_build: (item) ->

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -158,7 +158,7 @@ class @Chosen extends AbstractChosen
       delta = delta * 40 if evt.type is 'DOMMouseScroll'
       @search_results.scrollTop = delta + @search_results.scrollTop
 
-  blur_test: (evt) ->
+  blur_test: ->
     this.close_field() if not @active_field and @container.hasClassName("chosen-container-active")
 
   close_field: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -53,16 +53,16 @@ class AbstractChosen
     else
       item.html
 
-  mouse_enter: -> @mouse_on_container = true
-  mouse_leave: -> @mouse_on_container = false
+  mouse_enter: => @mouse_on_container = true
+  mouse_leave: => @mouse_on_container = false
 
-  input_focus: ->
+  input_focus: =>
     if @is_multiple
-      setTimeout (=> this.container_mousedown()), 50 unless @active_field
+      setTimeout (this.container_mousedown), 50 unless @active_field
     else
       @activate_field() unless @active_field
 
-  input_blur: ->
+  input_blur: =>
     if not @mouse_on_container
       @active_field = false
       setTimeout (=> this.blur_test()), 100
@@ -134,7 +134,7 @@ class AbstractChosen
 
     this.outerHTML(group_el)
 
-  results_update_field: ->
+  results_update_field: =>
     this.set_default_text()
     this.results_reset_cleanup() if not @is_multiple
     this.result_clear_highlight()
@@ -239,11 +239,11 @@ class AbstractChosen
 
     return @selected_option_count
 
-  choices_click: (evt) ->
+  choices_click: (evt) =>
     evt.preventDefault()
     this.results_show() unless @results_showing or @is_disabled
 
-  keydown_checker: (evt) ->
+  keydown_checker: (evt) =>
     stroke = evt.which ? evt.keyCode
     this.search_field_scale()
 
@@ -275,7 +275,7 @@ class AbstractChosen
         this.keydown_arrow()
         break
 
-  keyup_checker: (evt) ->
+  keyup_checker: (evt) =>
     stroke = evt.which ? evt.keyCode
     this.search_field_scale()
 
@@ -300,7 +300,7 @@ class AbstractChosen
         this.results_search()
         break
 
-  clipboard_event_checker: ->
+  clipboard_event_checker: =>
     return if @is_disabled
     setTimeout (=> this.results_search()), 50
 
@@ -314,15 +314,15 @@ class AbstractChosen
 
     return true
 
-  search_results_touchstart: (evt) ->
+  search_results_touchstart: (evt) =>
     @touch_started = true
     this.search_results_mouseover(evt)
 
-  search_results_touchmove: (evt) ->
+  search_results_touchmove: (evt) =>
     @touch_started = false
     this.search_results_mouseout(evt)
 
-  search_results_touchend: (evt) ->
+  search_results_touchend: (evt) =>
     this.search_results_mouseup(evt) if @touch_started
 
   outerHTML: (element) ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -15,7 +15,6 @@ class AbstractChosen
 
   set_default_values: ->
     @click_test_action = (evt) => this.test_active_click(evt)
-    @activate_action = (evt) => this.activate_field(evt)
     @active_field = false
     @mouse_on_container = false
     @results_showing = false

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -56,13 +56,13 @@ class AbstractChosen
   mouse_enter: -> @mouse_on_container = true
   mouse_leave: -> @mouse_on_container = false
 
-  input_focus: (evt) ->
+  input_focus: ->
     if @is_multiple
       setTimeout (=> this.container_mousedown()), 50 unless @active_field
     else
       @activate_field() unless @active_field
 
-  input_blur: (evt) ->
+  input_blur: ->
     if not @mouse_on_container
       @active_field = false
       setTimeout (=> this.blur_test()), 100
@@ -151,7 +151,7 @@ class AbstractChosen
     else
       this.results_show()
 
-  results_search: (evt) ->
+  results_search: ->
     if @results_showing
       this.winnow_results()
     else
@@ -300,7 +300,7 @@ class AbstractChosen
         this.results_search()
         break
 
-  clipboard_event_checker: (evt) ->
+  clipboard_event_checker: ->
     return if @is_disabled
     setTimeout (=> this.results_search()), 50
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -14,7 +14,6 @@ class AbstractChosen
     this.on_ready()
 
   set_default_values: ->
-    @click_test_action = (evt) => this.test_active_click(evt)
     @active_field = false
     @mouse_on_container = false
     @results_showing = false


### PR DESCRIPTION
- `search_field_disabled` has now less code duplication
- set tabindex on original variable instead of through the jQuery instance
- clean up some functions unused arguments
- replace custom function scoping with fat arrow functions at their definitions  
  So instead of:
  
  ``` coffeescript
  some_method: (evt) ->
    # ...
  
  $('.el').bind 'click', (evt) => this.some_method(evt)
  ```
  
  It's now:
  
  ``` coffeescript
  some_method: (evt) =>
    # ...
  
  $('.el').bind 'click', this.some_method
  ```
  
  It might be necessary to restore some of the `return` statements at the end of the functions, although I have not seen issue yet without them.
