### PR TITLE
Remove forgotten usage of css `clip`.

### DIFF
--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -143,7 +143,8 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
   }
   &.chosen-container-single-nosearch .chosen-search {
     position: absolute;
-    clip: rect(0,0,0,0);
+    opacity: 0;
+    pointer-events: none;
   }
 }
 /* @end */


### PR DESCRIPTION
@harvesthq/chosen-developers to fix #2942 originally reported by @taichunmin, a follow-up to #2939 which fixed #2816.

I missed a usage of `clip` — when the search input is hidden due to search being disabled in options or having fewer than `disable_search_threshold` items. 

This usage of `clip` was similar to the others — to hide the search input but allow it to still receive keyboard events. We can use the same approach as #2939 — simply make the search input transparent instead.