### PR TITLE
Fixed bug in 'destroy'

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -104,6 +104,7 @@ class Chosen extends AbstractChosen
       @container.bind 'click.chosen', (evt) -> evt.preventDefault(); return # gobble click of anchor
 
   destroy: ->
+    @disable_search = true
     $(@container[0].ownerDocument).unbind 'click.chosen', @click_test_action
     @form_field_label.unbind 'click.chosen' if @form_field_label.length > 0
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -86,6 +86,7 @@ class @Chosen extends AbstractChosen
       @container.observe "click", (evt) => evt.preventDefault() # gobble click of anchor
 
   destroy: ->
+    @disable_search = true
     @container.ownerDocument.stopObserving "click", @click_test_action
 
     for event in ['chosen:updated', 'chosen:activate', 'chosen:open', 'chosen:close']


### PR DESCRIPTION
When destroying a field, results_build() is called but breaks on
@form_field.options.length as  @form_field.options is undefined.
The simplest fix is to set @disable_search on destroy which matters
not as the instance is being destroyed.
