### PR TITLE
Replace deprecated CSS clip property

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -20,10 +20,10 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     border-top: 0;
     background: #fff;
     box-shadow: 0 4px 5px rgba(#000,.15);
-    clip: rect(0,0,0,0);
+    display: none;
   }
   &.chosen-with-drop .chosen-drop {
-    clip: auto;
+    display: block;
   }
   a{
     cursor: pointer;
@@ -136,8 +136,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     background-clip: padding-box;
   }
   &.chosen-container-single-nosearch .chosen-search {
-    position: absolute;
-    clip: rect(0,0,0,0);
+    display: none;
   }
 }
 /* @end */


### PR DESCRIPTION
### Summary

Previously, chosen used CSS clip property to hide the dropdown. There are two reasons for this PR to replace it. 

1. CSS clip property is deprecated. [MDN CSS clip](https://developer.mozilla.org/en/docs/Web/CSS/clip)
2. In IE9/10 the clip property causes the dropdown does not hide properly. 

This change has been tested in a big web application.

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [x] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [x] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.