### PR TITLE
Do not highlight first result or clear search input when holding control/meta key.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -374,7 +374,7 @@ class Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results()
+        this.winnow_results(skip_highlight: true)
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -366,7 +366,6 @@ class Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = null
-      @search_field.val("")
 
       if @is_multiple
         this.choice_build item
@@ -374,7 +373,11 @@ class Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results(skip_highlight: true)
+        if evt.metaKey or evt.ctrlKey
+          this.winnow_results(skip_highlight: true)
+        else
+          @search_field.val("")
+          this.winnow_results()
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -358,7 +358,6 @@ class @Chosen extends AbstractChosen
 
       @form_field.options[item.options_index].selected = true
       @selected_option_count = null
-      @search_field.value = ""
 
       if @is_multiple
         this.choice_build item
@@ -366,7 +365,11 @@ class @Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results(skip_highlight: true)
+        if evt.metaKey or evt.ctrlKey
+          this.winnow_results(skip_highlight: true)
+        else
+          @search_field.value = ""
+          this.winnow_results()
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -366,7 +366,7 @@ class @Chosen extends AbstractChosen
         this.single_set_selected_text(this.choice_label(item))
 
       if @is_multiple && (!@hide_results_on_select || (evt.metaKey or evt.ctrlKey))
-        this.winnow_results()
+        this.winnow_results(skip_highlight: true)
       else
         this.results_hide()
         this.show_search_field_default()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -159,7 +159,7 @@ class AbstractChosen
     else
       this.results_show()
 
-  winnow_results: ->
+  winnow_results: (options) ->
     this.no_results_clear()
 
     results = 0
@@ -214,7 +214,7 @@ class AbstractChosen
       this.no_results query
     else
       this.update_results_content this.results_option_build()
-      this.winnow_results_set_highlight()
+      this.winnow_results_set_highlight() unless options?.skip_highlight
 
   get_search_regex: (escaped_search_string) ->
     regex_string = if @search_contains then escaped_search_string else "(^|\\s|\\b)#{escaped_search_string}[^\\s]*"

--- a/spec/jquery/searching.spec.coffee
+++ b/spec/jquery/searching.spec.coffee
@@ -279,3 +279,93 @@ describe "Searching", ->
         search_field.trigger("keyup")
         expect(div.find(".active-result").length).toBe(1)
         expect(div.find(".active-result")[0].innerText.slice(1)).toBe(boundary_thing)
+
+  it "does not clear search text or highlight first suggestion when holding ctrl/cmd and selecting multiple items", () ->
+    div = $("<div>").html("""
+      <select multiple>
+        <option></option>
+        <option>Betty Holberton</option>
+        <option>Radia Perlman</option>
+        <option>Barbara Liskov</option>
+        <option>Frances Allen</option>
+        <option>Shafi Goldwasser</option>
+        <option>Maria Klawe</option>
+        <option>Jean E. Sammet</option>
+        <option>Adele Goldberg</option>
+        <option>Jeannette Wing</option>
+        <option>Éva Tardos</option>
+        <option>Lynn Conway</option>
+        <option>Karen Spärck Jones</option>
+        <option>Sophie Wilson</option>
+        <option>Wendy Hall</option>
+      </select>
+    """)
+
+    div.find("select").chosen()
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val("s").trigger("keyup")
+
+    results = div.find(".chosen-results")
+    first_result = results.find("li:nth-of-type(1)")
+    second_result = results.find("li:nth-of-type(2)")
+
+    expect(first_result.prop("class")).toContain("highlighted")
+
+    mouseup_with_meta = $.Event("mouseup")
+    mouseup_with_meta.metaKey = true
+    second_result.mouseover().trigger(mouseup_with_meta)
+
+    expect(div.find(".search-choice").length).toBe(1)
+    expect(search_field.val()).toBe("s")
+    expect(first_result.prop("class")).not.toContain("highlighted")
+
+    third_result = results.find("li:nth-of-type(3)")
+
+    mouseup_with_ctrl = $.Event("mouseup")
+    mouseup_with_ctrl.ctrlKey = true
+    third_result.mouseover().trigger(mouseup_with_ctrl)
+
+    expect(div.find(".search-choice").length).toBe(2)
+    expect(search_field.val()).toBe("s")
+    expect(first_result.prop("class")).not.toContain("highlighted")
+
+  it "clears search text and highlights first suggestion without ctrl/cmd and selecting multiple items without hide_results_on_select", () ->
+    div = $("<div>").html("""
+      <select multiple>
+        <option></option>
+        <option>Betty Holberton</option>
+        <option>Radia Perlman</option>
+        <option>Barbara Liskov</option>
+        <option>Frances Allen</option>
+        <option>Shafi Goldwasser</option>
+        <option>Maria Klawe</option>
+        <option>Jean E. Sammet</option>
+        <option>Adele Goldberg</option>
+        <option>Jeannette Wing</option>
+        <option>Éva Tardos</option>
+        <option>Lynn Conway</option>
+        <option>Karen Spärck Jones</option>
+        <option>Sophie Wilson</option>
+        <option>Wendy Hall</option>
+      </select>
+    """)
+
+    div.find("select").chosen(hide_results_on_select: false)
+    div.find(".chosen-container").trigger("mousedown") # open the drop
+
+    search_field = div.find(".chosen-search-input")
+    search_field.val("s").trigger("keyup")
+
+    results = div.find(".chosen-results")
+    first_result = results.find("li:nth-of-type(1)")
+    second_result = results.find("li:nth-of-type(2)")
+
+    expect(first_result.prop("class")).toContain("highlighted")
+
+    second_result.mouseover().mouseup()
+
+    expect(div.find(".search-choice").length).toBe(1)
+    expect(search_field.val()).toBe("")
+    expect(results.find("li:nth-of-type(1)").prop("class")).toContain("highlighted")


### PR DESCRIPTION
@harvesthq/chosen-developers to fix #2888, replaces #2900.

Building on @braddunbar’s #2900, this PR skips highlighting the first result as described in that PR and also does not reset the search input. This ensures we can do searchless multiple select when holding the control/meta key: 

![screencast of holding meta to select many options](https://cl.ly/1D1Q3D1I3w1N/Screen%20Recording%202017-10-25%20at%2003.23%20PM.gif)

This also ensures we can do multiple select while searching using the control/meta key:

![screencast of searching and holding meta to select many options](https://cl.ly/0914001f0Q21/Screen%20Recording%202017-10-25%20at%2003.24%20PM.gif)

This is similar to the suggestion that @koenpunt mentioned in https://github.com/harvesthq/chosen/pull/2867#issuecomment-324076160:

> … it might be relevant to leave the text in, if someone wants to select multiple options that matched their query. So maybe we should only clear the input when there are no more matching options visible?

This PR doesn’t exactly implement this behavior — it instead leaves the input when meta/control is pressed — but allows users to achieve the same thing.

I wasn’t able to implement a prototype version of the related test — `simulant` doesn’t appear to bubble events, so I can’t get the event handler to trigger correctly in prototype (either the event comes from the correct `.active-result` item and doesn’t hit the event handler which is registered on `.chosen-results`, or the event comes from the wrong item (`.chosen-results`) and hits the event handler). I spent… too much time (3:04) working on trying to get a test working for prototype — but at least we’re covered with a jQuery test.