### PR TITLE
Skip highlight when holding the meta key.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -374,7 +374,7 @@ class Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results()
+        this.winnow_results(skip_highlight: true)
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -366,7 +366,7 @@ class @Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results()
+        this.winnow_results(skip_highlight: true)
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -159,7 +159,7 @@ class AbstractChosen
     else
       this.results_show()
 
-  winnow_results: ->
+  winnow_results: (options) ->
     this.no_results_clear()
 
     results = 0
@@ -214,7 +214,7 @@ class AbstractChosen
       this.no_results query
     else
       this.update_results_content this.results_option_build()
-      this.winnow_results_set_highlight()
+      this.winnow_results_set_highlight() unless options?.skip_highlight
 
   get_search_regex: (escaped_search_string) ->
     regex_string = if @search_contains then escaped_search_string else "(^|\\s|\\b)#{escaped_search_string}[^\\s]*"


### PR DESCRIPTION
@harvesthq/chosen-developers 👋 

Fix #2888

When holding command and selecting an option from a multi-select, the selection area should not scroll back to the top. I'll write some tests and push those shortly!