### PR TITLE
Revert previous clip-deprecation fixes in favor of hybrid clip and clip-path.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -243,9 +243,6 @@ class Chosen extends AbstractChosen
       @form_field_jq.trigger("chosen:maxselected", {chosen: this})
       return false
 
-    unless @is_multiple
-      @search_container.append @search_field
-
     @container.addClass "chosen-with-drop"
     @results_showing = true
 
@@ -261,10 +258,6 @@ class Chosen extends AbstractChosen
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()
-
-      unless @is_multiple
-        @selected_item.prepend @search_field
-        @search_field.focus()
 
       @container.removeClass "chosen-with-drop"
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})

--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -50,8 +50,7 @@ class Chosen extends AbstractChosen
     @form_field_jq.hide().after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
-    @search_field = @container.find('input.chosen-search-input')
-    @focus_field = @container.find('input.chosen-focus-input')
+    @search_field = @container.find('input').first()
     @search_results = @container.find('ul.chosen-results').first()
     this.search_field_scale()
 
@@ -105,18 +104,6 @@ class Chosen extends AbstractChosen
       @search_choices.on 'click.chosen', (evt) => this.choices_click(evt); return
     else
       @container.on 'click.chosen', (evt) -> evt.preventDefault(); return # gobble click of anchor
-
-      @focus_field.on 'blur.chosen', (evt) => this.input_blur(evt); return
-      @focus_field.on 'focus.chosen', (evt) => this.input_focus(evt); return
-
-      transfer_value = () =>
-        @search_field.val(@focus_field.val())
-        @focus_field.val('')
-
-      @focus_field.on 'keyup.chosen', (evt) => transfer_value(); this.keyup_checker(evt); return
-      @focus_field.on 'keydown.chosen', (evt) => transfer_value(); this.keydown_checker(evt); return
-      @focus_field.on 'cut.chosen', (evt) => setTimeout(transfer_value, 0); this.clipboard_event_checker(evt); return
-      @focus_field.on 'paste.chosen', (evt) => setTimeout(transfer_value, 0); this.clipboard_event_checker(evt); return
 
   destroy: ->
     $(@container[0].ownerDocument).off 'click.chosen', @click_test_action
@@ -192,7 +179,9 @@ class Chosen extends AbstractChosen
     @container.addClass "chosen-container-active"
     @active_field = true
 
+    @search_field.val(@search_field.val())
     @search_field.focus()
+
 
   test_active_click: (evt) ->
     active_container = $(evt.target).closest('.chosen-container')
@@ -213,11 +202,9 @@ class Chosen extends AbstractChosen
       this.single_set_selected_text()
       if @disable_search or @form_field.options.length <= @disable_search_threshold
         @search_field[0].readOnly = true
-        @focus_field[0].readOnly = true
         @container.addClass "chosen-container-single-nosearch"
       else
         @search_field[0].readOnly = false
-        @focus_field[0].readOnly = false
         @container.removeClass "chosen-container-single-nosearch"
 
     this.update_results_content this.results_option_build({first:true})
@@ -256,6 +243,9 @@ class Chosen extends AbstractChosen
       @form_field_jq.trigger("chosen:maxselected", {chosen: this})
       return false
 
+    unless @is_multiple
+      @search_container.append @search_field
+
     @container.addClass "chosen-with-drop"
     @results_showing = true
 
@@ -272,7 +262,9 @@ class Chosen extends AbstractChosen
     if @results_showing
       this.result_clear_highlight()
 
-      setTimeout((() => @focus_field.focus()), 0)
+      unless @is_multiple
+        @selected_item.prepend @search_field
+        @search_field.focus()
 
       @container.removeClass "chosen-with-drop"
       @form_field_jq.trigger("chosen:hiding_dropdown", {chosen: this})
@@ -285,7 +277,6 @@ class Chosen extends AbstractChosen
       ti = @form_field.tabIndex
       @form_field.tabIndex = -1
       @search_field[0].tabIndex = ti
-      @focus_field[0]?.tabIndex = ti
 
   set_label_behavior: ->
     @form_field_label = @form_field_jq.parents("label") # first check for a parent label

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -235,9 +235,6 @@ class @Chosen extends AbstractChosen
       @form_field.fire("chosen:maxselected", {chosen: this})
       return false
 
-    unless @is_multiple
-      @search_container.insert @search_field
-
     @container.addClassName "chosen-with-drop"
     @results_showing = true
 
@@ -253,10 +250,6 @@ class @Chosen extends AbstractChosen
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()
-
-      unless @is_multiple
-        @selected_item.insert top: @search_field
-        @search_field.focus()
 
       @container.removeClassName "chosen-with-drop"
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -28,8 +28,7 @@ class @Chosen extends AbstractChosen
     @form_field.hide().insert({ after: @container })
     @dropdown = @container.down('div.chosen-drop')
 
-    @search_field = @container.down('input.chosen-search-input')
-    @focus_field = @container.down('input.chosen-focus-input')
+    @search_field = @container.down('input')
     @search_results = @container.down('ul.chosen-results')
     this.search_field_scale()
 
@@ -84,18 +83,6 @@ class @Chosen extends AbstractChosen
       @search_choices.observe "click", (evt) => this.choices_click(evt)
     else
       @container.observe "click", (evt) => evt.preventDefault() # gobble click of anchor
-
-      @focus_field.observe "blur", (evt) => this.input_blur(evt)
-      @focus_field.observe "focus", (evt) => this.input_focus(evt)
-
-      transfer_value = () =>
-        @search_field.value = @focus_field.value
-        @focus_field.value = ""
-
-      @focus_field.observe "keyup", (evt) => transfer_value(); this.keyup_checker(evt)
-      @focus_field.observe "keydown", (evt) => transfer_value(); this.keydown_checker(evt)
-      @focus_field.observe "cut", (evt) => setTimeout(transfer_value, 0); this.clipboard_event_checker(evt)
-      @focus_field.observe "paste", (evt) => setTimeout(transfer_value, 0); this.clipboard_event_checker(evt)
 
   destroy: ->
     @container.ownerDocument.stopObserving "click", @click_test_action
@@ -187,6 +174,7 @@ class @Chosen extends AbstractChosen
     @container.addClassName "chosen-container-active"
     @active_field = true
 
+    @search_field.value = this.get_search_field_value()
     @search_field.focus()
 
   test_active_click: (evt) ->
@@ -207,11 +195,9 @@ class @Chosen extends AbstractChosen
       this.single_set_selected_text()
       if @disable_search or @form_field.options.length <= @disable_search_threshold
         @search_field.readOnly = true
-        @focus_field?.readOnly = true
         @container.addClassName "chosen-container-single-nosearch"
       else
         @search_field.readOnly = false
-        @focus_field?.readOnly = false
         @container.removeClassName "chosen-container-single-nosearch"
 
     this.update_results_content this.results_option_build({first:true})
@@ -249,6 +235,9 @@ class @Chosen extends AbstractChosen
       @form_field.fire("chosen:maxselected", {chosen: this})
       return false
 
+    unless @is_multiple
+      @search_container.insert @search_field
+
     @container.addClassName "chosen-with-drop"
     @results_showing = true
 
@@ -265,7 +254,9 @@ class @Chosen extends AbstractChosen
     if @results_showing
       this.result_clear_highlight()
 
-      setTimeout((() => @focus_field?.focus()), 0)
+      unless @is_multiple
+        @selected_item.insert top: @search_field
+        @search_field.focus()
 
       @container.removeClassName "chosen-with-drop"
       @form_field.fire("chosen:hiding_dropdown", {chosen: this})
@@ -278,7 +269,6 @@ class @Chosen extends AbstractChosen
       ti = @form_field.tabIndex
       @form_field.tabIndex = -1
       @search_field.tabIndex = ti
-      @focus_field?.tabIndex = ti
 
   set_label_behavior: ->
     @form_field_label = @form_field.up("label") # first check for a parent label

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -332,13 +332,12 @@ class AbstractChosen
   get_single_html: ->
     """
       <a class="chosen-single chosen-default">
-        <input class="chosen-focus-input" type="text" autocomplete="off" />
+        <input class="chosen-search-input" type="text" autocomplete="off" />
         <span>#{@default_text}</span>
         <div><b></b></div>
       </a>
       <div class="chosen-drop">
         <div class="chosen-search">
-          <input class="chosen-search-input" type="text" autocomplete="off" />
         </div>
         <ul class="chosen-results"></ul>
       </div>

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -332,12 +332,12 @@ class AbstractChosen
   get_single_html: ->
     """
       <a class="chosen-single chosen-default">
-        <input class="chosen-search-input" type="text" autocomplete="off" />
         <span>#{@default_text}</span>
         <div><b></b></div>
       </a>
       <div class="chosen-drop">
         <div class="chosen-search">
+          <input class="chosen-search-input" type="text" autocomplete="off" />
         </div>
         <ul class="chosen-results"></ul>
       </div>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -21,9 +21,11 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     background: #fff;
     box-shadow: 0 4px 5px rgba(#000,.15);
     clip: rect(0,0,0,0);
+    clip-path: inset(100% 100%);
   }
   &.chosen-with-drop .chosen-drop {
     clip: auto;
+    clip-path: none;
   }
   a{
     cursor: pointer;
@@ -138,6 +140,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
   &.chosen-container-single-nosearch .chosen-search {
     position: absolute;
     clip: rect(0,0,0,0);
+    clip-path: inset(100% 100%);
   }
 }
 /* @end */

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -143,8 +143,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
   }
   &.chosen-container-single-nosearch .chosen-search {
     position: absolute;
-    opacity: 0;
-    pointer-events: none;
+    clip: rect(0,0,0,0);
   }
 }
 /* @end */

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -70,7 +70,6 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
       cursor: pointer;
       opacity: 0;
       position: absolute;
-      width: 0;
     }
   }
   .chosen-default {

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -20,10 +20,10 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     border-top: 0;
     background: #fff;
     box-shadow: 0 4px 5px rgba(#000,.15);
-    display: none;
+    clip: rect(0,0,0,0);
   }
   &.chosen-with-drop .chosen-drop {
-    display: block;
+    clip: auto;
   }
   a{
     cursor: pointer;
@@ -65,12 +65,6 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     text-decoration: none;
     white-space: nowrap;
     line-height: 24px;
-
-    input[type="text"] {
-      cursor: pointer;
-      opacity: 0;
-      position: absolute;
-    }
   }
   .chosen-default {
     color: #999;


### PR DESCRIPTION
@harvesthq/chosen-developers /cc @jisraelsen 

This PR reverts #2939 and #2943, which attempted to avoid using the deprecated `clip` property and used `display: none`, at the cost of a second input to capture focus events. 

It didn’t work out too well, and has continued to be a headache as we try to use the latest version in Harvest. I think the best thing to do is admit it was the wrong choice and revert it. Juggling focus and key events isn’t standard across browsers, especially while making DOM modifications.

This PR instead leaves the deprecated `clip` property and additionally introduces the same fix using `clip-path`. The result is that browsers that do not support the new standard `clip-path` will fallback to using the deprecated `clip` property, without requiring any additional changes.

----------------

One nice side-effect: while trying to make this all work correctly, I had to dig way into the way we handle focus and blur events in Chosen. If you’re not aware, we’re currently doing a lot of juggling around blur events, since blurring an input technically happens while clicking on an item to select it. I discovered that we can avoid doing all of that if we rely on `focusin` and `focusout` events on the wrapping container, as demonstrated [in this jsfiddle](https://jsfiddle.net/a6wgLjkn/15/) (watch for `chosenfocus` and `chosenblur` events). I’ll be pursuing this further in a separate PR, and expect to be able to delete a bunch of focus-specific properties as well as [the extra 100ms the chosen drop is visible](https://github.com/harvesthq/chosen/blob/5e11af9d432a73d4da08154c41b20456b3630e25/coffee/lib/abstract-chosen.coffee#L67-L70) — but didn’t want to hold this up on an unrelated change.