### PR TITLE
Add new option: hide_results_threshold

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -436,7 +436,8 @@ class Chosen extends AbstractChosen
 
   no_results: (terms) ->
     no_results_html = this.get_no_results_html(terms)
-    @search_results.append no_results_html
+    if terms
+      @search_results.append no_results_html
     @form_field_jq.trigger("chosen:no_results", {chosen:this})
 
   no_results_clear: ->

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -35,6 +35,7 @@ class AbstractChosen
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
     @case_sensitive_search = @options.case_sensitive_search || false
+    @hide_results_on_startup = @options.hide_results_on_startup || false;
     @hide_results_on_select = if @options.hide_results_on_select? then @options.hide_results_on_select else true
 
   set_default_text: ->
@@ -209,12 +210,16 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
-    if results < 1 and query.length
+    if this.hide_results_on_startup and !query.length and results >0
       this.update_results_content ""
       this.no_results query
     else
-      this.update_results_content this.results_option_build()
-      this.winnow_results_set_highlight()
+      if results < 1 and query.length
+        this.update_results_content ""
+        this.no_results query
+      else
+        this.update_results_content this.results_option_build()
+        this.winnow_results_set_highlight()
 
   get_search_regex: (escaped_search_string) ->
     regex_string = if @search_contains then escaped_search_string else "(^|\\s|\\b)#{escaped_search_string}[^\\s]*"

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -35,7 +35,7 @@ class AbstractChosen
     @include_group_label_in_selected = @options.include_group_label_in_selected || false
     @max_shown_results = @options.max_shown_results || Number.POSITIVE_INFINITY
     @case_sensitive_search = @options.case_sensitive_search || false
-    @hide_results_on_startup = @options.hide_results_on_startup || false;
+    @hide_results_threshold = if @options.hide_results_threshold? and @disable_search is no and @disable_search_threshold <= @options.hide_results_threshold then @options.hide_results_threshold else false;
     @hide_results_on_select = if @options.hide_results_on_select? then @options.hide_results_on_select else true
 
   set_default_text: ->
@@ -210,7 +210,7 @@ class AbstractChosen
 
     this.result_clear_highlight()
 
-    if this.hide_results_on_startup and !query.length and results >0
+    if this.hide_results_threshold isnt false and !query.length and results >0 and @form_field.options.length >= @hide_results_threshold
       this.update_results_content ""
       this.no_results query
     else


### PR DESCRIPTION
<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->

### Summary

Add new option: hide_results_threshold,
<p>The <code>hide_results_threshold</code> option can be specified to hide the results if there are too many options, such as 100 or more, to avoid response slow.</p>

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [x] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.
