### PR TITLE
Fix match highlighting, if multi-byte character is next to a word boundary

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -193,7 +193,7 @@ class AbstractChosen
 
           if option.search_match
             if searchText.length
-              startpos = option.search_text.search highlightRegex
+              startpos = option.search_text.indexOf highlightRegex.exec(option.search_text)[1]
               text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
               option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
 
@@ -217,9 +217,9 @@ class AbstractChosen
     new RegExp(regex_anchor + escaped_search_string, regex_flag)
 
   get_highlight_regex: (escaped_search_string) ->
-    regex_anchor = if @search_contains then "" else "\\b"
+    regex_anchor = if @search_contains then "" else "(?:^|\\s)"
     regex_flag = if @case_sensitive_search then "" else "i"
-    new RegExp(regex_anchor + escaped_search_string, regex_flag)
+    new RegExp(regex_anchor + "(" + escaped_search_string + ")", regex_flag)
 
   search_string_match: (search_string, regex) ->
     if regex.test search_string


### PR DESCRIPTION
## Before
![old](https://cloud.githubusercontent.com/assets/918599/25072118/1c09041e-22d0-11e7-94db-d119a11b6001.png)

## After
![new](https://cloud.githubusercontent.com/assets/918599/25072121/2460daf6-22d0-11e7-9b42-eeeed56a2275.png)

## Explanation

Hi, I made some changes to the highlighting regex so that it would for search patterns, where the first character is non-ASCII (e.g. "š").

Previously, for patterns such as `š` chosen would find the correct options (e.g. `foo & šoo`), but the highlighting code would cause the options to be rendered as a single character (e.g. `f`).

The solution is not to use the `\b` (only works for ASCII characters) and explicitly check for either beginning of a string or a whitespace character. I then had to use capturing groups + `String.prototype.indexOf`, because the whitespace character is also included in the entire matched string.

More details can be found [here](http://stackoverflow.com/a/10590516) and [here](http://stackoverflow.com/a/2449892).