### PR TITLE
Add `option` class passthrough for multi-select

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -310,6 +310,8 @@ class Chosen extends AbstractChosen
       close_link = $('<a />', { class: 'search-choice-close', 'data-option-array-index': item.array_index })
       close_link.on 'click.chosen', (evt) => this.choice_destroy_link_click(evt)
       choice.append close_link
+    if @inherit_option_classes && item.classes
+      choice[0].classList.add item.classes
 
     @search_container.before  choice
 

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -302,6 +302,8 @@ class @Chosen extends AbstractChosen
       close_link = new Element('a', { href: '#', class: 'search-choice-close', rel: item.array_index })
       close_link.observe "click", (evt) => this.choice_destroy_link_click(evt)
       choice.insert close_link
+    if @inherit_option_classes && item.classes
+      choice[0].classList.add item.classes
 
     @search_container.insert { before: choice }
 

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -30,6 +30,7 @@ class AbstractChosen
     @single_backstroke_delete = if @options.single_backstroke_delete? then @options.single_backstroke_delete else true
     @max_selected_options = @options.max_selected_options || Infinity
     @inherit_select_classes = @options.inherit_select_classes || false
+    @inherit_option_classes = @options.inherit_option_classes || false
     @display_selected_options = if @options.display_selected_options? then @options.display_selected_options else true
     @display_disabled_options = if @options.display_disabled_options? then @options.display_disabled_options else true
     @include_group_label_in_selected = @options.include_group_label_in_selected || false

--- a/public/options.html
+++ b/public/options.html
@@ -61,6 +61,11 @@
           <td>When set to <code class="language-javascript">true</code>, Chosen will grab any classes on the original select field and add them to Chosen’s container div.</td>
         </tr>
         <tr>
+          <td>inherit_option_classes</td>
+          <td>false</td>
+          <td>When set to <code class="language-javascript">true</code>, Chosen will grab any classes on the original option tags and add them to Chosen’s container li.</td>
+        </tr>
+        <tr>
           <td>max_selected_options</td>
           <td>Infinity</td>
           <td>Limits how many options the user can select. When the limit is reached, the <code class="language-javascript">chosen:maxselected</code> event is triggered.</td>


### PR DESCRIPTION
I had a fairly specific need to style a specific `option` tag differently than the rest of them in a multi-select box. This works somewhat similarly to the `inherit_select_classes` option, but it works on the `option` tags.

I've never worked with Coffee before, so I apologize if I have made any stupid mistakes. This code works for me, but the additional classes needs to be defined in CSS with the `important` rule if their style fields will be overwritten by `search-choice`.