### PR TITLE
Fix html entity in search results

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -420,7 +420,7 @@ class Chosen extends AbstractChosen
     @search_field.val()
 
   get_search_text: ->
-    this.escape_html $.trim(this.get_search_field_value())
+    $.trim this.get_search_field_value()
 
   escape_html: (text) ->
     $('<div/>').text(text).html()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -417,7 +417,7 @@ class @Chosen extends AbstractChosen
     @search_field.value
 
   get_search_text: ->
-    this.escape_html this.get_search_field_value().strip()
+    this.get_search_field_value().strip()
 
   escape_html: (text) ->
     text.escapeHTML()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -185,7 +185,7 @@ class AbstractChosen
           results += 1 if results_group.active_options is 0 and results_group.search_match
           results_group.active_options += 1
 
-        option.search_text = if option.group then option.label else option.html
+        option.search_text = if option.group then option.label else option.text
 
         unless option.group and not @group_search
           search_match = this.search_string_match(option.search_text, regex)
@@ -193,11 +193,14 @@ class AbstractChosen
 
           results += 1 if option.search_match and not option.group
 
+
           if option.search_match
             if searchText.length
               startpos = search_match.index
-              text = option.search_text.substr(0, startpos + searchText.length) + '</em>' + option.search_text.substr(startpos + searchText.length)
-              option.search_text = text.substr(0, startpos) + '<em>' + text.substr(startpos)
+              prefix = option.search_text.slice(0, startpos)
+              fix    = option.search_text.slice(startpos, startpos + query.length)
+              suffix = option.search_text.slice(startpos + query.length)
+              option.search_text = "#{this.escape_html(prefix)}<em>#{this.escape_html(fix)}</em>#{this.escape_html(suffix)}"
 
             results_group.group_match = true if results_group?
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -116,7 +116,7 @@ class AbstractChosen
     option_el.className = classes.join(" ")
     option_el.style.cssText = option.style
     option_el.setAttribute("data-option-array-index", option.array_index)
-    option_el.innerHTML = option.search_text
+    option_el.innerHTML = option.highlighted_html or option.html
     option_el.title = option.title if option.title
 
     this.outerHTML(option_el)
@@ -131,7 +131,7 @@ class AbstractChosen
 
     group_el = document.createElement("li")
     group_el.className = classes.join(" ")
-    group_el.innerHTML = group.search_text
+    group_el.innerHTML = group.highlighted_html or group.label
     group_el.title = group.title if group.title
 
     this.outerHTML(group_el)
@@ -173,6 +173,7 @@ class AbstractChosen
       option.search_match = false
       results_group = null
       search_match = null
+      option.highlighted_html = ''
 
       if this.include_option_in_results(option)
 
@@ -200,7 +201,7 @@ class AbstractChosen
               prefix = option.search_text.slice(0, startpos)
               fix    = option.search_text.slice(startpos, startpos + query.length)
               suffix = option.search_text.slice(startpos + query.length)
-              option.search_text = "#{this.escape_html(prefix)}<em>#{this.escape_html(fix)}</em>#{this.escape_html(suffix)}"
+              option.highlighted_html = "#{this.escape_html(prefix)}<em>#{this.escape_html(fix)}</em>#{this.escape_html(suffix)}"
 
             results_group.group_match = true if results_group?
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -186,21 +186,20 @@ class AbstractChosen
           results += 1 if results_group.active_options is 0 and results_group.search_match
           results_group.active_options += 1
 
-        option.search_text = if option.group then option.label else option.text
+        text = if option.group then option.label else option.text
 
         unless option.group and not @group_search
-          search_match = this.search_string_match(option.search_text, regex)
+          search_match = this.search_string_match(text, regex)
           option.search_match = search_match?
 
           results += 1 if option.search_match and not option.group
 
-
           if option.search_match
             if query.length
               startpos = search_match.index
-              prefix = option.search_text.slice(0, startpos)
-              fix    = option.search_text.slice(startpos, startpos + query.length)
-              suffix = option.search_text.slice(startpos + query.length)
+              prefix = text.slice(0, startpos)
+              fix    = text.slice(startpos, startpos + query.length)
+              suffix = text.slice(startpos + query.length)
               option.highlighted_html = "#{this.escape_html(prefix)}<em>#{this.escape_html(fix)}</em>#{this.escape_html(suffix)}"
 
             results_group.group_match = true if results_group?

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -164,9 +164,9 @@ class AbstractChosen
 
     results = 0
 
-    searchText = this.get_search_text()
-    escapedSearchText = searchText.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
-    regex = this.get_search_regex(escapedSearchText)
+    query = this.get_search_text()
+    escapedQuery = query.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")
+    regex = this.get_search_regex(escapedQuery)
 
     for option in @results_data
 
@@ -195,7 +195,7 @@ class AbstractChosen
 
 
           if option.search_match
-            if searchText.length
+            if query.length
               startpos = search_match.index
               prefix = option.search_text.slice(0, startpos)
               fix    = option.search_text.slice(startpos, startpos + query.length)
@@ -209,9 +209,9 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
-    if results < 1 and searchText.length
+    if results < 1 and query.length
       this.update_results_content ""
-      this.no_results searchText
+      this.no_results query
     else
       this.update_results_content this.results_option_build()
       this.winnow_results_set_highlight()

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -1,0 +1,28 @@
+describe "Searching", ->
+  it "should not match the actual text of HTML entities", ->
+    tmpl = "
+      <select data-placeholder='Choose an HTML Entity...'>
+        <option value=''></option>
+        <option value='This & That'>This &amp; That</option>
+        <option value='This < That'>This &lt; That</option>
+      </select>
+    "
+
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+    select.chosen({search_contains: true})
+
+    container = div.find(".chosen-container")
+    container.trigger("mousedown") # open the drop
+
+    # Both options should be active
+    results = div.find(".active-result")
+    expect(results.size()).toBe(2)
+
+    # Search for the html entity by name
+    search_field = div.find(".chosen-search input").first()
+    search_field.val("mp")
+    search_field.trigger("keyup")
+
+    results = div.find(".active-result")
+    expect(results.size()).toBe(0)

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -1,0 +1,30 @@
+describe "Searching", ->
+  it "should not match the actual text of HTML entities", ->
+    tmpl = "
+      <select data-placeholder='Choose an HTML Entity...'>
+        <option value=''></option>
+        <option value='This & That'>This &amp; That</option>
+        <option value='This < That'>This &lt; That</option>
+      </select>
+    "
+
+    div = new Element('div')
+    document.body.insert(div)
+    div.update(tmpl)
+    select = div.down('select')
+    new Chosen(select, {search_contains: true})
+
+    container = div.down('.chosen-container')
+    simulant.fire(container, 'mousedown') # open the drop
+
+    # Both options should be active
+    results = div.select('.active-result')
+    expect(results.length).toBe(2)
+
+    # Search for the html entity by name
+    search_field = div.down(".chosen-search input")
+    search_field.value = "mp"
+    simulant.fire(search_field, 'keyup')
+
+    results = div.select(".active-result")
+    expect(results.length).toBe(0)


### PR DESCRIPTION
Don't search escaped HTML text

Before this change, if you tried to search for "&" to match "Stuff & Nonsense", what we would do is html-escape _both_ things and compare the escaped strings.

This works fine in the case where you just type "&". However, if you type "mp", that will match the html entity "&amp;" in the middle of the html-escaped text we're comparing it to. Which is incorrect.

Additionally, we highlight our "matched" result. When we do, we break up the entity so that the resulting HTML looks like:

    Stuff &a<em>mp</em>; Nonsense

And you get to see what basically looks like garbage on the screen:

![screen garbage](https://camo.githubusercontent.com/b5e384f3f622f3560739c287c481e05a7b0668af/68747470733a2f2f646c2e64726f70626f7875736572636f6e74656e742e636f6d2f7370612f7470786279757478626b747069347a2f6c7566336c7835792e706e67)

The meat of this PR and this PR description comes from [this commit](https://github.com/harvesthq/chosen/commit/0adf2d5bf275dcbdfd72185959a4782158fe36a5). The subsequent commits are just refactorings and tidyings.

PR made in a pairing session with @braddunbar.