### PR TITLE
Escape optgroup label when appending to HTML.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -131,7 +131,7 @@ class AbstractChosen
 
     group_el = document.createElement("li")
     group_el.className = classes.join(" ")
-    group_el.innerHTML = group.highlighted_html or group.label
+    group_el.innerHTML = group.highlighted_html or this.escape_html(group.label)
     group_el.title = group.title if group.title
 
     this.outerHTML(group_el)

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -47,7 +47,22 @@ describe "Searching", ->
     expect(div.find(".active-result").length).toBe(1)
     expect(div.find(".active-result").first().html()).toBe("<em>A</em> &amp; B")
 
-  it "renders optgroups correctly when they contain characters that require HTML encoding", ->
+  it "renders optgroups correctly when they contain html encoded tags", ->
+    div = $("<div>").html("""
+      <select>
+        <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
+          <option value="Item">Item</option>
+        </optgroup>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    expect(div.find(".group-result").length).toBe(1)
+    expect(div.find(".group-result").first().html()).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
+
+  it "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
     div = $("<div>").html("""
       <select>
         <optgroup label="A &amp; B">

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -54,6 +54,22 @@ describe "Searching", ->
     div = new Element("div")
     div.update("""
       <select>
+        <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
+          <option value="Item">Item</option>
+        </optgroup>
+      </select>
+    """)
+
+    new Chosen(div.down("select"))
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    expect(div.select(".group-result").length).toBe(1)
+    expect(div.down(".group-result").innerHTML).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
+
+  it "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
+    div = new Element("div")
+    div.update("""
+      <select>
         <optgroup label="A &amp; B">
           <option value="Item">Item</option>
         </optgroup>


### PR DESCRIPTION
@harvesthq/chosen-developers 

Hot on the tails of the 1.8.1 release (and as a follow-up to #2879), this PR fixes a cross-site scripting vulnerability discovered when applying the 1.8.1 release to Harvest. 

When an optgroup’s label is not highlighted, we’re using the unescaped version of the `label` attribute — but we’re safe when the highlighting is added, since we’re [escaping each HTML fragment](https://github.com/harvesthq/chosen/blob/908b0bfc819ef407532c7bf289959045ea3c0b34/coffee/lib/abstract-chosen.coffee#L203) when building the highlighted string.

Included is a test which asserts HTML tags are not rendered into HTML unescaped in this case.