### PR TITLE
Update encrypted NPM release token and document it

### DIFF
--- a/package-travis.yml
+++ b/package-travis.yml
@@ -9,7 +9,11 @@ deploy:
   provider: npm
   email: chosenjs@getharvest.com
   api_key:
-    secure: jilkDlYp31lPr5AxNTSoC7cgeJv1k+HFyD97RdscUm7Oc45397H//62twQY1w8gUtonjqoncSUe+deElbBs8Zm1RXoX3F3YdcrdhLgmpUFa6Qt2L1ttSJRJ/HOn7NxupwNAHCFiLib5ffFED6FvntHJG/A1693yQeR9lycMsmrQ=
+    # This key is for automatically publishing releases to NPM,
+    # but it is encrypted for publishing publicly like this using Travis.
+    # More information about how this token is generated and encrypted here:
+    # https://docs.travis-ci.com/user/deployment/npm#NPM-auth-token
+    secure: "WXJUezbSyFX2bDLmBpO2mLSTxVzn7FH1ll6hzGPD4PUrDCRgBW7RyXX3UnIwSknIOQ/pqDq9zRPCSxHgyWNW3dX84n4P7+5C2dlxagtsBKc/ovwGqHFOrb/U+yWgrBimXvpDQeaBveZJXPhN46YYkb4NNWlP3d6bYaXqR5qtURM="
   on:
     tags: true
     repo: harvesthq/chosen-package


### PR DESCRIPTION
@harvesthq/chosen-developers See [this comment](https://github.com/harvesthq/chosen/pull/2998#issuecomment-396400137) and the ~3 following ones.

This token has been broken for a while, so I generated a new one, encrypted it, updated the encrypted version, and added documenting comments about where this all comes from for the future.