### PR TITLE
Update publish-package.sh to include LICENSE file.

### DIFF
--- a/publish-package.sh
+++ b/publish-package.sh
@@ -14,7 +14,7 @@ GITHUB_URL=https://pfiller:${GH_TOKEN}@github.com/harvesthq/chosen-package.git
 
 git clone $GITHUB_URL
 rm -rf chosen-package/*
-cp README.md public/*.json public/*.png public/*.js public/*.css chosen-package/
+cp README.md public/*.json public/*.png public/*.js public/*.css public/LICENSE* chosen-package/
 cp package-travis.yml chosen-package/.travis.yml
 cd chosen-package
 


### PR DESCRIPTION
@harvesthq/chosen-developers as follow-up to #2966 (which fixed #2945… almost).

Unfortunately, version 1.8.4 did not include the LICENSE in `chosen-package`. Although NPM automatically includes LICENSE files in packages, I overlooked our custom `publish-package.sh` script run on Travis CI builds of this repo, which has a specific list of files to copy to the folder which will be pushed to `chosen-package` and then published by NPM. 

I believe this is… now… the last thing that needs to be done. Whew! 