### PR TITLE
Don't run a matrix against node latest; just the version we support (6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 
 node_js:
   - 6
-  - node
 
 addons:
   apt:
@@ -12,11 +11,6 @@ addons:
       - git-core
     packages:
       - git
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: node
 
 before_install: npm install -g grunt-cli
 before_script: grunt build package-npm package-bower


### PR DESCRIPTION
@satchmorun and I discovered this while pairing on the automatic build stuff — though `node` was failing in the matrix (which is fine), if it ever _succeeded_, either accidentally or intentionally, it would run the publish script twice — once for each success.

Instead of testing against something we know is going to fail without a goal of fixing it, let's just remove it until we think we're going to make it pass.

/cc @harvesthq/chosen-developers 