### PR TITLE
Custom word boundary

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -27,6 +27,7 @@ class AbstractChosen
     @enable_split_word_search = if @options.enable_split_word_search? then @options.enable_split_word_search else true
     @group_search = if @options.group_search? then @options.group_search else true
     @search_contains = @options.search_contains || false
+    @search_word_boundary = if @options.search_word_boundary? then @options.search_word_boundary else '^|\\s|\\b'
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
@@ -217,7 +218,7 @@ class AbstractChosen
       this.winnow_results_set_highlight()
 
   get_search_regex: (escaped_search_string) ->
-    regex_string = if @search_contains then escaped_search_string else "(^|\\s|\\b)#{escaped_search_string}[^\\s]*"
+    regex_string = if @search_contains then escaped_search_string else "(#{@search_word_boundary})#{escaped_search_string}[^\\s]*"
     regex_string = "^#{regex_string}" unless @enable_split_word_search or @search_contains
     regex_flag = if @case_sensitive_search then "" else "i"
     new RegExp(regex_string, regex_flag)

--- a/nbproject/private/private.properties
+++ b/nbproject/private/private.properties
@@ -1,0 +1,1 @@
+browser=Chrome.INTEGRATED

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,4 @@
+file.reference.chosen-public=public
+files.encoding=UTF-8
+site.root.folder=${file.reference.chosen-public}
+source.folder=

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.web.clientproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/clientside-project/1">
+            <name>chosen</name>
+        </data>
+    </configuration>
+</project>

--- a/public/options.html
+++ b/public/options.html
@@ -92,6 +92,11 @@
           <td>By default, Chosen will search group labels as well as options, and filter to show all options below matching groups. Set this to <code class="language-javascript">false</code> to search only in the options.</td>
         </tr>
         <tr>
+          <td>search_word_boundary</td>
+          <td>^|\\b|\\s</td>
+          <td>By default, Chosen uses JS RegExp's built-in word boundary to detect word beginnings as well as whitespace or the beginning of the entire label. That works great for ascii-only languages, but <strong>will</strong> erroneously detect word boundaries after letters with umlauts among many, many others.<br>You can pass a string (that will be interpreted as part of a <code class="language-javascript">RegExp</code>) refined for your language and use case to correctly detect word boundaries. A (simplified) example could be <code class="language-javascript">'^|[^A-zæøåÆØÅ]'</code> for Danish.</td>
+        </tr>
+        <tr>
           <td>single_backstroke_delete</td>
           <td>true</td>
           <td>By default, pressing delete/backspace on multiple selects will remove a selected choice. When <code class="language-javascript">false</code>, pressing delete/backspace will highlight the last choice, and a second press deselects it.</td>

--- a/public/options.html
+++ b/public/options.html
@@ -87,11 +87,6 @@
           <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()s and []s.</td>
         </tr>
         <tr>
-          <td>search_word_boundary</td>
-          <td>^|\\b|\\s</td>
-          <td>By default, Chosen uses JS RegExp's built-in word boundary to detect word beginnings as well as whitespace or the beginning of the entire label. That works great for ascii-only languages, but <strong>will</strong> erroneously detect word boundaries after letters with umlauts among many, many others.<br>You can pass a string (that will be interpreted as part of a <code class="language-javascript">RegExp</code>) refined for your language and use case to correctly detect word boundaries. A (simplified) example could be <code class="language-javascript">'^|[^A-zæøåÆØÅ]'</code> for Danish.</td>
-        </tr>
-        <tr>
           <td>group_search</td>
           <td>true</td>
           <td>By default, Chosen will search group labels as well as options, and filter to show all options below matching groups. Set this to <code class="language-javascript">false</code> to search only in the options.</td>

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -247,7 +247,7 @@ describe "Searching", ->
 
     expect(div.find(".active-result").length).toBe(1)
     expect(div.find(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")
-
+    
   describe "respects word boundaries when not using search_contains", ->
     div = $("<div>").html("""
       <select>
@@ -279,3 +279,21 @@ describe "Searching", ->
         search_field.trigger("keyup")
         expect(div.find(".active-result").length).toBe(1)
         expect(div.find(".active-result")[0].innerText.slice(1)).toBe(boundary_thing)
+
+  it "respects custom search_word_boundary when not using search_contains", ->
+    div = $("<div>").html("""
+      <select>
+        <option value="Frank Møller">Frank Møller</option>
+      </select>
+    """)
+    div.find("select").chosen({search_word_boundary: '^|[^A-zæøåÆØÅ]'})
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val('ller')
+    search_field.trigger("keyup")
+    expect(div.find(".active-result").length).toBe(0)
+    search_field.val('Møl')
+    search_field.trigger("keyup")
+    expect(div.find(".active-result").length).toBe(1)
+    expect(div.find(".active-result")[0].innerHTML).toBe('Frank <em>Møl</em>ler')

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -291,3 +291,22 @@ describe "Searching", ->
         simulant.fire(search_field, "keyup")
         expect(div.select(".active-result").length).toBe(1)
         expect(div.select(".active-result")[0].innerText.slice(1)).toBe(boundary_thing)
+        
+  it "respects custom search_word_boundary when not using search_contains", ->
+    div = new Element("div")
+    div.update("""
+      <select>
+        <option value="Frank Møller">Frank Møller</option>
+      </select>
+    """)
+    new Chosen(div.down("select"), {search_word_boundary: '^|[^A-zæøåÆØÅ]'})
+    simulant.fire(div.down(".chosen-container"), "mousedown") # open the drop
+
+    search_field = div.down(".chosen-search-input")
+    search_field.value = 'ller'
+    simulant.fire(search_field, "keyup")
+    expect(div.select(".active-result").length).toBe(0)
+    search_field.value = 'Møl'
+    simulant.fire(search_field, "keyup")
+    expect(div.select(".active-result").length).toBe(1)
+    expect(div.select(".active-result")[0].innerHTML).toBe('Frank <em>Møl</em>ler')


### PR DESCRIPTION
### Summary

The default / current word boundary regex `^|\\b|\\s` is remarkably bad at actually finding word boundaries in languages that use non-unicode characters. A word boundary is basically detected after any non-ascii character (fx. ü, å, ø and æ to mention just a few - but there are MANY).

I've looked into possibilities, and unfortunately there doesn't seem to be any way to get decent word-boundary detection for anything except ascii in javascripts RegExp implementation... without either using a third-party library or including some 4k+ characters in the string.

Therefore, I don't see any way to reliably detect word boundaries with any pre-set, hardcoded regex.

Turning it into an option means that people can at least set something appropriate for their individual language and / or use case if they care about word boundaries being detected in "weird" places.

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [x] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [x] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

### References

First partial PR from: https://github.com/harvesthq/chosen/pull/2894