### PR TITLE
Escape the `group_label` when rendering it 

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -51,7 +51,7 @@ class AbstractChosen
 
   choice_label: (item) ->
     if @include_group_label_in_selected and item.group_label?
-      "<b class='group-name'>#{item.group_label}</b>#{item.html}"
+      "<b class='group-name'>#{this.escape_html(item.group_label)}</b>#{item.html}"
     else
       item.html
 

--- a/spec/jquery/bugfixes.spec.coffee
+++ b/spec/jquery/bugfixes.spec.coffee
@@ -1,0 +1,30 @@
+describe "Bugfixes", ->
+  it "https://github.com/harvesthq/chosen/issues/2996 - XSS Vulnerability with `include_group_label_in_selected: true`", ->
+    tmpl = "
+      <select>
+        <option value=''></option>
+        <optgroup label='</script><script>console.log(1)</script>'>
+          <option>an xss option</option>
+        </optgroup>
+      </select>
+    "
+
+    div = $("<div>").html(tmpl)
+    select = div.find("select")
+
+    select.chosen
+      include_group_label_in_selected: true
+
+    # open the drop
+    container = div.find(".chosen-container")
+    container.trigger("mousedown")
+
+    xss_option = container.find(".active-result").last()
+    expect(xss_option.html()).toBe "an xss option"
+
+    # trigger the selection of the xss option
+    xss_option.trigger("mouseup")
+
+    # make sure the script tags are escaped correctly
+    label_html = container.find("a.chosen-single").html()
+    expect(label_html).toContain('&lt;/script&gt;&lt;script&gt;console.log(1)&lt;/script&gt;')

--- a/spec/proto/bugfixes.spec.coffee
+++ b/spec/proto/bugfixes.spec.coffee
@@ -1,0 +1,32 @@
+describe "Bugfixes", ->
+  it "https://github.com/harvesthq/chosen/issues/2996 - XSS Vulnerability with `include_group_label_in_selected: true`", ->
+    tmpl = "
+      <select>
+        <option value=''></option>
+        <optgroup id='xss' label='</script><script>console.log(1)</script>'>
+          <option>an xss option</option>
+        </optgroup>
+      </select>
+    "
+    div = new Element("div")
+    document.body.insert(div)
+    div.innerHTML = tmpl
+
+    select = div.down("select")
+    new Chosen select,
+      include_group_label_in_selected: true
+
+    # open the drop
+    container = div.down(".chosen-container")
+    simulant.fire(container, "mousedown") # open the drop
+
+    xss_option = container.select(".active-result").last()
+    expect(xss_option.innerHTML).toBe "an xss option"
+
+    # trigger the selection of the xss option
+    simulant.fire(xss_option, "mouseup")
+
+    # make sure the script tags are escaped correctly
+    label_html = container.down("a.chosen-single").innerHTML
+    expect(label_html).toContain('&lt;/script&gt;&lt;script&gt;console.log(1)&lt;/script&gt;')
+


### PR DESCRIPTION
Fixes #2996.

An easy fix, we were simply missing a call to `this.escape_html`. To be honest, I'm surprised this hasn't been a reported issue yet.

As a bonus, there are even tests for red-greening the fix!

Many thanks to @cade for his assistance with figuring out was was going on in the Ancient Technology™ test (read: Prototype JS).