### PR TITLE
Add group_search to options page

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -87,6 +87,11 @@
           <td>By default, Chosen’s search matches starting at the beginning of a word. Setting this option to <code class="language-javascript">true</code> allows matches starting from anywhere within a word. This is especially useful for options that include a lot of special characters or phrases in ()s and []s.</td>
         </tr>
         <tr>
+          <td>group_search</td>
+          <td>true</td>
+          <td>By default chosen will search labels of groups as well as options, and display all options below matching groups. Set this to <code class="language-javascript">false</code> to search only in actual options.</td>
+        </tr>
+        <tr>
           <td>single_backstroke_delete</td>
           <td>true</td>
           <td>By default, pressing delete/backspace on multiple selects will remove a selected choice. When <code class="language-javascript">false</code>, pressing delete/backspace will highlight the last choice, and a second press deselects it.</td>


### PR DESCRIPTION
### Summary

Just added a short description of the undocumented `group_search` to the options page.

### References

https://github.com/harvesthq/chosen/issues/2752