### PR TITLE
Implement the ability to search with true regexes

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -36,6 +36,7 @@ class AbstractChosen
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
     @case_sensitive_search = @options.case_sensitive_search || false
     @hide_results_on_select = if @options.hide_results_on_select? then @options.hide_results_on_select else true
+    @escape_special_characters = true
 
   set_default_text: ->
     if @form_field.getAttribute("data-placeholder")
@@ -165,7 +166,10 @@ class AbstractChosen
     results = 0
 
     searchText = this.get_search_text()
-    escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+    if @escape_special_characters
+      escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+    else
+      escapedSearchText = searchText
     regex = this.get_search_regex(escapedSearchText)
     highlightRegex = this.get_highlight_regex(escapedSearchText)
 

--- a/public/options.html
+++ b/public/options.html
@@ -138,6 +138,13 @@
           </td>
         </tr>
         <tr>
+          <td>escape_special_characters</td>
+          <td>true</td>
+          <td>
+              <p>By default Chosen's search will escape any special characters. Setting this option to <code class="language-javascript">false</code> will allow the user to entire a javascript regex eg: <code>foo.*bar</code> will now match <code>foobazbar</code></p>
+          </td>
+        </tr>
+        <tr>
           <td>rtl</td>
           <td>false</td>
           <td>


### PR DESCRIPTION
Many times users want the ability to search via regex instead of simply searching for literal strings with special characters. This PR implements a new option flag "escape_special_characters" which is defaulted to true to match old behavior. Docs and coffeescript updated and pass grunt