### PR TITLE
Fix escaping in group names, no results message.

### DIFF
--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -3,12 +3,6 @@ class @Chosen extends AbstractChosen
   setup: ->
     @current_selectedIndex = @form_field.selectedIndex
 
-  set_default_values: ->
-    super()
-
-    # HTML Templates
-    @no_results_temp = new Template(this.get_no_results_html('#{terms}'))
-
   set_up_html: ->
     container_classes = ["chosen-container"]
     container_classes.push "chosen-container-" + (if @is_multiple then "multi" else "single")
@@ -435,7 +429,7 @@ class @Chosen extends AbstractChosen
     this.result_do_highlight do_high if do_high?
 
   no_results: (terms) ->
-    @search_results.insert @no_results_temp.evaluate( terms: terms )
+    @search_results.insert this.get_no_results_html(terms)
     @form_field.fire("chosen:no_results", {chosen: this})
 
   no_results_clear: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -356,7 +356,7 @@ class AbstractChosen
   get_no_results_html: (terms) ->
     """
       <li class="no-results">
-        #{@results_none_found} <span>#{terms}</span>
+        #{@results_none_found} <span>#{this.escape_html(terms)}</span>
       </li>
     """
 

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -15,7 +15,7 @@ class SelectParser
     @parsed.push
       array_index: group_position
       group: true
-      label: this.escapeExpression(group.label)
+      label: group.label
       title: group.title if group.title
       children: 0
       disabled: group.disabled,
@@ -46,21 +46,6 @@ class SelectParser
           options_index: @options_index
           empty: true
       @options_index += 1
-
-  escapeExpression: (text) ->
-    if not text? or text is false
-      return ""
-    unless /[\&\<\>\"\'\`]/.test(text)
-      return text
-    map =
-      "<": "&lt;"
-      ">": "&gt;"
-      '"': "&quot;"
-      "'": "&#x27;"
-      "`": "&#x60;"
-    unsafe_chars = /&(?!\w+;)|[\<\>\"\'\`]/g
-    text.replace unsafe_chars, (chr) ->
-      map[chr] || "&amp;"
 
 SelectParser.select_to_array = (select) ->
   parser = new SelectParser()

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -26,3 +26,45 @@ describe "Searching", ->
 
     results = div.find(".active-result")
     expect(results.length).toBe(0)
+
+  it "renders options correctly when they contain characters that require HTML encoding", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="A &amp; B">A &amp; B</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result").first().html()).toBe("A &amp; B")
+
+    search_field = div.find(".chosen-search-input").first()
+    search_field.val("A")
+    search_field.trigger("keyup")
+
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result").first().html()).toBe("<em>A</em> &amp; B")
+
+  it "renders optgroups correctly when they contain characters that require HTML encoding", ->
+    div = $("<div>").html("""
+      <select>
+        <optgroup label="A &amp; B">
+          <option value="Item">Item</option>
+        </optgroup>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".group-result").length).toBe(1)
+    expect(div.find(".group-result").first().html()).toBe("A &amp; B")
+
+    search_field = div.find(".chosen-search-input").first()
+    search_field.val("A")
+    search_field.trigger("keyup")
+
+    expect(div.find(".group-result").length).toBe(1)
+    expect(div.find(".group-result").first().html()).toBe("<em>A</em> &amp; B")

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -68,3 +68,26 @@ describe "Searching", ->
 
     expect(div.find(".group-result").length).toBe(1)
     expect(div.find(".group-result").first().html()).toBe("<em>A</em> &amp; B")
+
+  it "renders no results message correctly when it contains characters that require HTML encoding", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="Item">Item</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    search_field = div.find(".chosen-search-input").first()
+    search_field.val("&")
+    search_field.trigger("keyup")
+
+    expect(div.find(".no-results").length).toBe(1)
+    expect(div.find(".no-results").first().html().trim()).toBe("No results match <span>&amp;</span>")
+
+    search_field.val("&amp;")
+    search_field.trigger("keyup")
+
+    expect(div.find(".no-results").length).toBe(1)
+    expect(div.find(".no-results").first().html().trim()).toBe("No results match <span>&amp;amp;</span>")

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -72,3 +72,27 @@ describe "Searching", ->
 
     expect(div.select(".group-result").length).toBe(1)
     expect(div.down(".group-result").innerHTML).toBe("<em>A</em> &amp; B")
+
+  it "renders no results message correctly when it contains characters that require HTML encoding", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="Item">Item</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "&"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".no-results").length).toBe(1)
+    expect(div.down(".no-results").innerHTML.trim()).toBe("No results match <span>&amp;</span>")
+
+    search_field.value = "&amp;"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".no-results").length).toBe(1)
+    expect(div.down(".no-results").innerHTML.trim()).toBe("No results match <span>&amp;amp;</span>")

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -28,3 +28,47 @@ describe "Searching", ->
 
     results = div.select(".active-result")
     expect(results.length).toBe(0)
+
+  it "renders options correctly when they contain characters that require HTML encoding", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="A &amp; B">A &amp; B</option>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.down(".active-result").innerHTML).toBe("A &amp; B")
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "A"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.down(".active-result").innerHTML).toBe("<em>A</em> &amp; B")
+
+  it "renders optgroups correctly when they contain characters that require HTML encoding", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <optgroup label="A &amp; B">
+          <option value="Item">Item</option>
+        </optgroup>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".group-result").length).toBe(1)
+    expect(div.down(".group-result").innerHTML).toBe("A &amp; B")
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = "A"
+    simulant.fire(search_field, "keyup")
+
+    expect(div.select(".group-result").length).toBe(1)
+    expect(div.down(".group-result").innerHTML).toBe("<em>A</em> &amp; B")


### PR DESCRIPTION
@harvesthq/chosen-developers 

Surprisingly, I don’t think I found any issues in this repo for this one — but we’re incorrectly escaping group names and the no results message in some cases: 

- Group name is not properly escaped when it contains a highlighted search term.
- The user-entered text is never properly escaped in the no results message.

| Before this PR | After this PR | Status |
|---------------|-------------|--------|
|![image](https://user-images.githubusercontent.com/14930/29944785-c70ffd06-8e6c-11e7-92e3-c2086f14ce88.png)|![image](https://user-images.githubusercontent.com/14930/29944915-267e0116-8e6d-11e7-9b0c-6803353d0281.png)|(no issue)|
|![image](https://user-images.githubusercontent.com/14930/29944801-da73005a-8e6c-11e7-9052-756dfec0b086.png)|![image](https://user-images.githubusercontent.com/14930/29944962-5731bfaa-8e6d-11e7-8f98-86f0f3703ec7.png)|Fixed|
|![image](https://user-images.githubusercontent.com/14930/29944810-e206969c-8e6c-11e7-8f56-acc4ea83e78e.png)|![image](https://user-images.githubusercontent.com/14930/29944981-678a0de4-8e6d-11e7-95a2-5d968f9b0232.png)|(no issue)|
|![image](https://user-images.githubusercontent.com/14930/29944872-0d4c26d2-8e6d-11e7-9e1e-503068e2e00f.png)|![image](https://user-images.githubusercontent.com/14930/29944998-7c864a32-8e6d-11e7-970f-d528655a87a5.png)|Fixed|
|![image](https://user-images.githubusercontent.com/14930/29944889-1809a11c-8e6d-11e7-9ead-c802073cb2de.png)|![image](https://user-images.githubusercontent.com/14930/29945005-8768e0b8-8e6d-11e7-8cde-fd5bbd4f5a54.png)|(no issue)|

Test cases included.