### PR TITLE
Remove `clip` property by moving chosen-single’s search input.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -243,6 +243,9 @@ class Chosen extends AbstractChosen
       @form_field_jq.trigger("chosen:maxselected", {chosen: this})
       return false
 
+    unless @is_multiple
+      @search_container.append @search_field
+
     @container.addClass "chosen-with-drop"
     @results_showing = true
 
@@ -258,6 +261,10 @@ class Chosen extends AbstractChosen
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()
+
+      unless @is_multiple
+        @selected_item.prepend @search_field
+        @search_field.focus()
 
       @container.removeClass "chosen-with-drop"
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -235,6 +235,9 @@ class @Chosen extends AbstractChosen
       @form_field.fire("chosen:maxselected", {chosen: this})
       return false
 
+    unless @is_multiple
+      @search_container.insert @search_field
+
     @container.addClassName "chosen-with-drop"
     @results_showing = true
 
@@ -250,6 +253,10 @@ class @Chosen extends AbstractChosen
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()
+
+      unless @is_multiple
+        @selected_item.insert top: @search_field
+        @search_field.focus()
 
       @container.removeClassName "chosen-with-drop"
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -332,12 +332,12 @@ class AbstractChosen
   get_single_html: ->
     """
       <a class="chosen-single chosen-default">
+        <input class="chosen-search-input" type="text" autocomplete="off" />
         <span>#{@default_text}</span>
         <div><b></b></div>
       </a>
       <div class="chosen-drop">
         <div class="chosen-search">
-          <input class="chosen-search-input" type="text" autocomplete="off" />
         </div>
         <ul class="chosen-results"></ul>
       </div>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -20,10 +20,10 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     border-top: 0;
     background: #fff;
     box-shadow: 0 4px 5px rgba(#000,.15);
-    clip: rect(0,0,0,0);
+    display: none;
   }
   &.chosen-with-drop .chosen-drop {
-    clip: auto;
+    display: block;
   }
   a{
     cursor: pointer;
@@ -65,6 +65,12 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     text-decoration: none;
     white-space: nowrap;
     line-height: 24px;
+
+    input[type="text"] {
+      cursor: pointer;
+      opacity: 0;
+      position: absolute;
+    }
   }
   .chosen-default {
     color: #999;


### PR DESCRIPTION
@harvesthq/chosen-developers to fix #2816, replaces #2780.

This PR removes the deprecated `clip` property by replacing it with `display: none` and `display: block`, just as @bingxie did in #2780 — however, this PR also moves the search input when using a single-select chosen to fix focus issues.

The core issue is that we were relying on the search input to catch keyboard events (including tabbing to the field), and that for single-select chosen instances, the search input was inside of the results drop that is hidden when you’re tabbing to the field. 

When using `left: -9999px`, the element was still technically visible (although it wasn’t) so it could catch keyboard events. When using `clip: rect(0,0,0,0)`, it was also still technically visible (although it wasn’t). 

For single-select chosen instances: 

- On initial render, the search input is rendered outside the results drop, over the selected option area. It’s set to `opacity: 0` via CSS so it can receive keyboard events, but not adjust the design.
- On results show, the search input is inserted into the results drop. Since elements can only exist in one place in the DOM at a time, it’s automatically removed from the previous location. The `opacity: 0` CSS rule no longer applies.
- On results hide, the search input is inserted back into the selected option area, which automatically removes it from the results drop. The `opacity: 0` CSS rule applies once more.

/cc @mateuspv as the original issue reporter

-------

It looks like CI is failing to run tests because it can’t load jQuery — I checked for a quick fix but we may need to stop relying on a CDN for build stability. I’ll confirm that this is not just an issue with this PR, and then open up a new PR to fix the build. Until then, you can run the tests locally to confirm, if you’d like. 