### PR TITLE
Fix Chosen for non-ASCII languages.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -217,7 +217,7 @@ class AbstractChosen
       this.winnow_results_set_highlight()
 
   get_search_regex: (escaped_search_string) ->
-    regex_string = if @search_contains then escaped_search_string else "(^|\\s)#{escaped_search_string}[^\\s]*"
+    regex_string = if @search_contains then escaped_search_string else "(^|\\s|\\b)#{escaped_search_string}[^\\s]*"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     regex_flag = if @case_sensitive_search then "" else "i"
     new RegExp(regex_string, regex_flag)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -197,7 +197,6 @@ class AbstractChosen
           if option.search_match
             if query.length
               startpos = search_match.index
-              startpos += 1 if search_match[1] # make up for lack of lookbehind operator
               prefix = text.slice(0, startpos)
               fix    = text.slice(startpos, startpos + query.length)
               suffix = text.slice(startpos + query.length)
@@ -224,7 +223,9 @@ class AbstractChosen
     new RegExp(regex_string, regex_flag)
 
   search_string_match: (search_string, regex) ->
-    regex.exec(search_string)
+    match = regex.exec(search_string)
+    match.index += 1 if !@search_contains && match?[1] # make up for lack of lookbehind operator in regex
+    match
 
   choices_count: ->
     return @selected_option_count if @selected_option_count?

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -197,7 +197,7 @@ class AbstractChosen
           if option.search_match
             if query.length
               startpos = search_match.index
-              startpos += 1 if /\s/.test(search_match[0]) # make up for lack of lookbehind operator
+              startpos += 1 if search_match[1] # make up for lack of lookbehind operator
               prefix = text.slice(0, startpos)
               fix    = text.slice(startpos, startpos + query.length)
               suffix = text.slice(startpos + query.length)
@@ -218,7 +218,7 @@ class AbstractChosen
       this.winnow_results_set_highlight()
 
   get_search_regex: (escaped_search_string) ->
-    regex_string = if @search_contains then escaped_search_string else "(?:^|\\s)#{escaped_search_string}[^\\s]*"
+    regex_string = if @search_contains then escaped_search_string else "(^|\\s)#{escaped_search_string}[^\\s]*"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     regex_flag = if @case_sensitive_search then "" else "i"
     new RegExp(regex_string, regex_flag)

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -197,6 +197,7 @@ class AbstractChosen
           if option.search_match
             if query.length
               startpos = search_match.index
+              startpos += 1 if /\s/.test(search_match[0]) # make up for lack of lookbehind operator
               prefix = text.slice(0, startpos)
               fix    = text.slice(startpos, startpos + query.length)
               suffix = text.slice(startpos + query.length)
@@ -217,7 +218,7 @@ class AbstractChosen
       this.winnow_results_set_highlight()
 
   get_search_regex: (escaped_search_string) ->
-    regex_string = if @search_contains then escaped_search_string else "\\b#{escaped_search_string}\\w*\\b"
+    regex_string = if @search_contains then escaped_search_string else "(?:^|\\s)#{escaped_search_string}[^\\s]*"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     regex_flag = if @case_sensitive_search then "" else "i"
     new RegExp(regex_string, regex_flag)

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -26,3 +26,144 @@ describe "Searching", ->
 
     results = div.find(".active-result")
     expect(results.length).toBe(0)
+
+  it "matches in non-ascii languages like Chinese when selecting a single item", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(12)
+
+    search_field = div.find(".chosen-search-input").first()
+    search_field.val("一")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result")[0].innerHTML).toBe("<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting a single item with search_contains", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    div.find("select").chosen({search_contains: true})
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(12)
+
+    search_field = div.find(".chosen-search-input").first()
+    search_field.val("一")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(2)
+    expect(div.find(".active-result")[0].innerHTML).toBe("<em>一</em>")
+    expect(div.find(".active-result")[1].innerHTML).toBe("十<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting multiple items", ->
+    div = $("<div>").html("""
+      <select multiple>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(12)
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val("一")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result")[0].innerHTML).toBe("<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting multiple items with search_contains", ->
+    div = $("<div>").html("""
+      <select multiple>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    div.find("select").chosen({search_contains: true})
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(12)
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val("一")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(2)
+    expect(div.find(".active-result")[0].innerHTML).toBe("<em>一</em>")
+    expect(div.find(".active-result")[1].innerHTML).toBe("十<em>一</em>")
+
+  it "highlights results correctly when multiple words are present", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="oh hello">oh hello</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(1)
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val("h")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -167,3 +167,35 @@ describe "Searching", ->
 
     expect(div.find(".active-result").length).toBe(1)
     expect(div.find(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")
+
+  describe "respects word boundaries when not using search_contains", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="(lparen">(lparen</option>
+        <option value="&lt;langle">&lt;langle</option>
+        <option value="[lbrace">[lbrace</option>
+        <option value="{lcurly">{lcurly</option>
+        <option value="¡upsidedownbang">¡upsidedownbang</option>
+        <option value="¿upsidedownqmark">¿upsidedownqmark</option>
+        <option value=".period">.period</option>
+        <option value="-dash">-dash</option>
+        <option value='"leftquote'>"leftquote</option>
+        <option value="'leftsinglequote">'leftsinglequote</option>
+        <option value="“angledleftquote">“angledleftquote</option>
+        <option value="‘angledleftsinglequote">‘angledleftsinglequote</option>
+        <option value="«guillemet">«guillemet</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    search_field = div.find(".chosen-search-input")
+
+    div.find("option").each () ->
+      boundary_thing = this.value.slice(1)
+      it "correctly finds words that start after a(n) #{boundary_thing}", ->
+        search_field.val(boundary_thing)
+        search_field.trigger("keyup")
+        expect(div.find(".active-result").length).toBe(1)
+        expect(div.find(".active-result")[0].innerText.slice(1)).toBe(boundary_thing)

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -174,3 +174,36 @@ describe "Searching", ->
 
     expect(div.select(".active-result").length).toBe(1)
     expect(div.select(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")
+
+  describe "respects word boundaries when not using search_contains", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="(lparen">(lparen</option>
+        <option value="&lt;langle">&lt;langle</option>
+        <option value="[lbrace">[lbrace</option>
+        <option value="{lcurly">{lcurly</option>
+        <option value="¡upsidedownbang">¡upsidedownbang</option>
+        <option value="¿upsidedownqmark">¿upsidedownqmark</option>
+        <option value=".period">.period</option>
+        <option value="-dash">-dash</option>
+        <option value='"leftquote'>"leftquote</option>
+        <option value="'leftsinglequote">'leftsinglequote</option>
+        <option value="“angledleftquote">“angledleftquote</option>
+        <option value="‘angledleftsinglequote">‘angledleftsinglequote</option>
+        <option value="«guillemet">«guillemet</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    search_field = div.down(".chosen-search-input")
+
+    div.select("option").forEach (option) ->
+      boundary_thing = option.value.slice(1)
+      it "correctly finds words that start after a(n) #{boundary_thing}", ->
+        search_field.value = boundary_thing
+        simulant.fire(search_field, "keyup")
+        expect(div.select(".active-result").length).toBe(1)
+        expect(div.select(".active-result")[0].innerText.slice(1)).toBe(boundary_thing)

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -28,3 +28,149 @@ describe "Searching", ->
 
     results = div.select(".active-result")
     expect(results.length).toBe(0)
+
+  it "matches in non-ascii languages like Chinese when selecting a single item", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(12)
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "一"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.select(".active-result")[0].innerHTML).toBe("<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting a single item with search_contains", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"), {search_contains: true})
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(12)
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "一"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(2)
+    expect(div.select(".active-result")[0].innerHTML).toBe("<em>一</em>")
+    expect(div.select(".active-result")[1].innerHTML).toBe("十<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting multiple items", ->
+    div = new Element("div")
+    div.update("""
+      <select multiple>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(12)
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "一"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.select(".active-result")[0].innerHTML).toBe("<em>一</em>")
+
+  it "matches in non-ascii languages like Chinese when selecting multiple items with search_contains", ->
+    div = new Element("div")
+    div.update("""
+      <select multiple>
+        <option value="一">一</option>
+        <option value="二">二</option>
+        <option value="三">三</option>
+        <option value="四">四</option>
+        <option value="五">五</option>
+        <option value="六">六</option>
+        <option value="七">七</option>
+        <option value="八">八</option>
+        <option value="九">九</option>
+        <option value="十">十</option>
+        <option value="十一">十一</option>
+        <option value="十二">十二</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"), {search_contains: true})
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(12)
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "一"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(2)
+    expect(div.select(".active-result")[0].innerHTML).toBe("<em>一</em>")
+    expect(div.select(".active-result")[1].innerHTML).toBe("十<em>一</em>")
+
+  it "highlights results correctly when multiple words are present", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="oh hello">oh hello</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(1)
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "h"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.select(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")


### PR DESCRIPTION
@harvesthq/chosen-developers to fix #2821.

This tweaks the search regular expression for use in non-ASCII languages. The `\w` (word character) and `\b` (word boundary) characters are ASCII-only in JavaScript (even with the unicode flag set), so I attempted a “good enough” solution using `\s` (whitespace characters) to achieve a similar effect. This clearly isn’t the best, but for the test cases I imagined it seemed to work well enough. 

Is there a test case you can think of which this doesn’t work well? If so, I’ll write up a test (or you can) and we can adjust the solution.

<details><summary>I originally attempted to use unicode character ranges to better represent “word characters” — but that quickly got out of hand, resulting in a crazy regular expression which performed quite poorly — which resulted in switching to a “good enough” whitespace approach.</summary>

```
[A-Za-zªµºÀ-ÖØ-öø-ˁˆ-ˑˠ-ˤˬˮͰ-ʹͶ-ͷͺ-ͽΆΈ-ΊΌΎ-ΡΣ-ϵϷ-ҁҊ-ԣԱ-Ֆՙա-ևא-תװ-ײء-يٮ-ٯٱ-ۓەۥ-ۦۮ-ۯۺ-ۼۿܐܒ-ܯݍ-ޥޱߊ-ߪߴ-ߵߺऄ-हऽॐक़-ॡॱ-ॲॻ-ॿঅ-ঌএ-ঐও-নপ-রলশ-হঽৎড়-ঢ়য়-ৡৰ-ৱਅ-ਊਏ-ਐਓ-ਨਪ-ਰਲ-ਲ਼ਵ-ਸ਼ਸ-ਹਖ਼-ੜਫ਼ੲ-ੴઅ-ઍએ-ઑઓ-નપ-રલ-ળવ-હઽૐૠ-ૡଅ-ଌଏ-ଐଓ-ନପ-ରଲ-ଳଵ-ହଽଡ଼-ଢ଼ୟ-ୡୱஃஅ-ஊஎ-ஐஒ-கங-சஜஞ-டண-தந-பம-ஹௐఅ-ఌఎ-ఐఒ-నప-ళవ-హఽౘ-ౙౠ-ౡಅ-ಌಎ-ಐಒ-ನಪ-ಳವ-ಹಽೞೠ-ೡഅ-ഌഎ-ഐഒ-നപ-ഹഽൠ-ൡൺ-ൿඅ-ඖක-නඳ-රලව-ෆก-ะา-ำเ-ๆກ-ຂຄງ-ຈຊຍດ-ທນ-ຟມ-ຣລວສ-ຫອ-ະາ-ຳຽເ-ໄໆໜ-ໝༀཀ-ཇཉ-ཬྈ-ྋက-ဪဿၐ-ၕၚ-ၝၡၥ-ၦၮ-ၰၵ-ႁႎႠ-Ⴥა-ჺჼᄀ-ᅙᅟ-ᆢᆨ-ᇹሀ-ቈቊ-ቍቐ-ቖቘቚ-ቝበ-ኈኊ-ኍነ-ኰኲ-ኵኸ-ኾዀዂ-ዅወ-ዖዘ-ጐጒ-ጕጘ-ፚᎀ-ᎏᎠ-Ᏼᐁ-ᙬᙯ-ᙶᚁ-ᚚᚠ-ᛪᜀ-ᜌᜎ-ᜑᜠ-ᜱᝀ-ᝑᝠ-ᝬᝮ-ᝰក-ឳៗៜᠠ-ᡷᢀ-ᢨᢪᤀ-ᤜᥐ-ᥭᥰ-ᥴᦀ-ᦩᧁ-ᧇᨀ-ᨖᬅ-ᬳᭅ-ᭋᮃ-ᮠᮮ-ᮯᰀ-ᰣᱍ-ᱏᱚ-ᱽᴀ-ᶿḀ-ἕἘ-Ἕἠ-ὅὈ-Ὅὐ-ὗὙὛὝὟ-ώᾀ-ᾴᾶ-ᾼιῂ-ῄῆ-ῌῐ-ΐῖ-Ίῠ-Ῥῲ-ῴῶ-ῼⁱⁿₐ-ₔℂℇℊ-ℓℕℙ-ℝℤΩℨK-ℭℯ-ℹℼ-ℿⅅ-ⅉⅎↃ-ↄⰀ-Ⱞⰰ-ⱞⱠ-Ɐⱱ-ⱽⲀ-ⳤⴀ-ⴥⴰ-ⵥⵯⶀ-ⶖⶠ-ⶦⶨ-ⶮⶰ-ⶶⶸ-ⶾⷀ-ⷆⷈ-ⷎⷐ-ⷖⷘ-ⷞⸯ々-〆〱-〵〻-〼ぁ-ゖゝ-ゟァ-ヺー-ヿㄅ-ㄭㄱ-ㆎㆠ-ㆷㇰ-ㇿ㐀-䶵一-鿃ꀀ-ꒌꔀ-ꘌꘐ-ꘟꘪ-ꘫꙀ-ꙟꙢ-ꙮꙿ-ꚗꜗ-ꜟꜢ-ꞈꞋ-ꞌꟻ-ꠁꠃ-ꠅꠇ-ꠊꠌ-ꠢꡀ-ꡳꢂ-ꢳꤊ-ꤥꤰ-ꥆꨀ-ꨨꩀ-ꩂꩄ-ꩋ가-힣豈-鶴侮-頻並-龎ﬀ-ﬆﬓ-ﬗיִײַ-ﬨשׁ-זּטּ-לּמּנּ-סּףּ-פּצּ-ﮱﯓ-ﴽﵐ-ﶏﶒ-ﷇﷰ-ﷻﹰ-ﹴﹶ-ﻼＡ-Ｚａ-ｚｦ-ﾾￂ-ￇￊ-ￏￒ-ￗￚ-ￜ]|[\ud840-\ud868][\udc00-\udfff]|\ud800[\udc00-\udc0b\udc0d-\udc26\udc28-\udc3a\udc3c-\udc3d\udc3f-\udc4d\udc50-\udc5d\udc80-\udcfa\ude80-\ude9c\udea0-\uded0\udf00-\udf1e\udf30-\udf40\udf42-\udf49\udf80-\udf9d\udfa0-\udfc3\udfc8-\udfcf]|\ud801[\udc00-\udc9d]|\ud802[\udc00-\udc05\udc08\udc0a-\udc35\udc37-\udc38\udc3c\udc3f\udd00-\udd15\udd20-\udd39\ude00\ude10-\ude13\ude15-\ude17\ude19-\ude33]|\ud808[\udc00-\udf6e]|\ud835[\udc00-\udc54\udc56-\udc9c\udc9e-\udc9f\udca2\udca5-\udca6\udca9-\udcac\udcae-\udcb9\udcbb\udcbd-\udcc3\udcc5-\udd05\udd07-\udd0a\udd0d-\udd14\udd16-\udd1c\udd1e-\udd39\udd3b-\udd3e\udd40-\udd44\udd46\udd4a-\udd50\udd52-\udea5\udea8-\udec0\udec2-\udeda\udedc-\udefa\udefc-\udf14\udf16-\udf34\udf36-\udf4e\udf50-\udf6e\udf70-\udf88\udf8a-\udfa8\udfaa-\udfc2\udfc4-\udfcb]|\ud869[\udc00-\uded6]|\ud87e[\udc00-\ude1d]
```

</details><br>

One caveat to the whitespace approach is that we now occasionally match a whitespace character as the first character of our match. I compensated in the highlighter (and wrote a test for it) to adjust the start index when this is the case.

Would it be possible for those with experience in non-ASCII languages verify that this branch works as expected for you? I wrote the tests in Chinese, but… I can only count to 3 in Chinese, so y’all are definitely more qualified to test this.

- @ali1360 (Persian) 
- @aaltheiab2012 (Arabic) 
- @C-GM, @chengang0621 (Chinese)
- @evanre (Cyrillic) 
- @Flayter (Russian)

Here’s [this code on jsbin](https://jsbin.com/mevotacixu/edit?html,output) for quick testing — you should be able to quickly edit the HTML to adjust to your language and see if it displays/searches correctly.