### PR TITLE
Extended search behaviour options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ chosen*.zip
 .grunt
 _SpecRunner.html
 spec/public
+nbproject

--- a/public/docsupport/init.js
+++ b/public/docsupport/init.js
@@ -9,3 +9,29 @@ var config = {
 for (var selector in config) {
   $(selector).chosen(config[selector]);
 }
+
+function set_search_behaviour() {
+    var options = {};
+    $("[data-search-behaviour]").each(function(){
+        var setting = $(this).data('search-behaviour');
+        options[setting] = $('[name=' + this.name + ']:checked').val();
+        var stringified = false;
+        if (options[setting] === 'true') {
+            options[setting] = true;
+        } else if (options[setting] === 'false') {
+            options[setting] = false;
+        } else if (options[setting] === 'regex_space') {
+            options[setting] = /\s/;
+        } else {
+            stringified = JSON.stringify(options[setting]);
+        }
+        code_elm = $(this).closest('div').find('> label > code');
+        code_elm.html(setting + ': ' + (stringified ? stringified : options[setting].toString()));
+        Prism.highlightElement(code_elm[0]);
+    });
+    
+    $('.chosen-select-sb').chosen("destroy").chosen(options);
+}
+$(document).on('change', "[data-search-behaviour]", set_search_behaviour);
+
+set_search_behaviour();

--- a/public/docsupport/init.proto.js
+++ b/public/docsupport/init.proto.js
@@ -14,3 +14,36 @@ document.observe('dom:loaded', function(evt) {
     });
   }
 });
+
+
+var sb_chosens = [];
+function set_search_behaviour() {
+    var options = {};
+    $$("[data-search-behaviour]").each(function(elm){
+        var setting = elm.readAttribute('data-search-behaviour');
+        options[setting] = $$('[name=' + elm.name + ']:checked')[0].value;
+        var stringified = false;
+        if (options[setting] === 'true') {
+            options[setting] = true;
+        } else if (options[setting] === 'false') {
+            options[setting] = false;
+        } else if (options[setting] === 'regex_space') {
+            options[setting] = /\s/;
+        } else {
+            stringified = JSON.stringify(options[setting]);
+        }
+        code_elm = elm.up('div').down('> label > code');
+        code_elm.update(setting + ': ' + (stringified ? stringified : options[setting].toString()));
+        Prism.highlightElement(code_elm);
+    });
+    sb_chosens.each(function(elm) {
+        elm.destroy();
+    });
+    sb_chosens = [];
+    $$('.chosen-select-sb').each(function(elm){
+        sb_chosens.push(new Chosen(elm, options));
+    });
+}
+document.on('change', "[data-search-behaviour]", set_search_behaviour);
+
+set_search_behaviour();

--- a/public/docsupport/style.css
+++ b/public/docsupport/style.css
@@ -59,7 +59,7 @@ div.side-by-side > div > em { margin-bottom: 10px; display: block; }
   visibility: hidden;
 }
 
-a { color: #F36C00; outline: none; text-decoration: none; }
+a { color: #F36C00; /*outline: none;*/ text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 ul.credits li { margin-bottom: .25em; }
@@ -84,7 +84,7 @@ i { font-style: italic; }
   font-weight: 500;
   height: 31px;
   line-height: 28px;
-  outline: none;
+  /*outline: none;*/
   padding: 0 13px;
   text-shadow: 0 1px 0 white;
   text-decoration: none;
@@ -160,6 +160,10 @@ i { font-style: italic; }
   background-color: #333333;
 }
 
+.docs-table {
+    margin-bottom: 2em;
+}
+
 .docs-table th, .docs-table td {
   border: 1px solid #000;
   padding: 4px 6px;
@@ -209,11 +213,39 @@ i { font-style: italic; }
 .chosen-select-no-results,
 .chosen-select-deselect,
 .chosen-select-rtl,
-.chosen-select-width {
+.chosen-select-width,
+.chosen-select-sb {
   width: 350px;
 }
 
 .jquery-version-refer {
   margin-top: 40px;
   font-style: italic;
+}
+
+.search-behaviour ul {
+  margin: .5em 1em;
+}
+.search-behaviour li {
+  margin: .5em 0;
+  list-style: none;
+  position: relative;
+}
+.search-behaviour li label > span {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: #fff;
+    border: 1px solid #eee;
+    z-index: 2;
+    padding: 4px 8px;
+    pointer-events: none;
+}
+.search-behaviour li label:hover > span {
+    display: block;
+}
+
+.search-behaviour-right > div {
+  margin-bottom: 5em;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1226,6 +1226,804 @@
           </select>
         </div>
       </div>
+      
+      <h2><a name="search-behaviour" class="anchor" href="#search-behaviour">Search behaviour</a></h2>
+      <div class="side-by-side clearfix">
+        <p>By default Chosen's search is case-insensitive and matches the exact search string starting at any "word-boundary". However the behaviour is highly customizable. You can test the effects of each setting using the options below.</p>
+        <div class="search-behaviour">
+          <div>
+            <label><code class="language-javascript">case_sensitive_search: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="case_sensitive_search" data-search-behaviour="case_sensitive_search" value="true">
+                <code class="language-javascript">true</code>
+                <span>Search is case sensitive</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="case_sensitive_search" data-search-behaviour="case_sensitive_search" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Search is case insensitive</span> - default
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_term_delimiter: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="true">
+                <code class="language-javascript">true</code>
+                <span>Split the query in terms at any whitespace. Useful for most "natural" searches like first, middle and last names. "John Smith" will match "John Doe Smith".</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Do no split the query in terms, search string must exactly match (part of) the option label, including whitespaces etc.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="*">
+                <code class="language-javascript">"*"</code>
+                <span>Use a string (fx. asterix, percentage or underscore) to split terms. Useful for simple wildcard-character search.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="regex_space">
+                <code class="language-javascript">/\s/</code> or <code class="language-javascript">new RegExp("\\s")</code>
+                <span>You can pass any parameter that works with <code>string.split()</code>.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_contains: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_contains" data-search-behaviour="search_contains" value="true">
+                <code class="language-javascript">true</code>
+                <span>Matches any part of an option - ie. equivalent to <code>search_word_boundary: ''</code> and <code>enable_split_word_search: true</code>.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_contains" data-search-behaviour="search_contains" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Matches search terms according to <code>enable_split_word_search</code> and <code>search_word_boundary</code></span> - default
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">enable_split_word_search: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="enable_split_word_search" data-search-behaviour="enable_split_word_search" value="true" checked>
+                <code class="language-javascript">true</code>
+                <span>Matches each term only at the beginning of a word - as determined by <code>search_word_boundary</code>.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="enable_split_word_search" data-search-behaviour="enable_split_word_search" value="false">
+                <code class="language-javascript">false</code>
+                <span>Matches only the beginning of the full option label. If <code>search_in_order = false</code> then the first found term must be at the beginning of the label.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_word_boundary: '^|\\b|\\s'</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|\b|\s" checked>
+                <code class="language-javascript">"^|\\b|\\s"</code>
+                <span>Uses JS RegExp's built-in word boundary to detect word beginnings as well as whitespace or the beginning of the entire label. Works great for ascii-only languages, but <strong>will</strong> erroneously detect word boundaries after letters with umlauts among many, many others.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|\s">
+                <code class="language-javascript">"^|\\s"</code>
+                <span>Only detects beginning of "words" at whitespace characters or the beginning of the entire label - where the default is flawed for non-unicode, this is flawed for parenthesis and a plethora of other special characters (which you can add if relevant).</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|[^A-zæøå\(\)]">
+                <code class="language-javascript">custom</code>
+                <span>You can use a regex refined for your language and use case to correctly detect word boundaries. <strong>Note:</strong> The example given here would be a very bad choice for any real-life implementation!</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_in_order: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_in_order" data-search-behaviour="search_in_order" value="true">
+                <code class="language-javascript">true</code>
+                <span>Only matches if search terms are found in the same order as they entered.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_in_order" data-search-behaviour="search_in_order" value="false" checked>
+                <code class="language-javascript">false</code> - default
+                <span>Matches search terms in any order.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">group_search: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="group_search" data-search-behaviour="group_search" value="true" checked>
+                <code class="language-javascript">true</code>
+                <span>Shows entire groups whose label match the search query.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="group_search" data-search-behaviour="group_search" value="false">
+                <code class="language-javascript">false</code>
+                <span>Only shows groups that contain options matching the query.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_highlight_full_match: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_highlight_full_match" data-search-behaviour="search_highlight_full_match" value="true">
+                <code class="language-javascript">true</code>
+                <span>Highlights the entire match - ie. from the first matching letter to the last.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_highlight_full_match" data-search-behaviour="search_highlight_full_match" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Highlights only the letters / terms entered</span> - default
+              </label></li>
+            </ul>
+          </div>
+        </div>
+        <div class="search-behaviour-right">
+          <div>
+            <h3>Test your settings...</h3>
+            <p>These select boxes are all updated to reflect the settings on the left.</p>
+          </div>
+          <div>
+            <em>Simple Single Select</em>
+            <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-sb" tabindex="10">
+              <option value=""></option>
+              <option>American Black Bear</option>
+              <option>Asiatic Black Bear</option>
+              <option>Brown Bear</option>
+              <option>Giant Panda</option>
+              <option>Sloth Bear</option>
+              <option>Sun Bear</option>
+              <option>Polar Bear</option>
+              <option>Spectacled Bear</option>
+            </select>
+          </div>
+          <div>
+            <em>Simple Multiple Select</em>
+            <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-sb" tabindex="11">
+              <option value=""></option>
+              <option>American Black Bear</option>
+              <option>Asiatic Black Bear</option>
+              <option>Brown Bear</option>
+              <option>Giant Panda</option>
+              <option>Sloth Bear</option>
+              <option>Sun Bear</option>
+              <option>Polar Bear</option>
+              <option>Spectacled Bear</option>
+            </select>
+          </div>
+          <div>
+            <em>Single Select with Groups</em>
+            <select data-placeholder="Your Favorite Football Team" class="chosen-select-sb" tabindex="12">
+              <option value=""></option>
+              <optgroup label="NFC EAST <test>">
+                <option>Dallas Cowboys &lt;test&gt;</option>
+                <option>New York Giants</option>
+                <option>Philadelphia Eagles</option>
+                <option>Washington Redskins</option>
+              </optgroup>
+              <optgroup label="NFC NORTH">
+                <option>Chicago Bears</option>
+                <option>Detroit Lions</option>
+                <option>Green Bay Packers</option>
+                <option>Minnesota Vikings</option>
+              </optgroup>
+              <optgroup label="NFC SOUTH">
+                <option>Atlanta Falcons</option>
+                <option>Carolina Panthers</option>
+                <option>New Orleans Saints</option>
+                <option>Tampa Bay Buccaneers</option>
+              </optgroup>
+              <optgroup label="NFC WEST">
+                <option>Arizona Cardinals</option>
+                <option>St. Louis Rams</option>
+                <option>San Francisco 49ers</option>
+                <option>Seattle Seahawks</option>
+              </optgroup>
+              <optgroup label="AFC EAST">
+                <option>Buffalo Bills</option>
+                <option>Miami Dolphins</option>
+                <option>New England Patriots</option>
+                <option>New York Jets</option>
+              </optgroup>
+              <optgroup label="AFC NORTH">
+                <option>Baltimore Ravens</option>
+                <option>Cincinnati Bengals</option>
+                <option>Cleveland Browns</option>
+                <option>Pittsburgh Steelers</option>
+              </optgroup>
+              <optgroup label="AFC SOUTH">
+                <option>Houston Texans</option>
+                <option>Indianapolis Colts</option>
+                <option>Jacksonville Jaguars</option>
+                <option>Tennessee Titans</option>
+              </optgroup>
+              <optgroup label="AFC WEST">
+                <option>Denver Broncos</option>
+                <option>Kansas City Chiefs</option>
+                <option>Oakland Raiders</option>
+                <option>San Diego Chargers</option>
+              </optgroup>
+            </select>
+          </div>
+          <div>
+            <em>Multiple Select with Groups</em>
+            <select data-placeholder="Your Favorite Football Team" class="chosen-select-sb" multiple tabindex="13">
+              <option value=""></option>
+              <optgroup label="NFC EAST">
+                <option>Dallas Cowboys</option>
+                <option>New York Giants</option>
+                <option>Philadelphia Eagles</option>
+                <option>Washington Redskins</option>
+              </optgroup>
+              <optgroup label="NFC NORTH">
+                <option>Chicago Bears</option>
+                <option>Detroit Lions</option>
+                <option>Green Bay Packers</option>
+                <option>Minnesota Vikings</option>
+              </optgroup>
+              <optgroup label="NFC SOUTH">
+                <option>Atlanta Falcons</option>
+                <option>Carolina Panthers</option>
+                <option>New Orleans Saints</option>
+                <option>Tampa Bay Buccaneers</option>
+              </optgroup>
+              <optgroup label="NFC WEST">
+                <option>Arizona Cardinals</option>
+                <option>St. Louis Rams</option>
+                <option>San Francisco 49ers</option>
+                <option>Seattle Seahawks</option>
+              </optgroup>
+              <optgroup label="AFC EAST">
+                <option>Buffalo Bills</option>
+                <option>Miami Dolphins</option>
+                <option>New England Patriots</option>
+                <option>New York Jets</option>
+              </optgroup>
+              <optgroup label="AFC NORTH">
+                <option>Baltimore Ravens</option>
+                <option>Cincinnati Bengals</option>
+                <option>Cleveland Browns</option>
+                <option>Pittsburgh Steelers</option>
+              </optgroup>
+              <optgroup label="AFC SOUTH">
+                <option>Houston Texans</option>
+                <option>Indianapolis Colts</option>
+                <option>Jacksonville Jaguars</option>
+                <option>Tennessee Titans</option>
+              </optgroup>
+              <optgroup label="AFC WEST">
+                <option>Denver Broncos</option>
+                <option>Kansas City Chiefs</option>
+                <option>Oakland Raiders</option>
+                <option>San Diego Chargers</option>
+              </optgroup>
+            </select>
+          </div>
+          <div>
+            <em>Single Select Country</em>
+            <select data-placeholder="Choose a Country..." class="chosen-select-sb" tabindex="14">
+              <option value=""></option>
+              <option value="United States">United States</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="Afghanistan">Afghanistan</option>
+              <option value="Aland Islands">Aland Islands</option>
+              <option value="Albania">Albania</option>
+              <option value="Algeria">Algeria</option>
+              <option value="American Samoa">American Samoa</option>
+              <option value="Andorra">Andorra</option>
+              <option value="Angola">Angola</option>
+              <option value="Anguilla">Anguilla</option>
+              <option value="Antarctica">Antarctica</option>
+              <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+              <option value="Argentina">Argentina</option>
+              <option value="Armenia">Armenia</option>
+              <option value="Aruba">Aruba</option>
+              <option value="Australia">Australia</option>
+              <option value="Austria">Austria</option>
+              <option value="Azerbaijan">Azerbaijan</option>
+              <option value="Bahamas">Bahamas</option>
+              <option value="Bahrain">Bahrain</option>
+              <option value="Bangladesh">Bangladesh</option>
+              <option value="Barbados">Barbados</option>
+              <option value="Belarus">Belarus</option>
+              <option value="Belgium">Belgium</option>
+              <option value="Belize">Belize</option>
+              <option value="Benin">Benin</option>
+              <option value="Bermuda">Bermuda</option>
+              <option value="Bhutan">Bhutan</option>
+              <option value="Bolivia, Plurinational State of">Bolivia, Plurinational State of</option>
+              <option value="Bonaire, Sint Eustatius and Saba">Bonaire, Sint Eustatius and Saba</option>
+              <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+              <option value="Botswana">Botswana</option>
+              <option value="Bouvet Island">Bouvet Island</option>
+              <option value="Brazil">Brazil</option>
+              <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+              <option value="Brunei Darussalam">Brunei Darussalam</option>
+              <option value="Bulgaria">Bulgaria</option>
+              <option value="Burkina Faso">Burkina Faso</option>
+              <option value="Burundi">Burundi</option>
+              <option value="Cambodia">Cambodia</option>
+              <option value="Cameroon">Cameroon</option>
+              <option value="Canada">Canada</option>
+              <option value="Cape Verde">Cape Verde</option>
+              <option value="Cayman Islands">Cayman Islands</option>
+              <option value="Central African Republic">Central African Republic</option>
+              <option value="Chad">Chad</option>
+              <option value="Chile">Chile</option>
+              <option value="China">China</option>
+              <option value="Christmas Island">Christmas Island</option>
+              <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+              <option value="Colombia">Colombia</option>
+              <option value="Comoros">Comoros</option>
+              <option value="Congo">Congo</option>
+              <option value="Congo, The Democratic Republic of The">Congo, The Democratic Republic of The</option>
+              <option value="Cook Islands">Cook Islands</option>
+              <option value="Costa Rica">Costa Rica</option>
+              <option value="Cote D&apos;ivoire">Cote D'ivoire</option>
+              <option value="Croatia">Croatia</option>
+              <option value="Cuba">Cuba</option>
+              <option value="Curacao">Curacao</option>
+              <option value="Cyprus">Cyprus</option>
+              <option value="Czech Republic">Czech Republic</option>
+              <option value="Denmark">Denmark</option>
+              <option value="Djibouti">Djibouti</option>
+              <option value="Dominica">Dominica</option>
+              <option value="Dominican Republic">Dominican Republic</option>
+              <option value="Ecuador">Ecuador</option>
+              <option value="Egypt">Egypt</option>
+              <option value="El Salvador">El Salvador</option>
+              <option value="Equatorial Guinea">Equatorial Guinea</option>
+              <option value="Eritrea">Eritrea</option>
+              <option value="Estonia">Estonia</option>
+              <option value="Ethiopia">Ethiopia</option>
+              <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+              <option value="Faroe Islands">Faroe Islands</option>
+              <option value="Fiji">Fiji</option>
+              <option value="Finland">Finland</option>
+              <option value="France">France</option>
+              <option value="French Guiana">French Guiana</option>
+              <option value="French Polynesia">French Polynesia</option>
+              <option value="French Southern Territories">French Southern Territories</option>
+              <option value="Gabon">Gabon</option>
+              <option value="Gambia">Gambia</option>
+              <option value="Georgia">Georgia</option>
+              <option value="Germany">Germany</option>
+              <option value="Ghana">Ghana</option>
+              <option value="Gibraltar">Gibraltar</option>
+              <option value="Greece">Greece</option>
+              <option value="Greenland">Greenland</option>
+              <option value="Grenada">Grenada</option>
+              <option value="Guadeloupe">Guadeloupe</option>
+              <option value="Guam">Guam</option>
+              <option value="Guatemala">Guatemala</option>
+              <option value="Guernsey">Guernsey</option>
+              <option value="Guinea">Guinea</option>
+              <option value="Guinea-bissau">Guinea-bissau</option>
+              <option value="Guyana">Guyana</option>
+              <option value="Haiti">Haiti</option>
+              <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+              <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+              <option value="Honduras">Honduras</option>
+              <option value="Hong Kong">Hong Kong</option>
+              <option value="Hungary">Hungary</option>
+              <option value="Iceland">Iceland</option>
+              <option value="India">India</option>
+              <option value="Indonesia">Indonesia</option>
+              <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+              <option value="Iraq">Iraq</option>
+              <option value="Ireland">Ireland</option>
+              <option value="Isle of Man">Isle of Man</option>
+              <option value="Israel">Israel</option>
+              <option value="Italy">Italy</option>
+              <option value="Jamaica">Jamaica</option>
+              <option value="Japan">Japan</option>
+              <option value="Jersey">Jersey</option>
+              <option value="Jordan">Jordan</option>
+              <option value="Kazakhstan">Kazakhstan</option>
+              <option value="Kenya">Kenya</option>
+              <option value="Kiribati">Kiribati</option>
+              <option value="Korea, Democratic People&apos;s Republic of">Korea, Democratic People's Republic of</option>
+              <option value="Korea, Republic of">Korea, Republic of</option>
+              <option value="Kuwait">Kuwait</option>
+              <option value="Kyrgyzstan">Kyrgyzstan</option>
+              <option value="Lao People&apos;s Democratic Republic">Lao People's Democratic Republic</option>
+              <option value="Latvia">Latvia</option>
+              <option value="Lebanon">Lebanon</option>
+              <option value="Lesotho">Lesotho</option>
+              <option value="Liberia">Liberia</option>
+              <option value="Libya">Libya</option>
+              <option value="Liechtenstein">Liechtenstein</option>
+              <option value="Lithuania">Lithuania</option>
+              <option value="Luxembourg">Luxembourg</option>
+              <option value="Macao">Macao</option>
+              <option value="Macedonia, The Former Yugoslav Republic of">Macedonia, The Former Yugoslav Republic of</option>
+              <option value="Madagascar">Madagascar</option>
+              <option value="Malawi">Malawi</option>
+              <option value="Malaysia">Malaysia</option>
+              <option value="Maldives">Maldives</option>
+              <option value="Mali">Mali</option>
+              <option value="Malta">Malta</option>
+              <option value="Marshall Islands">Marshall Islands</option>
+              <option value="Martinique">Martinique</option>
+              <option value="Mauritania">Mauritania</option>
+              <option value="Mauritius">Mauritius</option>
+              <option value="Mayotte">Mayotte</option>
+              <option value="Mexico">Mexico</option>
+              <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+              <option value="Moldova, Republic of">Moldova, Republic of</option>
+              <option value="Monaco">Monaco</option>
+              <option value="Mongolia">Mongolia</option>
+              <option value="Montenegro">Montenegro</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Morocco">Morocco</option>
+              <option value="Mozambique">Mozambique</option>
+              <option value="Myanmar">Myanmar</option>
+              <option value="Namibia">Namibia</option>
+              <option value="Nauru">Nauru</option>
+              <option value="Nepal">Nepal</option>
+              <option value="Netherlands">Netherlands</option>
+              <option value="New Caledonia">New Caledonia</option>
+              <option value="New Zealand">New Zealand</option>
+              <option value="Nicaragua">Nicaragua</option>
+              <option value="Niger">Niger</option>
+              <option value="Nigeria">Nigeria</option>
+              <option value="Niue">Niue</option>
+              <option value="Norfolk Island">Norfolk Island</option>
+              <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+              <option value="Norway">Norway</option>
+              <option value="Oman">Oman</option>
+              <option value="Pakistan">Pakistan</option>
+              <option value="Palau">Palau</option>
+              <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+              <option value="Panama">Panama</option>
+              <option value="Papua New Guinea">Papua New Guinea</option>
+              <option value="Paraguay">Paraguay</option>
+              <option value="Peru">Peru</option>
+              <option value="Philippines">Philippines</option>
+              <option value="Pitcairn">Pitcairn</option>
+              <option value="Poland">Poland</option>
+              <option value="Portugal">Portugal</option>
+              <option value="Puerto Rico">Puerto Rico</option>
+              <option value="Qatar">Qatar</option>
+              <option value="Reunion">Reunion</option>
+              <option value="Romania">Romania</option>
+              <option value="Russian Federation">Russian Federation</option>
+              <option value="Rwanda">Rwanda</option>
+              <option value="Saint Barthelemy">Saint Barthelemy</option>
+              <option value="Saint Helena, Ascension and Tristan da Cunha">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+              <option value="Saint Lucia">Saint Lucia</option>
+              <option value="Saint Martin (French part)">Saint Martin (French part)</option>
+              <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+              <option value="Saint Vincent and The Grenadines">Saint Vincent and The Grenadines</option>
+              <option value="Samoa">Samoa</option>
+              <option value="San Marino">San Marino</option>
+              <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="Senegal">Senegal</option>
+              <option value="Serbia">Serbia</option>
+              <option value="Seychelles">Seychelles</option>
+              <option value="Sierra Leone">Sierra Leone</option>
+              <option value="Singapore">Singapore</option>
+              <option value="Sint Maarten (Dutch part)">Sint Maarten (Dutch part)</option>
+              <option value="Slovakia">Slovakia</option>
+              <option value="Slovenia">Slovenia</option>
+              <option value="Solomon Islands">Solomon Islands</option>
+              <option value="Somalia">Somalia</option>
+              <option value="South Africa">South Africa</option>
+              <option value="South Georgia and The South Sandwich Islands">South Georgia and The South Sandwich Islands</option>
+              <option value="South Sudan">South Sudan</option>
+              <option value="Spain">Spain</option>
+              <option value="Sri Lanka">Sri Lanka</option>
+              <option value="Sudan">Sudan</option>
+              <option value="Suriname">Suriname</option>
+              <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+              <option value="Swaziland">Swaziland</option>
+              <option value="Sweden">Sweden</option>
+              <option value="Switzerland">Switzerland</option>
+              <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+              <option value="Taiwan, Province of China">Taiwan, Province of China</option>
+              <option value="Tajikistan">Tajikistan</option>
+              <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+              <option value="Thailand">Thailand</option>
+              <option value="Timor-leste">Timor-leste</option>
+              <option value="Togo">Togo</option>
+              <option value="Tokelau">Tokelau</option>
+              <option value="Tonga">Tonga</option>
+              <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+              <option value="Tunisia">Tunisia</option>
+              <option value="Turkey">Turkey</option>
+              <option value="Turkmenistan">Turkmenistan</option>
+              <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+              <option value="Tuvalu">Tuvalu</option>
+              <option value="Uganda">Uganda</option>
+              <option value="Ukraine">Ukraine</option>
+              <option value="United Arab Emirates">United Arab Emirates</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="United States">United States</option>
+              <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+              <option value="Uruguay">Uruguay</option>
+              <option value="Uzbekistan">Uzbekistan</option>
+              <option value="Vanuatu">Vanuatu</option>
+              <option value="Venezuela, Bolivarian Republic of">Venezuela, Bolivarian Republic of</option>
+              <option value="Viet Nam">Viet Nam</option>
+              <option value="Virgin Islands, British">Virgin Islands, British</option>
+              <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+              <option value="Wallis and Futuna">Wallis and Futuna</option>
+              <option value="Western Sahara">Western Sahara</option>
+              <option value="Yemen">Yemen</option>
+              <option value="Zambia">Zambia</option>
+              <option value="Zimbabwe">Zimbabwe</option>
+            </select>
+          </div>
+          <div>
+            <em>Country Multiple Select</em>
+            <select data-placeholder="Choose a Country..." class="chosen-select-sb" multiple tabindex="15">
+              <option value=""></option>
+              <option value="United States">United States</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="Afghanistan">Afghanistan</option>
+              <option value="Aland Islands">Aland Islands</option>
+              <option value="Albania">Albania</option>
+              <option value="Algeria">Algeria</option>
+              <option value="American Samoa">American Samoa</option>
+              <option value="Andorra">Andorra</option>
+              <option value="Angola">Angola</option>
+              <option value="Anguilla">Anguilla</option>
+              <option value="Antarctica">Antarctica</option>
+              <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+              <option value="Argentina">Argentina</option>
+              <option value="Armenia">Armenia</option>
+              <option value="Aruba">Aruba</option>
+              <option value="Australia">Australia</option>
+              <option value="Austria">Austria</option>
+              <option value="Azerbaijan">Azerbaijan</option>
+              <option value="Bahamas">Bahamas</option>
+              <option value="Bahrain">Bahrain</option>
+              <option value="Bangladesh">Bangladesh</option>
+              <option value="Barbados">Barbados</option>
+              <option value="Belarus">Belarus</option>
+              <option value="Belgium">Belgium</option>
+              <option value="Belize">Belize</option>
+              <option value="Benin">Benin</option>
+              <option value="Bermuda">Bermuda</option>
+              <option value="Bhutan">Bhutan</option>
+              <option value="Bolivia, Plurinational State of">Bolivia, Plurinational State of</option>
+              <option value="Bonaire, Sint Eustatius and Saba">Bonaire, Sint Eustatius and Saba</option>
+              <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+              <option value="Botswana">Botswana</option>
+              <option value="Bouvet Island">Bouvet Island</option>
+              <option value="Brazil">Brazil</option>
+              <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+              <option value="Brunei Darussalam">Brunei Darussalam</option>
+              <option value="Bulgaria">Bulgaria</option>
+              <option value="Burkina Faso">Burkina Faso</option>
+              <option value="Burundi">Burundi</option>
+              <option value="Cambodia">Cambodia</option>
+              <option value="Cameroon">Cameroon</option>
+              <option value="Canada">Canada</option>
+              <option value="Cape Verde">Cape Verde</option>
+              <option value="Cayman Islands">Cayman Islands</option>
+              <option value="Central African Republic">Central African Republic</option>
+              <option value="Chad">Chad</option>
+              <option value="Chile">Chile</option>
+              <option value="China">China</option>
+              <option value="Christmas Island">Christmas Island</option>
+              <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+              <option value="Colombia">Colombia</option>
+              <option value="Comoros">Comoros</option>
+              <option value="Congo">Congo</option>
+              <option value="Congo, The Democratic Republic of The">Congo, The Democratic Republic of The</option>
+              <option value="Cook Islands">Cook Islands</option>
+              <option value="Costa Rica">Costa Rica</option>
+              <option value="Cote D&apos;ivoire">Cote D'ivoire</option>
+              <option value="Croatia">Croatia</option>
+              <option value="Cuba">Cuba</option>
+              <option value="Curacao">Curacao</option>
+              <option value="Cyprus">Cyprus</option>
+              <option value="Czech Republic">Czech Republic</option>
+              <option value="Denmark">Denmark</option>
+              <option value="Djibouti">Djibouti</option>
+              <option value="Dominica">Dominica</option>
+              <option value="Dominican Republic">Dominican Republic</option>
+              <option value="Ecuador">Ecuador</option>
+              <option value="Egypt">Egypt</option>
+              <option value="El Salvador">El Salvador</option>
+              <option value="Equatorial Guinea">Equatorial Guinea</option>
+              <option value="Eritrea">Eritrea</option>
+              <option value="Estonia">Estonia</option>
+              <option value="Ethiopia">Ethiopia</option>
+              <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+              <option value="Faroe Islands">Faroe Islands</option>
+              <option value="Fiji">Fiji</option>
+              <option value="Finland">Finland</option>
+              <option value="France">France</option>
+              <option value="French Guiana">French Guiana</option>
+              <option value="French Polynesia">French Polynesia</option>
+              <option value="French Southern Territories">French Southern Territories</option>
+              <option value="Gabon">Gabon</option>
+              <option value="Gambia">Gambia</option>
+              <option value="Georgia">Georgia</option>
+              <option value="Germany">Germany</option>
+              <option value="Ghana">Ghana</option>
+              <option value="Gibraltar">Gibraltar</option>
+              <option value="Greece">Greece</option>
+              <option value="Greenland">Greenland</option>
+              <option value="Grenada">Grenada</option>
+              <option value="Guadeloupe">Guadeloupe</option>
+              <option value="Guam">Guam</option>
+              <option value="Guatemala">Guatemala</option>
+              <option value="Guernsey">Guernsey</option>
+              <option value="Guinea">Guinea</option>
+              <option value="Guinea-bissau">Guinea-bissau</option>
+              <option value="Guyana">Guyana</option>
+              <option value="Haiti">Haiti</option>
+              <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+              <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+              <option value="Honduras">Honduras</option>
+              <option value="Hong Kong">Hong Kong</option>
+              <option value="Hungary">Hungary</option>
+              <option value="Iceland">Iceland</option>
+              <option value="India">India</option>
+              <option value="Indonesia">Indonesia</option>
+              <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+              <option value="Iraq">Iraq</option>
+              <option value="Ireland">Ireland</option>
+              <option value="Isle of Man">Isle of Man</option>
+              <option value="Israel">Israel</option>
+              <option value="Italy">Italy</option>
+              <option value="Jamaica">Jamaica</option>
+              <option value="Japan">Japan</option>
+              <option value="Jersey">Jersey</option>
+              <option value="Jordan">Jordan</option>
+              <option value="Kazakhstan">Kazakhstan</option>
+              <option value="Kenya">Kenya</option>
+              <option value="Kiribati">Kiribati</option>
+              <option value="Korea, Democratic People&apos;s Republic of">Korea, Democratic People's Republic of</option>
+              <option value="Korea, Republic of">Korea, Republic of</option>
+              <option value="Kuwait">Kuwait</option>
+              <option value="Kyrgyzstan">Kyrgyzstan</option>
+              <option value="Lao People&apos;s Democratic Republic">Lao People's Democratic Republic</option>
+              <option value="Latvia">Latvia</option>
+              <option value="Lebanon">Lebanon</option>
+              <option value="Lesotho">Lesotho</option>
+              <option value="Liberia">Liberia</option>
+              <option value="Libya">Libya</option>
+              <option value="Liechtenstein">Liechtenstein</option>
+              <option value="Lithuania">Lithuania</option>
+              <option value="Luxembourg">Luxembourg</option>
+              <option value="Macao">Macao</option>
+              <option value="Macedonia, The Former Yugoslav Republic of">Macedonia, The Former Yugoslav Republic of</option>
+              <option value="Madagascar">Madagascar</option>
+              <option value="Malawi">Malawi</option>
+              <option value="Malaysia">Malaysia</option>
+              <option value="Maldives">Maldives</option>
+              <option value="Mali">Mali</option>
+              <option value="Malta">Malta</option>
+              <option value="Marshall Islands">Marshall Islands</option>
+              <option value="Martinique">Martinique</option>
+              <option value="Mauritania">Mauritania</option>
+              <option value="Mauritius">Mauritius</option>
+              <option value="Mayotte">Mayotte</option>
+              <option value="Mexico">Mexico</option>
+              <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+              <option value="Moldova, Republic of">Moldova, Republic of</option>
+              <option value="Monaco">Monaco</option>
+              <option value="Mongolia">Mongolia</option>
+              <option value="Montenegro">Montenegro</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Morocco">Morocco</option>
+              <option value="Mozambique">Mozambique</option>
+              <option value="Myanmar">Myanmar</option>
+              <option value="Namibia">Namibia</option>
+              <option value="Nauru">Nauru</option>
+              <option value="Nepal">Nepal</option>
+              <option value="Netherlands">Netherlands</option>
+              <option value="New Caledonia">New Caledonia</option>
+              <option value="New Zealand">New Zealand</option>
+              <option value="Nicaragua">Nicaragua</option>
+              <option value="Niger">Niger</option>
+              <option value="Nigeria">Nigeria</option>
+              <option value="Niue">Niue</option>
+              <option value="Norfolk Island">Norfolk Island</option>
+              <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+              <option value="Norway">Norway</option>
+              <option value="Oman">Oman</option>
+              <option value="Pakistan">Pakistan</option>
+              <option value="Palau">Palau</option>
+              <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+              <option value="Panama">Panama</option>
+              <option value="Papua New Guinea">Papua New Guinea</option>
+              <option value="Paraguay">Paraguay</option>
+              <option value="Peru">Peru</option>
+              <option value="Philippines">Philippines</option>
+              <option value="Pitcairn">Pitcairn</option>
+              <option value="Poland">Poland</option>
+              <option value="Portugal">Portugal</option>
+              <option value="Puerto Rico">Puerto Rico</option>
+              <option value="Qatar">Qatar</option>
+              <option value="Reunion">Reunion</option>
+              <option value="Romania">Romania</option>
+              <option value="Russian Federation">Russian Federation</option>
+              <option value="Rwanda">Rwanda</option>
+              <option value="Saint Barthelemy">Saint Barthelemy</option>
+              <option value="Saint Helena, Ascension and Tristan da Cunha">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+              <option value="Saint Lucia">Saint Lucia</option>
+              <option value="Saint Martin (French part)">Saint Martin (French part)</option>
+              <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+              <option value="Saint Vincent and The Grenadines">Saint Vincent and The Grenadines</option>
+              <option value="Samoa">Samoa</option>
+              <option value="San Marino">San Marino</option>
+              <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="Senegal">Senegal</option>
+              <option value="Serbia">Serbia</option>
+              <option value="Seychelles">Seychelles</option>
+              <option value="Sierra Leone">Sierra Leone</option>
+              <option value="Singapore">Singapore</option>
+              <option value="Sint Maarten (Dutch part)">Sint Maarten (Dutch part)</option>
+              <option value="Slovakia">Slovakia</option>
+              <option value="Slovenia">Slovenia</option>
+              <option value="Solomon Islands">Solomon Islands</option>
+              <option value="Somalia">Somalia</option>
+              <option value="South Africa">South Africa</option>
+              <option value="South Georgia and The South Sandwich Islands">South Georgia and The South Sandwich Islands</option>
+              <option value="South Sudan">South Sudan</option>
+              <option value="Spain">Spain</option>
+              <option value="Sri Lanka">Sri Lanka</option>
+              <option value="Sudan">Sudan</option>
+              <option value="Suriname">Suriname</option>
+              <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+              <option value="Swaziland">Swaziland</option>
+              <option value="Sweden">Sweden</option>
+              <option value="Switzerland">Switzerland</option>
+              <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+              <option value="Taiwan, Province of China">Taiwan, Province of China</option>
+              <option value="Tajikistan">Tajikistan</option>
+              <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+              <option value="Thailand">Thailand</option>
+              <option value="Timor-leste">Timor-leste</option>
+              <option value="Togo">Togo</option>
+              <option value="Tokelau">Tokelau</option>
+              <option value="Tonga">Tonga</option>
+              <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+              <option value="Tunisia">Tunisia</option>
+              <option value="Turkey">Turkey</option>
+              <option value="Turkmenistan">Turkmenistan</option>
+              <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+              <option value="Tuvalu">Tuvalu</option>
+              <option value="Uganda">Uganda</option>
+              <option value="Ukraine">Ukraine</option>
+              <option value="United Arab Emirates">United Arab Emirates</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="United States">United States</option>
+              <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+              <option value="Uruguay">Uruguay</option>
+              <option value="Uzbekistan">Uzbekistan</option>
+              <option value="Vanuatu">Vanuatu</option>
+              <option value="Venezuela, Bolivarian Republic of">Venezuela, Bolivarian Republic of</option>
+              <option value="Viet Nam">Viet Nam</option>
+              <option value="Virgin Islands, British">Virgin Islands, British</option>
+              <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+              <option value="Wallis and Futuna">Wallis and Futuna</option>
+              <option value="Western Sahara">Western Sahara</option>
+              <option value="Yemen">Yemen</option>
+              <option value="Zambia">Zambia</option>
+              <option value="Zimbabwe">Zimbabwe</option>
+            </select>
+          </div>
+        </div>
+      </div>
 
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
@@ -1241,7 +2039,7 @@
         <p></p>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="16">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1255,7 +2053,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="17">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1281,7 +2079,7 @@
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
         <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="18">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1302,7 +2100,7 @@
 
         <div>
           <em>Single Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="19">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1314,7 +2112,7 @@
         </div>
         <div>
           <em>Multiple Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="20">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1353,7 +2151,7 @@
         <pre><code class="language-javascript"> $(".chosen-select").chosen({width: "95%"}); </code></pre>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="15">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="21">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1367,7 +2165,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-width" tabindex="16">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-width" tabindex="22">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1387,7 +2185,7 @@
         <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="23" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1401,7 +2199,7 @@
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="24" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>

--- a/public/index.proto.html
+++ b/public/index.proto.html
@@ -1227,7 +1227,805 @@
           </select>
         </div>
       </div>
-
+      
+      <h2><a name="search-behaviour" class="anchor" href="#search-behaviour">Search behaviour</a></h2>
+      <div class="side-by-side clearfix">
+        <p>By default Chosen's search is case-insensitive and matches the exact search string starting at any "word-boundary". However the behaviour is highly customizable. You can test the effects of each setting using the options below.</p>
+        <div class="search-behaviour">
+          <div>
+            <label><code class="language-javascript">case_sensitive_search: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="case_sensitive_search" data-search-behaviour="case_sensitive_search" value="true">
+                <code class="language-javascript">true</code>
+                <span>Search is case sensitive</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="case_sensitive_search" data-search-behaviour="case_sensitive_search" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Search is case insensitive</span> - default
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_term_delimiter: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="true">
+                <code class="language-javascript">true</code>
+                <span>Split the query in terms at any whitespace. Useful for most "natural" searches like first, middle and last names. "John Smith" will match "John Doe Smith".</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Do no split the query in terms, search string must exactly match (part of) the option label, including whitespaces etc.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="*">
+                <code class="language-javascript">"*"</code>
+                <span>Use a string (fx. asterix, percentage or underscore) to split terms. Useful for simple wildcard-character search.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_term_delimiter" data-search-behaviour="search_term_delimiter" value="regex_space">
+                <code class="language-javascript">/\s/</code> or <code class="language-javascript">new RegExp("\\s")</code>
+                <span>You can pass any parameter that works with <code>string.split()</code>.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_contains: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_contains" data-search-behaviour="search_contains" value="true">
+                <code class="language-javascript">true</code>
+                <span>Matches any part of an option - ie. equivalent to <code>search_word_boundary: ''</code> and <code>enable_split_word_search: true</code>.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_contains" data-search-behaviour="search_contains" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Matches search terms according to <code>enable_split_word_search</code> and <code>search_word_boundary</code></span> - default
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">enable_split_word_search: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="enable_split_word_search" data-search-behaviour="enable_split_word_search" value="true" checked>
+                <code class="language-javascript">true</code>
+                <span>Matches each term only at the beginning of a word - as determined by <code>search_word_boundary</code>.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="enable_split_word_search" data-search-behaviour="enable_split_word_search" value="false">
+                <code class="language-javascript">false</code>
+                <span>Matches only the beginning of the full option label. If <code>search_in_order = false</code> then the first found term must be at the beginning of the label.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_word_boundary: '^|\\b|\\s'</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|\b|\s" checked>
+                <code class="language-javascript">"^|\\b|\\s"</code>
+                <span>Uses JS RegExp's built-in word boundary to detect word beginnings as well as whitespace or the beginning of the entire label. Works great for ascii-only languages, but <strong>will</strong> erroneously detect word boundaries after letters with umlauts among many, many others.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|\s">
+                <code class="language-javascript">"^|\\s"</code>
+                <span>Only detects beginning of "words" at whitespace characters or the beginning of the entire label - where the default is flawed for non-unicode, this is flawed for parenthesis and a plethora of other special characters (which you can add if relevant).</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_word_boundary" data-search-behaviour="search_word_boundary" value="^|[^A-zæøå\(\)]">
+                <code class="language-javascript">custom</code>
+                <span>You can use a regex refined for your language and use case to correctly detect word boundaries. <strong>Note:</strong> The example given here would be a very bad choice for any real-life implementation!</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_in_order: false</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_in_order" data-search-behaviour="search_in_order" value="true">
+                <code class="language-javascript">true</code>
+                <span>Only matches if search terms are found in the same order as they entered.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_in_order" data-search-behaviour="search_in_order" value="false" checked>
+                <code class="language-javascript">false</code> - default
+                <span>Matches search terms in any order.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">group_search: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="group_search" data-search-behaviour="group_search" value="true" checked>
+                <code class="language-javascript">true</code>
+                <span>Shows entire groups whose label match the search query.</span> - default
+              </label></li>
+              <li><label>
+                <input type="radio" name="group_search" data-search-behaviour="group_search" value="false">
+                <code class="language-javascript">false</code>
+                <span>Only shows groups that contain options matching the query.</span>
+              </label></li>
+            </ul>
+          </div>
+          <div>
+            <label><code class="language-javascript">search_highlight_full_match: true</code></label>
+            <ul>
+              <li><label>
+                <input type="radio" name="search_highlight_full_match" data-search-behaviour="search_highlight_full_match" value="true">
+                <code class="language-javascript">true</code>
+                <span>Highlights the entire match - ie. from the first matching letter to the last.</span>
+              </label></li>
+              <li><label>
+                <input type="radio" name="search_highlight_full_match" data-search-behaviour="search_highlight_full_match" value="false" checked>
+                <code class="language-javascript">false</code>
+                <span>Highlights only the letters / terms entered</span> - default
+              </label></li>
+            </ul>
+          </div>
+        </div>
+        <div class="search-behaviour-right">
+          <div>
+            <h3>Test your settings...</h3>
+            <p>These select boxes are all updated to reflect the settings on the left.</p>
+          </div>
+          <div>
+            <em>Simple Single Select</em>
+            <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-sb" tabindex="10">
+              <option value=""></option>
+              <option>American Black Bear</option>
+              <option>Asiatic Black Bear</option>
+              <option>Brown Bear</option>
+              <option>Giant Panda</option>
+              <option>Sloth Bear</option>
+              <option>Sun Bear</option>
+              <option>Polar Bear</option>
+              <option>Spectacled Bear</option>
+            </select>
+          </div>
+          <div>
+            <em>Simple Multiple Select</em>
+            <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-sb" tabindex="11">
+              <option value=""></option>
+              <option>American Black Bear</option>
+              <option>Asiatic Black Bear</option>
+              <option>Brown Bear</option>
+              <option>Giant Panda</option>
+              <option>Sloth Bear</option>
+              <option>Sun Bear</option>
+              <option>Polar Bear</option>
+              <option>Spectacled Bear</option>
+            </select>
+          </div>
+          <div>
+            <em>Single Select with Groups</em>
+            <select data-placeholder="Your Favorite Football Team" class="chosen-select-sb" tabindex="12">
+              <option value=""></option>
+              <optgroup label="NFC EAST <test>">
+                <option>Dallas Cowboys &lt;test&gt;</option>
+                <option>New York Giants</option>
+                <option>Philadelphia Eagles</option>
+                <option>Washington Redskins</option>
+              </optgroup>
+              <optgroup label="NFC NORTH">
+                <option>Chicago Bears</option>
+                <option>Detroit Lions</option>
+                <option>Green Bay Packers</option>
+                <option>Minnesota Vikings</option>
+              </optgroup>
+              <optgroup label="NFC SOUTH">
+                <option>Atlanta Falcons</option>
+                <option>Carolina Panthers</option>
+                <option>New Orleans Saints</option>
+                <option>Tampa Bay Buccaneers</option>
+              </optgroup>
+              <optgroup label="NFC WEST">
+                <option>Arizona Cardinals</option>
+                <option>St. Louis Rams</option>
+                <option>San Francisco 49ers</option>
+                <option>Seattle Seahawks</option>
+              </optgroup>
+              <optgroup label="AFC EAST">
+                <option>Buffalo Bills</option>
+                <option>Miami Dolphins</option>
+                <option>New England Patriots</option>
+                <option>New York Jets</option>
+              </optgroup>
+              <optgroup label="AFC NORTH">
+                <option>Baltimore Ravens</option>
+                <option>Cincinnati Bengals</option>
+                <option>Cleveland Browns</option>
+                <option>Pittsburgh Steelers</option>
+              </optgroup>
+              <optgroup label="AFC SOUTH">
+                <option>Houston Texans</option>
+                <option>Indianapolis Colts</option>
+                <option>Jacksonville Jaguars</option>
+                <option>Tennessee Titans</option>
+              </optgroup>
+              <optgroup label="AFC WEST">
+                <option>Denver Broncos</option>
+                <option>Kansas City Chiefs</option>
+                <option>Oakland Raiders</option>
+                <option>San Diego Chargers</option>
+              </optgroup>
+            </select>
+          </div>
+          <div>
+            <em>Multiple Select with Groups</em>
+            <select data-placeholder="Your Favorite Football Team" class="chosen-select-sb" multiple tabindex="13">
+              <option value=""></option>
+              <optgroup label="NFC EAST">
+                <option>Dallas Cowboys</option>
+                <option>New York Giants</option>
+                <option>Philadelphia Eagles</option>
+                <option>Washington Redskins</option>
+              </optgroup>
+              <optgroup label="NFC NORTH">
+                <option>Chicago Bears</option>
+                <option>Detroit Lions</option>
+                <option>Green Bay Packers</option>
+                <option>Minnesota Vikings</option>
+              </optgroup>
+              <optgroup label="NFC SOUTH">
+                <option>Atlanta Falcons</option>
+                <option>Carolina Panthers</option>
+                <option>New Orleans Saints</option>
+                <option>Tampa Bay Buccaneers</option>
+              </optgroup>
+              <optgroup label="NFC WEST">
+                <option>Arizona Cardinals</option>
+                <option>St. Louis Rams</option>
+                <option>San Francisco 49ers</option>
+                <option>Seattle Seahawks</option>
+              </optgroup>
+              <optgroup label="AFC EAST">
+                <option>Buffalo Bills</option>
+                <option>Miami Dolphins</option>
+                <option>New England Patriots</option>
+                <option>New York Jets</option>
+              </optgroup>
+              <optgroup label="AFC NORTH">
+                <option>Baltimore Ravens</option>
+                <option>Cincinnati Bengals</option>
+                <option>Cleveland Browns</option>
+                <option>Pittsburgh Steelers</option>
+              </optgroup>
+              <optgroup label="AFC SOUTH">
+                <option>Houston Texans</option>
+                <option>Indianapolis Colts</option>
+                <option>Jacksonville Jaguars</option>
+                <option>Tennessee Titans</option>
+              </optgroup>
+              <optgroup label="AFC WEST">
+                <option>Denver Broncos</option>
+                <option>Kansas City Chiefs</option>
+                <option>Oakland Raiders</option>
+                <option>San Diego Chargers</option>
+              </optgroup>
+            </select>
+          </div>
+          <div>
+            <em>Single Select Country</em>
+            <select data-placeholder="Choose a Country..." class="chosen-select-sb" tabindex="14">
+              <option value=""></option>
+              <option value="United States">United States</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="Afghanistan">Afghanistan</option>
+              <option value="Aland Islands">Aland Islands</option>
+              <option value="Albania">Albania</option>
+              <option value="Algeria">Algeria</option>
+              <option value="American Samoa">American Samoa</option>
+              <option value="Andorra">Andorra</option>
+              <option value="Angola">Angola</option>
+              <option value="Anguilla">Anguilla</option>
+              <option value="Antarctica">Antarctica</option>
+              <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+              <option value="Argentina">Argentina</option>
+              <option value="Armenia">Armenia</option>
+              <option value="Aruba">Aruba</option>
+              <option value="Australia">Australia</option>
+              <option value="Austria">Austria</option>
+              <option value="Azerbaijan">Azerbaijan</option>
+              <option value="Bahamas">Bahamas</option>
+              <option value="Bahrain">Bahrain</option>
+              <option value="Bangladesh">Bangladesh</option>
+              <option value="Barbados">Barbados</option>
+              <option value="Belarus">Belarus</option>
+              <option value="Belgium">Belgium</option>
+              <option value="Belize">Belize</option>
+              <option value="Benin">Benin</option>
+              <option value="Bermuda">Bermuda</option>
+              <option value="Bhutan">Bhutan</option>
+              <option value="Bolivia, Plurinational State of">Bolivia, Plurinational State of</option>
+              <option value="Bonaire, Sint Eustatius and Saba">Bonaire, Sint Eustatius and Saba</option>
+              <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+              <option value="Botswana">Botswana</option>
+              <option value="Bouvet Island">Bouvet Island</option>
+              <option value="Brazil">Brazil</option>
+              <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+              <option value="Brunei Darussalam">Brunei Darussalam</option>
+              <option value="Bulgaria">Bulgaria</option>
+              <option value="Burkina Faso">Burkina Faso</option>
+              <option value="Burundi">Burundi</option>
+              <option value="Cambodia">Cambodia</option>
+              <option value="Cameroon">Cameroon</option>
+              <option value="Canada">Canada</option>
+              <option value="Cape Verde">Cape Verde</option>
+              <option value="Cayman Islands">Cayman Islands</option>
+              <option value="Central African Republic">Central African Republic</option>
+              <option value="Chad">Chad</option>
+              <option value="Chile">Chile</option>
+              <option value="China">China</option>
+              <option value="Christmas Island">Christmas Island</option>
+              <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+              <option value="Colombia">Colombia</option>
+              <option value="Comoros">Comoros</option>
+              <option value="Congo">Congo</option>
+              <option value="Congo, The Democratic Republic of The">Congo, The Democratic Republic of The</option>
+              <option value="Cook Islands">Cook Islands</option>
+              <option value="Costa Rica">Costa Rica</option>
+              <option value="Cote D&apos;ivoire">Cote D'ivoire</option>
+              <option value="Croatia">Croatia</option>
+              <option value="Cuba">Cuba</option>
+              <option value="Curacao">Curacao</option>
+              <option value="Cyprus">Cyprus</option>
+              <option value="Czech Republic">Czech Republic</option>
+              <option value="Denmark">Denmark</option>
+              <option value="Djibouti">Djibouti</option>
+              <option value="Dominica">Dominica</option>
+              <option value="Dominican Republic">Dominican Republic</option>
+              <option value="Ecuador">Ecuador</option>
+              <option value="Egypt">Egypt</option>
+              <option value="El Salvador">El Salvador</option>
+              <option value="Equatorial Guinea">Equatorial Guinea</option>
+              <option value="Eritrea">Eritrea</option>
+              <option value="Estonia">Estonia</option>
+              <option value="Ethiopia">Ethiopia</option>
+              <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+              <option value="Faroe Islands">Faroe Islands</option>
+              <option value="Fiji">Fiji</option>
+              <option value="Finland">Finland</option>
+              <option value="France">France</option>
+              <option value="French Guiana">French Guiana</option>
+              <option value="French Polynesia">French Polynesia</option>
+              <option value="French Southern Territories">French Southern Territories</option>
+              <option value="Gabon">Gabon</option>
+              <option value="Gambia">Gambia</option>
+              <option value="Georgia">Georgia</option>
+              <option value="Germany">Germany</option>
+              <option value="Ghana">Ghana</option>
+              <option value="Gibraltar">Gibraltar</option>
+              <option value="Greece">Greece</option>
+              <option value="Greenland">Greenland</option>
+              <option value="Grenada">Grenada</option>
+              <option value="Guadeloupe">Guadeloupe</option>
+              <option value="Guam">Guam</option>
+              <option value="Guatemala">Guatemala</option>
+              <option value="Guernsey">Guernsey</option>
+              <option value="Guinea">Guinea</option>
+              <option value="Guinea-bissau">Guinea-bissau</option>
+              <option value="Guyana">Guyana</option>
+              <option value="Haiti">Haiti</option>
+              <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+              <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+              <option value="Honduras">Honduras</option>
+              <option value="Hong Kong">Hong Kong</option>
+              <option value="Hungary">Hungary</option>
+              <option value="Iceland">Iceland</option>
+              <option value="India">India</option>
+              <option value="Indonesia">Indonesia</option>
+              <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+              <option value="Iraq">Iraq</option>
+              <option value="Ireland">Ireland</option>
+              <option value="Isle of Man">Isle of Man</option>
+              <option value="Israel">Israel</option>
+              <option value="Italy">Italy</option>
+              <option value="Jamaica">Jamaica</option>
+              <option value="Japan">Japan</option>
+              <option value="Jersey">Jersey</option>
+              <option value="Jordan">Jordan</option>
+              <option value="Kazakhstan">Kazakhstan</option>
+              <option value="Kenya">Kenya</option>
+              <option value="Kiribati">Kiribati</option>
+              <option value="Korea, Democratic People&apos;s Republic of">Korea, Democratic People's Republic of</option>
+              <option value="Korea, Republic of">Korea, Republic of</option>
+              <option value="Kuwait">Kuwait</option>
+              <option value="Kyrgyzstan">Kyrgyzstan</option>
+              <option value="Lao People&apos;s Democratic Republic">Lao People's Democratic Republic</option>
+              <option value="Latvia">Latvia</option>
+              <option value="Lebanon">Lebanon</option>
+              <option value="Lesotho">Lesotho</option>
+              <option value="Liberia">Liberia</option>
+              <option value="Libya">Libya</option>
+              <option value="Liechtenstein">Liechtenstein</option>
+              <option value="Lithuania">Lithuania</option>
+              <option value="Luxembourg">Luxembourg</option>
+              <option value="Macao">Macao</option>
+              <option value="Macedonia, The Former Yugoslav Republic of">Macedonia, The Former Yugoslav Republic of</option>
+              <option value="Madagascar">Madagascar</option>
+              <option value="Malawi">Malawi</option>
+              <option value="Malaysia">Malaysia</option>
+              <option value="Maldives">Maldives</option>
+              <option value="Mali">Mali</option>
+              <option value="Malta">Malta</option>
+              <option value="Marshall Islands">Marshall Islands</option>
+              <option value="Martinique">Martinique</option>
+              <option value="Mauritania">Mauritania</option>
+              <option value="Mauritius">Mauritius</option>
+              <option value="Mayotte">Mayotte</option>
+              <option value="Mexico">Mexico</option>
+              <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+              <option value="Moldova, Republic of">Moldova, Republic of</option>
+              <option value="Monaco">Monaco</option>
+              <option value="Mongolia">Mongolia</option>
+              <option value="Montenegro">Montenegro</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Morocco">Morocco</option>
+              <option value="Mozambique">Mozambique</option>
+              <option value="Myanmar">Myanmar</option>
+              <option value="Namibia">Namibia</option>
+              <option value="Nauru">Nauru</option>
+              <option value="Nepal">Nepal</option>
+              <option value="Netherlands">Netherlands</option>
+              <option value="New Caledonia">New Caledonia</option>
+              <option value="New Zealand">New Zealand</option>
+              <option value="Nicaragua">Nicaragua</option>
+              <option value="Niger">Niger</option>
+              <option value="Nigeria">Nigeria</option>
+              <option value="Niue">Niue</option>
+              <option value="Norfolk Island">Norfolk Island</option>
+              <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+              <option value="Norway">Norway</option>
+              <option value="Oman">Oman</option>
+              <option value="Pakistan">Pakistan</option>
+              <option value="Palau">Palau</option>
+              <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+              <option value="Panama">Panama</option>
+              <option value="Papua New Guinea">Papua New Guinea</option>
+              <option value="Paraguay">Paraguay</option>
+              <option value="Peru">Peru</option>
+              <option value="Philippines">Philippines</option>
+              <option value="Pitcairn">Pitcairn</option>
+              <option value="Poland">Poland</option>
+              <option value="Portugal">Portugal</option>
+              <option value="Puerto Rico">Puerto Rico</option>
+              <option value="Qatar">Qatar</option>
+              <option value="Reunion">Reunion</option>
+              <option value="Romania">Romania</option>
+              <option value="Russian Federation">Russian Federation</option>
+              <option value="Rwanda">Rwanda</option>
+              <option value="Saint Barthelemy">Saint Barthelemy</option>
+              <option value="Saint Helena, Ascension and Tristan da Cunha">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+              <option value="Saint Lucia">Saint Lucia</option>
+              <option value="Saint Martin (French part)">Saint Martin (French part)</option>
+              <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+              <option value="Saint Vincent and The Grenadines">Saint Vincent and The Grenadines</option>
+              <option value="Samoa">Samoa</option>
+              <option value="San Marino">San Marino</option>
+              <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="Senegal">Senegal</option>
+              <option value="Serbia">Serbia</option>
+              <option value="Seychelles">Seychelles</option>
+              <option value="Sierra Leone">Sierra Leone</option>
+              <option value="Singapore">Singapore</option>
+              <option value="Sint Maarten (Dutch part)">Sint Maarten (Dutch part)</option>
+              <option value="Slovakia">Slovakia</option>
+              <option value="Slovenia">Slovenia</option>
+              <option value="Solomon Islands">Solomon Islands</option>
+              <option value="Somalia">Somalia</option>
+              <option value="South Africa">South Africa</option>
+              <option value="South Georgia and The South Sandwich Islands">South Georgia and The South Sandwich Islands</option>
+              <option value="South Sudan">South Sudan</option>
+              <option value="Spain">Spain</option>
+              <option value="Sri Lanka">Sri Lanka</option>
+              <option value="Sudan">Sudan</option>
+              <option value="Suriname">Suriname</option>
+              <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+              <option value="Swaziland">Swaziland</option>
+              <option value="Sweden">Sweden</option>
+              <option value="Switzerland">Switzerland</option>
+              <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+              <option value="Taiwan, Province of China">Taiwan, Province of China</option>
+              <option value="Tajikistan">Tajikistan</option>
+              <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+              <option value="Thailand">Thailand</option>
+              <option value="Timor-leste">Timor-leste</option>
+              <option value="Togo">Togo</option>
+              <option value="Tokelau">Tokelau</option>
+              <option value="Tonga">Tonga</option>
+              <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+              <option value="Tunisia">Tunisia</option>
+              <option value="Turkey">Turkey</option>
+              <option value="Turkmenistan">Turkmenistan</option>
+              <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+              <option value="Tuvalu">Tuvalu</option>
+              <option value="Uganda">Uganda</option>
+              <option value="Ukraine">Ukraine</option>
+              <option value="United Arab Emirates">United Arab Emirates</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="United States">United States</option>
+              <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+              <option value="Uruguay">Uruguay</option>
+              <option value="Uzbekistan">Uzbekistan</option>
+              <option value="Vanuatu">Vanuatu</option>
+              <option value="Venezuela, Bolivarian Republic of">Venezuela, Bolivarian Republic of</option>
+              <option value="Viet Nam">Viet Nam</option>
+              <option value="Virgin Islands, British">Virgin Islands, British</option>
+              <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+              <option value="Wallis and Futuna">Wallis and Futuna</option>
+              <option value="Western Sahara">Western Sahara</option>
+              <option value="Yemen">Yemen</option>
+              <option value="Zambia">Zambia</option>
+              <option value="Zimbabwe">Zimbabwe</option>
+            </select>
+          </div>
+          <div>
+            <em>Country Multiple Select</em>
+            <select data-placeholder="Choose a Country..." class="chosen-select-sb" multiple tabindex="15">
+              <option value=""></option>
+              <option value="United States">United States</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="Afghanistan">Afghanistan</option>
+              <option value="Aland Islands">Aland Islands</option>
+              <option value="Albania">Albania</option>
+              <option value="Algeria">Algeria</option>
+              <option value="American Samoa">American Samoa</option>
+              <option value="Andorra">Andorra</option>
+              <option value="Angola">Angola</option>
+              <option value="Anguilla">Anguilla</option>
+              <option value="Antarctica">Antarctica</option>
+              <option value="Antigua and Barbuda">Antigua and Barbuda</option>
+              <option value="Argentina">Argentina</option>
+              <option value="Armenia">Armenia</option>
+              <option value="Aruba">Aruba</option>
+              <option value="Australia">Australia</option>
+              <option value="Austria">Austria</option>
+              <option value="Azerbaijan">Azerbaijan</option>
+              <option value="Bahamas">Bahamas</option>
+              <option value="Bahrain">Bahrain</option>
+              <option value="Bangladesh">Bangladesh</option>
+              <option value="Barbados">Barbados</option>
+              <option value="Belarus">Belarus</option>
+              <option value="Belgium">Belgium</option>
+              <option value="Belize">Belize</option>
+              <option value="Benin">Benin</option>
+              <option value="Bermuda">Bermuda</option>
+              <option value="Bhutan">Bhutan</option>
+              <option value="Bolivia, Plurinational State of">Bolivia, Plurinational State of</option>
+              <option value="Bonaire, Sint Eustatius and Saba">Bonaire, Sint Eustatius and Saba</option>
+              <option value="Bosnia and Herzegovina">Bosnia and Herzegovina</option>
+              <option value="Botswana">Botswana</option>
+              <option value="Bouvet Island">Bouvet Island</option>
+              <option value="Brazil">Brazil</option>
+              <option value="British Indian Ocean Territory">British Indian Ocean Territory</option>
+              <option value="Brunei Darussalam">Brunei Darussalam</option>
+              <option value="Bulgaria">Bulgaria</option>
+              <option value="Burkina Faso">Burkina Faso</option>
+              <option value="Burundi">Burundi</option>
+              <option value="Cambodia">Cambodia</option>
+              <option value="Cameroon">Cameroon</option>
+              <option value="Canada">Canada</option>
+              <option value="Cape Verde">Cape Verde</option>
+              <option value="Cayman Islands">Cayman Islands</option>
+              <option value="Central African Republic">Central African Republic</option>
+              <option value="Chad">Chad</option>
+              <option value="Chile">Chile</option>
+              <option value="China">China</option>
+              <option value="Christmas Island">Christmas Island</option>
+              <option value="Cocos (Keeling) Islands">Cocos (Keeling) Islands</option>
+              <option value="Colombia">Colombia</option>
+              <option value="Comoros">Comoros</option>
+              <option value="Congo">Congo</option>
+              <option value="Congo, The Democratic Republic of The">Congo, The Democratic Republic of The</option>
+              <option value="Cook Islands">Cook Islands</option>
+              <option value="Costa Rica">Costa Rica</option>
+              <option value="Cote D&apos;ivoire">Cote D'ivoire</option>
+              <option value="Croatia">Croatia</option>
+              <option value="Cuba">Cuba</option>
+              <option value="Curacao">Curacao</option>
+              <option value="Cyprus">Cyprus</option>
+              <option value="Czech Republic">Czech Republic</option>
+              <option value="Denmark">Denmark</option>
+              <option value="Djibouti">Djibouti</option>
+              <option value="Dominica">Dominica</option>
+              <option value="Dominican Republic">Dominican Republic</option>
+              <option value="Ecuador">Ecuador</option>
+              <option value="Egypt">Egypt</option>
+              <option value="El Salvador">El Salvador</option>
+              <option value="Equatorial Guinea">Equatorial Guinea</option>
+              <option value="Eritrea">Eritrea</option>
+              <option value="Estonia">Estonia</option>
+              <option value="Ethiopia">Ethiopia</option>
+              <option value="Falkland Islands (Malvinas)">Falkland Islands (Malvinas)</option>
+              <option value="Faroe Islands">Faroe Islands</option>
+              <option value="Fiji">Fiji</option>
+              <option value="Finland">Finland</option>
+              <option value="France">France</option>
+              <option value="French Guiana">French Guiana</option>
+              <option value="French Polynesia">French Polynesia</option>
+              <option value="French Southern Territories">French Southern Territories</option>
+              <option value="Gabon">Gabon</option>
+              <option value="Gambia">Gambia</option>
+              <option value="Georgia">Georgia</option>
+              <option value="Germany">Germany</option>
+              <option value="Ghana">Ghana</option>
+              <option value="Gibraltar">Gibraltar</option>
+              <option value="Greece">Greece</option>
+              <option value="Greenland">Greenland</option>
+              <option value="Grenada">Grenada</option>
+              <option value="Guadeloupe">Guadeloupe</option>
+              <option value="Guam">Guam</option>
+              <option value="Guatemala">Guatemala</option>
+              <option value="Guernsey">Guernsey</option>
+              <option value="Guinea">Guinea</option>
+              <option value="Guinea-bissau">Guinea-bissau</option>
+              <option value="Guyana">Guyana</option>
+              <option value="Haiti">Haiti</option>
+              <option value="Heard Island and Mcdonald Islands">Heard Island and Mcdonald Islands</option>
+              <option value="Holy See (Vatican City State)">Holy See (Vatican City State)</option>
+              <option value="Honduras">Honduras</option>
+              <option value="Hong Kong">Hong Kong</option>
+              <option value="Hungary">Hungary</option>
+              <option value="Iceland">Iceland</option>
+              <option value="India">India</option>
+              <option value="Indonesia">Indonesia</option>
+              <option value="Iran, Islamic Republic of">Iran, Islamic Republic of</option>
+              <option value="Iraq">Iraq</option>
+              <option value="Ireland">Ireland</option>
+              <option value="Isle of Man">Isle of Man</option>
+              <option value="Israel">Israel</option>
+              <option value="Italy">Italy</option>
+              <option value="Jamaica">Jamaica</option>
+              <option value="Japan">Japan</option>
+              <option value="Jersey">Jersey</option>
+              <option value="Jordan">Jordan</option>
+              <option value="Kazakhstan">Kazakhstan</option>
+              <option value="Kenya">Kenya</option>
+              <option value="Kiribati">Kiribati</option>
+              <option value="Korea, Democratic People&apos;s Republic of">Korea, Democratic People's Republic of</option>
+              <option value="Korea, Republic of">Korea, Republic of</option>
+              <option value="Kuwait">Kuwait</option>
+              <option value="Kyrgyzstan">Kyrgyzstan</option>
+              <option value="Lao People&apos;s Democratic Republic">Lao People's Democratic Republic</option>
+              <option value="Latvia">Latvia</option>
+              <option value="Lebanon">Lebanon</option>
+              <option value="Lesotho">Lesotho</option>
+              <option value="Liberia">Liberia</option>
+              <option value="Libya">Libya</option>
+              <option value="Liechtenstein">Liechtenstein</option>
+              <option value="Lithuania">Lithuania</option>
+              <option value="Luxembourg">Luxembourg</option>
+              <option value="Macao">Macao</option>
+              <option value="Macedonia, The Former Yugoslav Republic of">Macedonia, The Former Yugoslav Republic of</option>
+              <option value="Madagascar">Madagascar</option>
+              <option value="Malawi">Malawi</option>
+              <option value="Malaysia">Malaysia</option>
+              <option value="Maldives">Maldives</option>
+              <option value="Mali">Mali</option>
+              <option value="Malta">Malta</option>
+              <option value="Marshall Islands">Marshall Islands</option>
+              <option value="Martinique">Martinique</option>
+              <option value="Mauritania">Mauritania</option>
+              <option value="Mauritius">Mauritius</option>
+              <option value="Mayotte">Mayotte</option>
+              <option value="Mexico">Mexico</option>
+              <option value="Micronesia, Federated States of">Micronesia, Federated States of</option>
+              <option value="Moldova, Republic of">Moldova, Republic of</option>
+              <option value="Monaco">Monaco</option>
+              <option value="Mongolia">Mongolia</option>
+              <option value="Montenegro">Montenegro</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Morocco">Morocco</option>
+              <option value="Mozambique">Mozambique</option>
+              <option value="Myanmar">Myanmar</option>
+              <option value="Namibia">Namibia</option>
+              <option value="Nauru">Nauru</option>
+              <option value="Nepal">Nepal</option>
+              <option value="Netherlands">Netherlands</option>
+              <option value="New Caledonia">New Caledonia</option>
+              <option value="New Zealand">New Zealand</option>
+              <option value="Nicaragua">Nicaragua</option>
+              <option value="Niger">Niger</option>
+              <option value="Nigeria">Nigeria</option>
+              <option value="Niue">Niue</option>
+              <option value="Norfolk Island">Norfolk Island</option>
+              <option value="Northern Mariana Islands">Northern Mariana Islands</option>
+              <option value="Norway">Norway</option>
+              <option value="Oman">Oman</option>
+              <option value="Pakistan">Pakistan</option>
+              <option value="Palau">Palau</option>
+              <option value="Palestinian Territory, Occupied">Palestinian Territory, Occupied</option>
+              <option value="Panama">Panama</option>
+              <option value="Papua New Guinea">Papua New Guinea</option>
+              <option value="Paraguay">Paraguay</option>
+              <option value="Peru">Peru</option>
+              <option value="Philippines">Philippines</option>
+              <option value="Pitcairn">Pitcairn</option>
+              <option value="Poland">Poland</option>
+              <option value="Portugal">Portugal</option>
+              <option value="Puerto Rico">Puerto Rico</option>
+              <option value="Qatar">Qatar</option>
+              <option value="Reunion">Reunion</option>
+              <option value="Romania">Romania</option>
+              <option value="Russian Federation">Russian Federation</option>
+              <option value="Rwanda">Rwanda</option>
+              <option value="Saint Barthelemy">Saint Barthelemy</option>
+              <option value="Saint Helena, Ascension and Tristan da Cunha">Saint Helena, Ascension and Tristan da Cunha</option>
+              <option value="Saint Kitts and Nevis">Saint Kitts and Nevis</option>
+              <option value="Saint Lucia">Saint Lucia</option>
+              <option value="Saint Martin (French part)">Saint Martin (French part)</option>
+              <option value="Saint Pierre and Miquelon">Saint Pierre and Miquelon</option>
+              <option value="Saint Vincent and The Grenadines">Saint Vincent and The Grenadines</option>
+              <option value="Samoa">Samoa</option>
+              <option value="San Marino">San Marino</option>
+              <option value="Sao Tome and Principe">Sao Tome and Principe</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="Senegal">Senegal</option>
+              <option value="Serbia">Serbia</option>
+              <option value="Seychelles">Seychelles</option>
+              <option value="Sierra Leone">Sierra Leone</option>
+              <option value="Singapore">Singapore</option>
+              <option value="Sint Maarten (Dutch part)">Sint Maarten (Dutch part)</option>
+              <option value="Slovakia">Slovakia</option>
+              <option value="Slovenia">Slovenia</option>
+              <option value="Solomon Islands">Solomon Islands</option>
+              <option value="Somalia">Somalia</option>
+              <option value="South Africa">South Africa</option>
+              <option value="South Georgia and The South Sandwich Islands">South Georgia and The South Sandwich Islands</option>
+              <option value="South Sudan">South Sudan</option>
+              <option value="Spain">Spain</option>
+              <option value="Sri Lanka">Sri Lanka</option>
+              <option value="Sudan">Sudan</option>
+              <option value="Suriname">Suriname</option>
+              <option value="Svalbard and Jan Mayen">Svalbard and Jan Mayen</option>
+              <option value="Swaziland">Swaziland</option>
+              <option value="Sweden">Sweden</option>
+              <option value="Switzerland">Switzerland</option>
+              <option value="Syrian Arab Republic">Syrian Arab Republic</option>
+              <option value="Taiwan, Province of China">Taiwan, Province of China</option>
+              <option value="Tajikistan">Tajikistan</option>
+              <option value="Tanzania, United Republic of">Tanzania, United Republic of</option>
+              <option value="Thailand">Thailand</option>
+              <option value="Timor-leste">Timor-leste</option>
+              <option value="Togo">Togo</option>
+              <option value="Tokelau">Tokelau</option>
+              <option value="Tonga">Tonga</option>
+              <option value="Trinidad and Tobago">Trinidad and Tobago</option>
+              <option value="Tunisia">Tunisia</option>
+              <option value="Turkey">Turkey</option>
+              <option value="Turkmenistan">Turkmenistan</option>
+              <option value="Turks and Caicos Islands">Turks and Caicos Islands</option>
+              <option value="Tuvalu">Tuvalu</option>
+              <option value="Uganda">Uganda</option>
+              <option value="Ukraine">Ukraine</option>
+              <option value="United Arab Emirates">United Arab Emirates</option>
+              <option value="United Kingdom">United Kingdom</option>
+              <option value="United States">United States</option>
+              <option value="United States Minor Outlying Islands">United States Minor Outlying Islands</option>
+              <option value="Uruguay">Uruguay</option>
+              <option value="Uzbekistan">Uzbekistan</option>
+              <option value="Vanuatu">Vanuatu</option>
+              <option value="Venezuela, Bolivarian Republic of">Venezuela, Bolivarian Republic of</option>
+              <option value="Viet Nam">Viet Nam</option>
+              <option value="Virgin Islands, British">Virgin Islands, British</option>
+              <option value="Virgin Islands, U.S.">Virgin Islands, U.S.</option>
+              <option value="Wallis and Futuna">Wallis and Futuna</option>
+              <option value="Western Sahara">Western Sahara</option>
+              <option value="Yemen">Yemen</option>
+              <option value="Zambia">Zambia</option>
+              <option value="Zimbabwe">Zimbabwe</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      
       <h2><a name="default-text-support" class="anchor" href="#default-text-support">Default Text Support</a></h2>
       <div class="side-by-side clearfix">
         <p>Chosen automatically sets the default field text ("Choose a country...") by reading the select element's data-placeholder value. If no data-placeholder value is present, it will default to "Select an Option" or "Select Some Options" depending on whether the select is single or multiple. You can change these elements in the plugin js file as you see fit.</p>
@@ -1242,7 +2040,7 @@
 
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="10">
+          <select data-placeholder="Type &apos;C&apos; to view" class="chosen-select-no-results" tabindex="16">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1256,7 +2054,7 @@
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="11">
+          <select data-placeholder="Type &apos;C&apos; to view" multiple class="chosen-select-no-results" tabindex="17">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1282,7 +2080,7 @@
       <div class="side-by-side clearfix">
         <p>When a single select box isn't a required field, you can set <code class="language-javascript">allow_single_deselect: true</code> and Chosen will add a UI element for option deselection. This will only work if the first option has blank text.</p>
         <div class="side-by-side clearfix">
-          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="12">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-deselect" tabindex="18">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1302,7 +2100,7 @@
         <pre><code class="language-javascript"> $(".chosen-select").chosen({rtl: true}); </code></pre>
         <div>
           <em>Single Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="13">
+          <select data-placeholder="Your Favorite Type of Bear" class="chosen-select-rtl" tabindex="19">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1314,7 +2112,7 @@
         </div>
         <div>
           <em>Multiple Right-to-Left Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="14">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-rtl" tabindex="20">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1357,7 +2155,7 @@ chosen.destroy();</code></pre>
         <pre><code class="language-javascript">new Chosen($("chosen_select_field"),{width: "95%"}); </code></pre>
         <div>
           <em>Single Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="15">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select-width" tabindex="21">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1371,7 +2169,7 @@ chosen.destroy();</code></pre>
         </div>
         <div>
           <em>Multiple Select</em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-width" tabindex="16">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select-width" tabindex="22">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1391,7 +2189,7 @@ chosen.destroy();</code></pre>
         <p></p>
         <div>
           <em><label for="single-label-example">Click to Highlight Single Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="17" id="single-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" class="chosen-select" tabindex="23" id="single-label-example">
             <option value=""></option>
             <option selected>American Black Bear</option>
             <option>Asiatic Black Bear</option>
@@ -1405,7 +2203,7 @@ chosen.destroy();</code></pre>
         </div>
         <div>
           <em><label for="multiple-label-example">Click to Highlight Multiple Select</label></em>
-          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="18" id="multiple-label-example">
+          <select data-placeholder="Your Favorite Types of Bear" multiple class="chosen-select" tabindex="24" id="multiple-label-example">
             <option value=""></option>
             <option>American Black Bear</option>
             <option>Asiatic Black Bear</option>

--- a/public/options.html
+++ b/public/options.html
@@ -30,7 +30,56 @@
     width: "95%"
   });</code>
 </pre>
+    
+    <h3>Options related to search behaviour</h3>
+      <table class="docs-table">
+        <tr>
+          <td>case_sensitive_search</td>
+          <td>false</td>
+          <td>
+            <p>By default Chosen's search is case-insensitive. Setting this option to <code class="language-javascript">true</code> makes the search case-sensitive.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>search_term_delimiter</td>
+          <td>false</td>
+          <td>
+            <p>By default Chosen will consider the query literal - ie. "John Doe" will match "John Doe Smith", but not "John Smith Doe". Setting this option to <code class="language-javascript">true</code> interprets whitespaces in the query as term delimiters. Useful for most "natural" searches like first, middle and last names. You can also pass a string (fx. '*', '_' or '?') for simple wildcard-character searching. Or pass in a RegExp object to use multiple delimiters / wildcards, for example <code class="language-javascript">/\s|,|*|?/</code></p>
+          </td>
+        </tr>
+        <tr>
+          <td>search_contains</td>
+          <td>false</td>
+          <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()s and []s.<br>Setting this to <code class="language-javascript">true</code> is equivalent to <code class="language-javascript">{search_word_boundary: '', enable_split_word_search: true}</code></td>
+        </tr>
+        <tr>
+          <td>enable_split_word_search</td>
+          <td>true</td>
+          <td>By default, searching will match on any word within an option tag. Set this option to <code class="language-javascript">false</code> if you want to only match at the beginning of an option tag.</td>
+        </tr>
+        <tr>
+          <td>search_word_boundary</td>
+          <td>^|\\b|\\s</td>
+          <td>By default, chosen uses JS RegExp's built-in word boundary to detect word beginnings as well as whitespace or the beginning of the entire label. Works great for ascii-only languages, but <strong>will</strong> erroneously detect word boundaries after letters with umlauts among many, many others.<br>You can pass a string (that will be interpreted as a regex) refined for your language and use case to correctly detect word boundaries. See the demo page for further information and a few examples.</td>
+        </tr>
+        <tr>
+          <td>search_in_order</td>
+          <td>false</td>
+          <td>By default "terms" (as determined by <code class="language-javascript">search_term_delimiter</code>) will be matched in any order. Set this to <code class="language-javascript">true</code> to only match options where the terms occur in the same order as the query.</td>
+        </tr>
+        <tr>
+          <td>group_search</td>
+          <td>true</td>
+          <td>By default chosen will search group labels as well as options, and display all options belonging to matching groups. Set this to false to only search inside options.</td>
+        </tr>
+        <tr>
+          <td>search_highlight_full_match</td>
+          <td>false</td>
+          <td>By default chosen will highlight only the terms entered. Set this to true to highlight everything from the first matching character to the last.</td>
+        </tr>
+      </table>
 
+    <h3>Other options</h3>
       <table class="docs-table">
         <tr>
           <th>Option</th><th>Default</th><th>Description</th>
@@ -49,11 +98,6 @@
           <td>disable_search_threshold</td>
           <td>0</td>
           <td>Hide the search input on single selects if there are <i>n</i> or fewer options.</td>
-        </tr>
-        <tr>
-          <td>enable_split_word_search</td>
-          <td>true</td>
-          <td>By default, searching will match on any word within an option tag. Set this option to <code class="language-javascript">false</code> if you want to only match on the entire text of an option tag.</td>
         </tr>
         <tr>
           <td>inherit_select_classes</td>
@@ -80,11 +124,6 @@
           <td>placeholder_text_single</td>
           <td>"Select an Option"</td>
           <td>The text to be displayed as a placeholder when no options are selected for a single select.</td>
-        </tr>
-        <tr>
-          <td>search_contains</td>
-          <td>false</td>
-          <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()s and []s.</td>
         </tr>
         <tr>
           <td>single_backstroke_delete</td>
@@ -121,13 +160,6 @@
           <td>Infinity</td>
           <td>
             <p>Only show the first (n) matching options in the results. This can be used to increase performance for selects with very many options.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>case_sensitive_search</td>
-          <td>false</td>
-          <td>
-            <p>By default Chosen's search is case-insensitive. Setting this option to <code class="language-javascript">true</code> makes the search case-sensitive.</p>
           </td>
         </tr>
         <tr>

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -1,88 +1,179 @@
 describe "Searching", ->
-  it "should not match the actual text of HTML entities", ->
-    tmpl = "
-      <select data-placeholder='Choose an HTML Entity...'>
-        <option value=''></option>
-        <option value='This & That'>This &amp; That</option>
-        <option value='This < That'>This &lt; That</option>
-      </select>
-    "
+  describe "should not match the actual text of HTML entities", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          tmpl = "
+            <select data-placeholder='Choose an HTML Entity...'>
+              <option value=''></option>
+              <option value='This & That'>This &amp; That</option>
+              <option value='This < That'>This &lt; That</option>
+            </select>
+          "
 
-    div = $("<div>").html(tmpl)
-    select = div.find("select")
-    select.chosen({search_contains: true})
+          div = $("<div>").html(tmpl)
+          select = div.find("select")
+          select.chosen({search_contains: true, search_in_order: search_in_order_setting})
 
-    container = div.find(".chosen-container")
-    container.trigger("mousedown") # open the drop
+          container = div.find(".chosen-container")
+          container.trigger("mousedown") # open the drop
 
-    # Both options should be active
-    results = div.find(".active-result")
-    expect(results.length).toBe(2)
+          # Both options should be active
+          results = div.find(".active-result")
+          expect(results.length).toBe(2)
 
-    # Search for the html entity by name
-    search_field = div.find(".chosen-search input").first()
-    search_field.val("mp")
-    search_field.trigger("keyup")
+          # Search for the html entity by name
+          search_field = div.find(".chosen-search input").first()
+          search_field.val("mp")
+          search_field.trigger("keyup")
 
-    results = div.find(".active-result")
-    expect(results.length).toBe(0)
+          results = div.find(".active-result")
+          expect(results.length).toBe(0)
 
-  it "renders options correctly when they contain characters that require HTML encoding", ->
-    div = $("<div>").html("""
-      <select>
-        <option value="A &amp; B">A &amp; B</option>
-      </select>
-    """)
+  describe "renders options correctly when they contain characters that require HTML encoding", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = $("<div>").html("""
+            <select>
+              <option value="A &amp; B">A &amp; B</option>
+            </select>
+          """)
 
-    div.find("select").chosen()
-    div.find(".chosen-container").trigger("mousedown") # open the drop
+          div.find("select").chosen({search_in_order: search_in_order_setting})
+          div.find(".chosen-container").trigger("mousedown") # open the drop
 
-    expect(div.find(".active-result").length).toBe(1)
-    expect(div.find(".active-result").first().html()).toBe("A &amp; B")
+          expect(div.find(".active-result").length).toBe(1)
+          expect(div.find(".active-result").first().html()).toBe("A &amp; B")
 
-    search_field = div.find(".chosen-search-input").first()
-    search_field.val("A")
-    search_field.trigger("keyup")
+          search_field = div.find(".chosen-search-input").first()
+          search_field.val("A")
+          search_field.trigger("keyup")
 
-    expect(div.find(".active-result").length).toBe(1)
-    expect(div.find(".active-result").first().html()).toBe("<em>A</em> &amp; B")
+          expect(div.find(".active-result").length).toBe(1)
+          expect(div.find(".active-result").first().html()).toBe("<em>A</em> &amp; B")
 
-  it "renders optgroups correctly when they contain html encoded tags", ->
-    div = $("<div>").html("""
-      <select>
-        <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
-          <option value="Item">Item</option>
-        </optgroup>
-      </select>
-    """)
+  describe "renders optgroups correctly when they contain html encoded tags", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = $("<div>").html("""
+            <select>
+              <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
+                <option value="Item">Item</option>
+              </optgroup>
+            </select>
+          """)
 
-    div.find("select").chosen()
-    div.find(".chosen-container").trigger("mousedown") # open the drop
+          div.find("select").chosen({search_in_order: search_in_order_setting})
+          div.find(".chosen-container").trigger("mousedown") # open the drop
 
-    expect(div.find(".group-result").length).toBe(1)
-    expect(div.find(".group-result").first().html()).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
+          expect(div.find(".group-result").length).toBe(1)
+          expect(div.find(".group-result").first().html()).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
 
-  it "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
-    div = $("<div>").html("""
-      <select>
-        <optgroup label="A &amp; B">
-          <option value="Item">Item</option>
-        </optgroup>
-      </select>
-    """)
+  describe "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = $("<div>").html("""
+            <select>
+              <optgroup label="A &amp; B">
+                <option value="Item">Item</option>
+              </optgroup>
+            </select>
+          """)
 
-    div.find("select").chosen()
-    div.find(".chosen-container").trigger("mousedown") # open the drop
+          div.find("select").chosen({search_in_order: search_in_order_setting})
+          div.find(".chosen-container").trigger("mousedown") # open the drop
 
-    expect(div.find(".group-result").length).toBe(1)
-    expect(div.find(".group-result").first().html()).toBe("A &amp; B")
+          expect(div.find(".group-result").length).toBe(1)
+          expect(div.find(".group-result").first().html()).toBe("A &amp; B")
 
-    search_field = div.find(".chosen-search-input").first()
-    search_field.val("A")
-    search_field.trigger("keyup")
+          search_field = div.find(".chosen-search-input").first()
+          search_field.val("A")
+          search_field.trigger("keyup")
 
-    expect(div.find(".group-result").length).toBe(1)
-    expect(div.find(".group-result").first().html()).toBe("<em>A</em> &amp; B")
+          expect(div.find(".group-result").length).toBe(1)
+          expect(div.find(".group-result").first().html()).toBe("<em>A</em> &amp; B")
+
+  describe "finding and highlighting", ->
+    setup_results_test = (query, settings = {}) ->
+      div = $("<div>").html("""
+        <select>
+          <option value="abbbba">abbbba</option>
+          <option value="Frank Miller">Frank Miller</option>
+          <option value="Frank Møller">Frank Møller</option>
+          <option value="Frank Øller">Frank Øller</option>
+          <option value="John Doe Smith">John Doe Smith</option>
+          <option value="John Smith">John Smith</option>
+          <option value="Smith Johnson">Smith Johnson</option>
+          <option value="Smith F. Johnson">Smith F. Johnson</option>
+        </select>
+      """)
+      correct_results_chosen = div.find("select").chosen(settings)
+      div.find(".chosen-container").trigger("mousedown") # open the drop
+      search_field = div.find(".chosen-search-input")
+      search_field.val(query)
+      search_field.trigger("keyup")
+      div.find(".active-result")
+    
+    it "treats space literally by default", ->
+      results = setup_results_test 'John D'
+      expect(results.length).toBe(1)
+      expect(results.first().html()).toBe('<em>John D</em>oe Smith')
+    it "treats space as term delimiter when search_term_delimiter is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true}
+      expect(results.length).toBe(4)
+      expect(results.eq(0).html()).toBe('<em>John</em> Doe <em>Smi</em>th')
+      expect(results.eq(1).html()).toBe('<em>John Smi</em>th')
+      expect(results.eq(2).html()).toBe('<em>Smi</em>th <em>John</em>son')
+      expect(results.eq(3).html()).toBe('<em>Smi</em>th F. <em>John</em>son')
+    it "treats asterix as term delimiter when search_term_delimiter is '*'", ->
+      results = setup_results_test 'John*Smi', {search_term_delimiter: '*'}
+      expect(results.length).toBe(4)
+      expect(results.eq(0).html()).toBe('<em>John</em> Doe <em>Smi</em>th')
+    it "respects word boundaries when search_term_delimiter is true", ->
+      results = setup_results_test 'John mi', {search_term_delimiter: true}
+      expect(results.length).toBe(0)
+    it "ignores word boundaries when search_term_delimiter and search_contains are true", ->
+      results = setup_results_test 'John mi', {search_term_delimiter: true, search_contains: true}
+      expect(results.length).toBe(4)
+      expect(results.eq(0).html()).toBe('<em>John</em> Doe S<em>mi</em>th')
+      expect(results.eq(1).html()).toBe('<em>John</em> S<em>mi</em>th')
+      expect(results.eq(2).html()).toBe('S<em>mi</em>th <em>John</em>son')
+      expect(results.eq(3).html()).toBe('S<em>mi</em>th F. <em>John</em>son')
+    it "only finds options with terms in correct order when search_in_order is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_in_order: true}
+      expect(results.length).toBe(2)
+      expect(results.eq(0).html()).toBe('<em>John</em> Doe <em>Smi</em>th')
+    it "includes spaces between neighbouring terms in highlight", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_in_order: true}
+      expect(results.length).toBe(2)
+      expect(results.eq(0).html()).toBe('<em>John</em> Doe <em>Smi</em>th')
+      expect(results.eq(1).html()).toBe('<em>John Smi</em>th')
+    it "includes characters between terms in highlight when search_highlight_full_match is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_highlight_full_match: true}
+      expect(results.length).toBe(4)
+      expect(results.eq(0).html()).toBe('<em>John Doe Smi</em>th')
+      expect(results.eq(1).html()).toBe('<em>John Smi</em>th')
+      expect(results.eq(2).html()).toBe('<em>Smith John</em>son')
+      expect(results.eq(3).html()).toBe('<em>Smith F. John</em>son')
+    it "considers non-ascii characters word-boundaries by default", ->
+      results = setup_results_test 'ller', {}
+      expect(results.length).toBe(2)
+      expect(results.eq(0).html()).toBe('Frank Mø<em>ller</em>')
+      expect(results.eq(1).html()).toBe('Frank Ø<em>ller</em>')
+    it "does not consider non-ascii characters word-boundaries if search_word_boundary is '^|\\s'", ->
+      results = setup_results_test 'ller', {search_word_boundary: '^|\\s'}
+      expect(results.length).toBe(0)
+    it "correctly highlights terms despite capturing group(s) in search_word_boundary", ->
+      results = setup_results_test 'Øller', {search_word_boundary: '(^|\\s|(,))'}
+      expect(results.length).toBe(1)
+      expect(results.eq(0).html()).toBe('Frank <em>Øller</em>')
+    it "does not include redundant '</em><em>' in highlighted results", ->
+      results = setup_results_test 'ab bb ba', {search_term_delimiter: true, search_contains: true}
+      expect(results.length).toBe(1)
+      expect(results.eq(0).html()).toBe('<em>abbbba</em>')
 
   it "renders no results message correctly when it contains characters that require HTML encoding", ->
     div = $("<div>").html("""

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -1,93 +1,197 @@
 describe "Searching", ->
-  it "should not match the actual text of HTML entities", ->
-    tmpl = "
-      <select data-placeholder='Choose an HTML Entity...'>
-        <option value=''></option>
-        <option value='This & That'>This &amp; That</option>
-        <option value='This < That'>This &lt; That</option>
-      </select>
-    "
+  describe "should not match the actual text of HTML entities", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          tmpl = "
+            <select data-placeholder='Choose an HTML Entity...'>
+              <option value=''></option>
+              <option value='This & That'>This &amp; That</option>
+              <option value='This < That'>This &lt; That</option>
+            </select>
+          "
 
-    div = new Element('div')
-    document.body.insert(div)
-    div.update(tmpl)
-    select = div.down('select')
-    new Chosen(select, {search_contains: true})
+          div = new Element('div')
+          document.body.insert(div)
+          div.update(tmpl)
+          select = div.down('select')
+          new Chosen(select, {search_contains: true, search_in_order: search_in_order_setting})
 
-    container = div.down('.chosen-container')
-    simulant.fire(container, 'mousedown') # open the drop
+          container = div.down('.chosen-container')
+          simulant.fire(container, 'mousedown') # open the drop
 
-    # Both options should be active
-    results = div.select('.active-result')
-    expect(results.length).toBe(2)
+          # Both options should be active
+          results = div.select('.active-result')
+          expect(results.length).toBe(2)
 
-    # Search for the html entity by name
-    search_field = div.down(".chosen-search input")
-    search_field.value = "mp"
-    simulant.fire(search_field, 'keyup')
+          # Search for the html entity by name
+          search_field = div.down(".chosen-search input")
+          search_field.value = "mp"
+          simulant.fire(search_field, 'keyup')
 
-    results = div.select(".active-result")
-    expect(results.length).toBe(0)
+          results = div.select(".active-result")
+          expect(results.length).toBe(0)
 
-  it "renders options correctly when they contain characters that require HTML encoding", ->
-    div = new Element("div")
-    div.update("""
-      <select>
-        <option value="A &amp; B">A &amp; B</option>
-      </select>
-    """)
+  describe "renders options correctly when they contain characters that require HTML encoding", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = new Element("div")
+          div.update("""
+            <select>
+              <option value="A &amp; B">A &amp; B</option>
+            </select>
+          """)
 
-    new Chosen(div.down("select"))
-    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+          new Chosen(div.down("select"), {search_in_order: search_in_order_setting})
+          simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
 
-    expect(div.select(".active-result").length).toBe(1)
-    expect(div.down(".active-result").innerHTML).toBe("A &amp; B")
+          expect(div.select(".active-result").length).toBe(1)
+          expect(div.down(".active-result").innerHTML).toBe("A &amp; B")
 
-    search_field = div.down(".chosen-search-input")
-    search_field.value = "A"
-    simulant.fire(search_field, "keyup")
+          search_field = div.down(".chosen-search-input")
+          search_field.value = "A"
+          simulant.fire(search_field, "keyup")
 
-    expect(div.select(".active-result").length).toBe(1)
-    expect(div.down(".active-result").innerHTML).toBe("<em>A</em> &amp; B")
+          expect(div.select(".active-result").length).toBe(1)
+          expect(div.down(".active-result").innerHTML).toBe("<em>A</em> &amp; B")
 
-  it "renders optgroups correctly when they contain characters that require HTML encoding", ->
-    div = new Element("div")
-    div.update("""
-      <select>
-        <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
-          <option value="Item">Item</option>
-        </optgroup>
-      </select>
-    """)
+  describe "renders optgroups correctly when they contain characters that require HTML encoding", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = new Element("div")
+          div.update("""
+            <select>
+              <optgroup label="A &lt;b&gt;hi&lt;/b&gt; B">
+                <option value="Item">Item</option>
+              </optgroup>
+            </select>
+          """)
 
-    new Chosen(div.down("select"))
-    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+          new Chosen(div.down("select"), {search_in_order: search_in_order_setting})
+          simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
 
-    expect(div.select(".group-result").length).toBe(1)
-    expect(div.down(".group-result").innerHTML).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
+          expect(div.select(".group-result").length).toBe(1)
+          expect(div.down(".group-result").innerHTML).toBe("A &lt;b&gt;hi&lt;/b&gt; B")
 
-  it "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
-    div = new Element("div")
-    div.update("""
-      <select>
-        <optgroup label="A &amp; B">
-          <option value="Item">Item</option>
-        </optgroup>
-      </select>
-    """)
+  describe "renders optgroups correctly when they contain characters that require HTML encoding when searching", ->
+    for search_in_order_setting in [true, false]
+      do (search_in_order_setting) ->
+        it "when search_in_order is " + search_in_order_setting, ->
+          div = new Element("div")
+          div.update("""
+            <select>
+              <optgroup label="A &amp; B">
+                <option value="Item">Item</option>
+              </optgroup>
+            </select>
+          """)
 
-    new Chosen(div.down("select"))
-    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+          new Chosen(div.down("select"), {search_in_order: search_in_order_setting})
+          simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
 
-    expect(div.select(".group-result").length).toBe(1)
-    expect(div.down(".group-result").innerHTML).toBe("A &amp; B")
+          expect(div.select(".group-result").length).toBe(1)
+          expect(div.down(".group-result").innerHTML).toBe("A &amp; B")
 
-    search_field = div.down(".chosen-search-input")
-    search_field.value = "A"
-    simulant.fire(search_field, "keyup")
+          search_field = div.down(".chosen-search-input")
+          search_field.value = "A"
+          simulant.fire(search_field, "keyup")
 
-    expect(div.select(".group-result").length).toBe(1)
-    expect(div.down(".group-result").innerHTML).toBe("<em>A</em> &amp; B")
+          expect(div.select(".group-result").length).toBe(1)
+          expect(div.down(".group-result").innerHTML).toBe("<em>A</em> &amp; B")
+
+
+
+
+
+
+  describe "finding and highlighting", ->
+    setup_results_test = (query, settings = {}) ->
+      div = new Element("div")
+      div.update("""
+        <select>
+          <option value="abbbba">abbbba</option>
+          <option value="Frank Miller">Frank Miller</option>
+          <option value="Frank Møller">Frank Møller</option>
+          <option value="Frank Øller">Frank Øller</option>
+          <option value="John Doe Smith">John Doe Smith</option>
+          <option value="John Smith">John Smith</option>
+          <option value="Smith Johnson">Smith Johnson</option>
+          <option value="Smith F. Johnson">Smith F. Johnson</option>
+        </select>
+      """)
+      correct_results_chosen = new Chosen(div.down("select"), settings)
+      simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+      search_field = div.down(".chosen-search-input")
+      search_field.value = query
+      simulant.fire(search_field, "keyup")
+      div.select(".active-result")
+    
+    it "treats space literally by default", ->
+      results = setup_results_test 'John D'
+      expect(results.length).toBe(1)
+      expect(results[0].innerHTML).toBe('<em>John D</em>oe Smith')
+    it "treats space as term delimiter when search_term_delimiter is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true}
+      expect(results.length).toBe(4)
+      expect(results[0].innerHTML).toBe('<em>John</em> Doe <em>Smi</em>th')
+      expect(results[1].innerHTML).toBe('<em>John Smi</em>th')
+      expect(results[2].innerHTML).toBe('<em>Smi</em>th <em>John</em>son')
+      expect(results[3].innerHTML).toBe('<em>Smi</em>th F. <em>John</em>son')
+    it "treats asterix as term delimiter when search_term_delimiter is '*'", ->
+      results = setup_results_test 'John*Smi', {search_term_delimiter: '*'}
+      expect(results.length).toBe(4)
+      expect(results[0].innerHTML).toBe('<em>John</em> Doe <em>Smi</em>th')
+    it "respects word boundaries when search_term_delimiter is true", ->
+      results = setup_results_test 'John mi', {search_term_delimiter: true}
+      expect(results.length).toBe(0)
+    it "ignores word boundaries when search_term_delimiter and search_contains are true", ->
+      results = setup_results_test 'John mi', {search_term_delimiter: true, search_contains: true}
+      expect(results.length).toBe(4)
+      expect(results[0].innerHTML).toBe('<em>John</em> Doe S<em>mi</em>th')
+      expect(results[1].innerHTML).toBe('<em>John</em> S<em>mi</em>th')
+      expect(results[2].innerHTML).toBe('S<em>mi</em>th <em>John</em>son')
+      expect(results[3].innerHTML).toBe('S<em>mi</em>th F. <em>John</em>son')
+    it "only finds options with terms in correct order when search_in_order is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_in_order: true}
+      expect(results.length).toBe(2)
+      expect(results[0].innerHTML).toBe('<em>John</em> Doe <em>Smi</em>th')
+    it "includes spaces between neighbouring terms in highlight", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_in_order: true}
+      expect(results.length).toBe(2)
+      expect(results[0].innerHTML).toBe('<em>John</em> Doe <em>Smi</em>th')
+      expect(results[1].innerHTML).toBe('<em>John Smi</em>th')
+    it "includes characters between terms in highlight when search_highlight_full_match is true", ->
+      results = setup_results_test 'John Smi', {search_term_delimiter: true, search_highlight_full_match: true}
+      expect(results.length).toBe(4)
+      expect(results[0].innerHTML).toBe('<em>John Doe Smi</em>th')
+      expect(results[1].innerHTML).toBe('<em>John Smi</em>th')
+      expect(results[2].innerHTML).toBe('<em>Smith John</em>son')
+      expect(results[3].innerHTML).toBe('<em>Smith F. John</em>son')
+    it "considers non-ascii characters word-boundaries by default", ->
+      results = setup_results_test 'ller', {}
+      expect(results.length).toBe(2)
+      expect(results[0].innerHTML).toBe('Frank Mø<em>ller</em>')
+      expect(results[1].innerHTML).toBe('Frank Ø<em>ller</em>')
+    it "does not consider non-ascii characters word-boundaries if search_word_boundary is '^|\\s'", ->
+      results = setup_results_test 'ller', {search_word_boundary: '^|\\s'}
+      expect(results.length).toBe(0)
+    it "correctly highlights terms despite capturing group(s) in search_word_boundary", ->
+      results = setup_results_test 'Øller', {search_word_boundary: '(^|\\s|(,))'}
+      expect(results.length).toBe(1)
+      expect(results[0].innerHTML).toBe('Frank <em>Øller</em>')
+    it "does not include redundant '</em><em>' in highlighted results", ->
+      results = setup_results_test 'ab bb ba', {search_term_delimiter: true, search_contains: true}
+      expect(results.length).toBe(1)
+      expect(results[0].innerHTML).toBe('<em>abbbba</em>')
+
+
+
+
+
+
+
 
   it "renders no results message correctly when it contains characters that require HTML encoding", ->
     div = new Element("div")


### PR DESCRIPTION
### Summary

Extended chosen with several options to improve flexibility of searching significantly.

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [x] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [x] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).


## Backstory
A client of mine used his brand new system for about a month and then commented something like:
"*Overall I love it! It's faster than the old system and it looks great. It's just a pity the search is so lousy.*"

When I dug a bit deeper it turned out he was referring to the Chosen selects I had implemented everywhere in an effort to make it *easier* to find stuff.

One issue for example, is that he has a bunch of Chosens where he can choose a customer based on their name. Now, some people may have the same first and last name, and some of them may have middle names. They are listed with other info that makes it possible to distinguish who's who if only they turn up in the search.

What my client means by "lousy" is that if he enters a persons first and last name, that person doesn't show up in the list if his middle name happens to also be in the database.

At this point I had to agree that "*the search is lousy*".

So I set out to improve it, and I believe what I have now is worth sharing.

## What it is

### New options:

**search_term_delimiter**
*What:* `true`, `false`, `string` or `RegExp`
*Why:* Massive improvement to the flexibility of searches - this was my primary goal
*How:* When set to `true` whitespaces are considered query separators, so a query with multiple words is split into terms that may be found in separate positions in the option. It also accepts a `string` or a `RegExp`, so if someone fx. wants to interpret spaces as literal, but have both asterix, question mark and comma work as "wildcards" that is possible (together with `search_contains`).
*Defaults to* `false` so it doesn't affect default behaviour or backwards compatibility - the entire query is interpreted as one literal term just the way it always has been unless this is set to something other than `false`.

**search_word_boundary**
*What:* `string`
*Why:* The default `^|\\b|\\s` is remarkably bad at finding word boundaries in languages that use non-unicode characters. A word boundary is basically detected after every non-ascii character (fx. ü, å, ø and æ to mention just a few - but there are **many***). I've looked into possibilities, and unfortunately there doesn't seem to be any way to get decent word-boundary detection for anything except ascii in javascripts RegExp implementation... without either using a third-party library or including some 4k+ characters in the string. Turning it into an option means that people can at least set something appropriate for their language and individual use case if they care. I **know** I've seen this discussed on GitHub, but can't find it at this moment.
*How:* Whatever this is set to will be used as the word boundary in the regexes when enable_split_word_search is true, but search_contains is false (which are the defaults!).
*Defaults to* `^|\\b|\\s` so it doesn't affect default behaviour or backwards compatibility (I'm actually not 100% sure here - I think I saw that this was changed quite recently somewhere?).

**search_in_order**
*What:* `Boolean`
*Why:* More flexibility
*How:* When `true` terms will be matched in *any* order. Fx. `Smith John` would match `John Smith`. When false options will only match if the terms appear in exactly the same order they are entered in the query (but other characters may appear in between depending on other settings).
*Defaults to* `true` - because when you want to match individual terms, you most likely want to match them even in a different order, as long as the option contains all the entered terms. **Does not** affect default behaviour or backwards compatibility because the query is interpreted a single literal term.

**search_highlight_full_match**
*What:* `Boolean`
*Why:* Because in certain situations it just makes more sense.
*How:* When `true` the entire match will be highlighted - ie. from the first matched letter to the last.
*Defaults to* `false` - because in the vast majority of cases it is much clearer to highlight only the typed letters.

**group_search** (Not really new!)
*What:* `Boolean`
*Why:* I didn't actually add this, but it wasn't documented anywhere, so I've added it to the documentation and examples. The behaviour should be the same as previously.
*How:* When set to `false` chosen will not search inside group labels and show the entire group among the results.
*Defaults to* `true`, which means *do* search in group labels.

I've added a new section to the demo-page that makes it easier to see the result of all the different settings.

## Compatibility and testing

I believe this correctly solves the problem that previous "fuzzy search" PR's tried to solve - but without the issues they each had.

**As far as my own testing goes:**

1. It is 100% backwards compatible - if you don't set any of the new options it should behave exactly as it has previously in spite of differences in the underlying code.
2. It correctly and consistently highlights matching terms (which - as far as I can tell - none of the previous "fuzzy search" PR's could)
3. It respects all combinations of all pre-existing search related options (search_contains, case_sensitive_search etc.)
4. It passes all tests.
5. I have also added several new tests as well, to help minimize the risk of future commits inadvertently modifying the behaviour.
6. It is fully implemented and working in both jquery and prototype version

One known issue that I haven't solved is that with `search_in_order = false`, `search_contains = true` and a query containing many very short terms that are present in a lot of options it will be rather slow. For instance typing in `s a i n t h e l e n a a s c e n s` will become pretty sluggish after the first 5-10 "terms". Add just one two-letter term and it dramatically improves. For now I have decided this is enough of an edge-case to not be worth fixing... I simply don't see it becoming relevant in any real-world query. I'm sure it can be fixed if anyone can come up with an example where it actually would be relevant.

## Cleaning up the naming...?

I'll take the opportunity to also propose the following changes to pre-existing search-behaviour related options (which I have not included in this PR):

* "group_search" should be "search_group_labels" - the prefix for consistency, and the "_labels" to better describe what it does.
* "enable_split_word_search" should be "search_only_from_beginning" - which will do the opposite of what it used to - ie. it should default to false, and match only at the beginning of the label when set to true
* "case_sensitive_search" should be "search_case_sensitive" - again for consistency

These changes can easily be implemented without breaking compatibility by preserving the current names as alternatives (maybe with a deprecation warning in the console) for the next x months / years / versions.


### References

**Previous PR's attempting to push flexibility into chosens master branch**

https://github.com/harvesthq/chosen/pull/2599
https://github.com/harvesthq/chosen/pull/2811
https://github.com/harvesthq/chosen/pull/2028
https://github.com/harvesthq/chosen/pull/858
https://github.com/harvesthq/chosen/pull/867
https://github.com/harvesthq/chosen/pull/1037
https://github.com/harvesthq/chosen/pull/2028

**A couple of open issues that would be fixed**

https://github.com/harvesthq/chosen/issues/2752
https://github.com/harvesthq/chosen/issues/2831
... there are probably several others