### PR TITLE
Clear search input value, reset results when using hide_results_on_select option.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -366,13 +366,16 @@ class Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = null
+      @search_field.val("")
 
       if @is_multiple
         this.choice_build item
       else
         this.single_set_selected_text(this.choice_label(item))
 
-      unless @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
+      if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
+        this.winnow_results()
+      else
         this.results_hide()
         this.show_search_field_default()
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -364,13 +364,16 @@ class @Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = null
+      @search_field.value = ""
 
       if @is_multiple
         this.choice_build item
       else
         this.single_set_selected_text(this.choice_label(item))
 
-      unless @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
+      if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
+        this.winnow_results()
+      else
         this.results_hide()
         this.show_search_field_default()
 


### PR DESCRIPTION
@harvesthq/chosen-developers 

This PR affects mutiple-select Chosen when using the `hide_results_on_select: false` option introduced in #2687, and fixes #2809.

When `hide_results_on_select: true` (the default), `show_search_field_default()` is called which clears the search input and the results are hidden (which then are re-rendered when displaying again). Great! 

However, when `hide_results_on_select: false` is set, those are not called — leaving the text in the search input as well as not re-rendering the results list (the cause of #2809). Here‘s a reproduction in the Chosen docs (changed to pass `hide_results_on_select: false`) which makes it a lot easier to follow: 

![screencast of issue described above](https://cl.ly/461p011A1s0P/Screen%20Recording%202017-08-22%20at%2011.30%20AM.gif)

In the demo above, the input should be cleared (“alan” should no longer be typed in Chosen after selecting the result).

If we additionally pass `display_selected_options: false`, we can exactly reproduce #2809, demonstrating that we’re not correctly re-rendering the list of available options:

![screencast of issue 2809](https://cl.ly/3l2F0b2e2P2M/Screen%20Recording%202017-08-22%20at%2011.32%20AM.gif)

In the demo immediately above, the input should be cleared (“alan” should no longer be typed in Chosen) and the results list should immediately not contain the item anymore (rather than having to re-filter to see the item disappear).

The fix is relatively easy — simply clear the search input value, and re-winnow results when the results list is not immediately hidden — which is what is done in this PR.

Let me know if you have any thoughts or questions, I’d be happy to explain further! :heart: