### PR TITLE
Use two inputs for Chosen’s focus and search.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -332,12 +332,13 @@ class AbstractChosen
   get_single_html: ->
     """
       <a class="chosen-single chosen-default">
-        <input class="chosen-search-input" type="text" autocomplete="off" />
+        <input class="chosen-focus-input" type="text" autocomplete="off" />
         <span>#{@default_text}</span>
         <div><b></b></div>
       </a>
       <div class="chosen-drop">
         <div class="chosen-search">
+          <input class="chosen-search-input" type="text" autocomplete="off" />
         </div>
         <ul class="chosen-results"></ul>
       </div>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -70,6 +70,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
       cursor: pointer;
       opacity: 0;
       position: absolute;
+      width: 0;
     }
   }
   .chosen-default {


### PR DESCRIPTION
@harvesthq/chosen-developers as a follow-up to #2939, fixing #2953.

As mentioned in #2939: 

> As an aside, I originally went with two inputs — a new one to catch the focus events when the results drop was closed, and the existing search input — however, it quickly became ridiculous because letters typed into the focus input cause the results drop to filter and show at the same time. This meant that I had to forward events that caused letters to be typed into the focus input over to the search input… and simulating keyboard events is gross.
> 
> Using a single input that moves ended up being significantly easier.

This isn’t my first choice, but IE11 has demonstrated interesting behavior when moving a focused input element in the DOM: 

- If an input is moved in the DOM during the processing of a `focus` event, it results in the input becoming blurred (this is the same cross-browser). 
- In IE11, the input never triggers a `blur` event, it just simply no longer is focused.
- In IE11, the browser seems to still considers the element focused, and therefore calling `focus()` on it does not cause it to become focused. 

Here’s [a minimal example](https://jsfiddle.net/y7ywv8hf/11/): 

| IE11 | Chrome | 
|-----|---------|
| ![screencast showing that blur events are not fired in IE11](https://user-images.githubusercontent.com/14930/37485535-1f958e7a-2862-11e8-8fcc-8fcaf8a6bf2f.gif) | ![screencast showing blur events being fired in Chrome](https://user-images.githubusercontent.com/14930/37485621-623ebf8a-2862-11e8-9fc7-993a98beeabf.gif) |

I dug into this quite a bit, but I wasn’t able to come up with a way to reliably move the input cross-browser.

The result: introducing a second input, registering the same event handlers on it, and then syncing the values of the inputs when jumping focus between the two inputs when the results drop is shown. It’s a little hacky, but I’m not confident that I can find a less-hacky solution. If you can think of one, I’m _so interested_ in doing that. 😅 
