### PR TITLE
describe => it

### DIFF
--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -248,7 +248,7 @@ describe "Searching", ->
     expect(div.find(".active-result").length).toBe(1)
     expect(div.find(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")
 
-  describe "respects word boundaries when not using search_contains", ->
+  it "respects word boundaries when not using search_contains", ->
     div = $("<div>").html("""
       <select>
         <option value="(lparen">(lparen</option>

--- a/spec/proto/searching.spec.coffee
+++ b/spec/proto/searching.spec.coffee
@@ -259,7 +259,7 @@ describe "Searching", ->
     expect(div.select(".active-result").length).toBe(1)
     expect(div.select(".active-result")[0].innerHTML).toBe("oh <em>h</em>ello")
 
-  describe "respects word boundaries when not using search_contains", ->
+  it "respects word boundaries when not using search_contains", ->
     div = new Element("div")
     div.update("""
       <select>


### PR DESCRIPTION
The incorrect keyword was being used.