### PR TITLE
Only trim input_width to container_width when calculable.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -500,9 +500,8 @@ class Chosen extends AbstractChosen
     width = div.width() + 25
     div.remove()
 
-    container_width = @container.outerWidth()
-
-    width = Math.min(container_width - 10, width)
+    if @container.is(':visible')
+      width = Math.min(@container.outerWidth() - 10, width)
 
     @search_field.width(width)
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -505,9 +505,8 @@ class @Chosen extends AbstractChosen
     width = div.measure('width') + 25
     div.remove()
 
-    container_width = @container.getWidth()
-
-    width = Math.min(container_width - 10, width)
+    if container_width = @container.getWidth()
+      width = Math.min(container_width - 10, width)
 
     @search_field.setStyle(width: width + 'px')
 


### PR DESCRIPTION
@harvesthq/chosen-developers to fix #2480.

This PR adjusts the logic used to calculate the width of the text input when in multi-select mode. 

If Chosen is not visible when initialized (it’s within a hidden container), the calculated width of Chosen’s container is `0`. This means that we’re setting the search input width to an initial value of `-10px`, which is nonsense — resulting in a fallback to it’s default width in CSS (25px). 

This, of course, is adjusted after Chosen is interacted with, since it is now visible and the container width can be correctly calculated. 

Since we don’t know when Chosen becomes visible, I propose we adjust the default width for the search input to be the full calculated width, and ignore the calculated container_width if it results in zero. The text doesn’t actually overflow outside of the container — the only downside is that a few pixels of space isn’t present. 

Here’s a GIF of Chosen (which was rendered off-screen initially) being opened and closed. Before, the width of the search input was not contained to the container, and after it is:

![screencast](https://cl.ly/0K0e2E1j3k0v/Screen%20Recording%202017-08-31%20at%2006.13%20PM.gif)

If you didn’t catch it, look for the tail end of the “a” character. This is _significantly better_ than what’s currently happening — the input is rendered at 25px wide:

|  | Before this PR | After this PR |
|--|---------------|--------------|
|Before Opening|![image](https://user-images.githubusercontent.com/14930/29947327-005b5056-8e77-11e7-844b-f24a9d42dbb4.png)|![image](https://user-images.githubusercontent.com/14930/29947267-c02591fe-8e76-11e7-8433-e9825a8d853b.png)|
|After Opening|![image](https://user-images.githubusercontent.com/14930/29947333-10d38a16-8e77-11e7-81f4-30458872f61e.png)|![image](https://user-images.githubusercontent.com/14930/29947296-dbf54438-8e76-11e7-981f-29078b87472f.png)|

