### PR TITLE
Commit selected element along with the index on change event

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -398,7 +398,7 @@ class Chosen extends AbstractChosen
         this.results_hide()
         this.show_search_field_default()
 
-      this.trigger_form_field_change selected: @form_field.options[item.options_index].value  if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
+      this.trigger_form_field_change selected: @form_field.options[item.options_index].value, selected_element: @form_field.options[item.options_index]  if @is_multiple || @form_field.selectedIndex != @current_selectedIndex
       @current_selectedIndex = @form_field.selectedIndex
 
       evt.preventDefault()
@@ -426,7 +426,7 @@ class Chosen extends AbstractChosen
       this.result_clear_highlight()
       this.winnow_results() if @results_showing
 
-      this.trigger_form_field_change deselected: @form_field.options[result_data.options_index].value
+      this.trigger_form_field_change deselected: @form_field.options[result_data.options_index].value, deselected_element: @form_field.options[result_data.options_index]
       this.search_field_scale()
 
       return true


### PR DESCRIPTION
### Summary

I have build a small external listener to chosen that builds some custom "null" Elements for selection complete optgroups with a single click. These "All of "-Elements have a simple null value and nothing more then the name to get them. The Index of Chosen is the thing that had not helped me to get the selected element in the origin select box (the hidden form element). 

So i added ```selected_element``` along with ```selected``` and ```deselected_element``` along with ```deselected```. These are additional information that will be send along with the change event to the hidden select element. 

I have not added the fields to code parts that does not have the ```selected``` or ```deselected``` fields. 