### PR TITLE
form_field_jq.hide(...).after is not a function

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -47,7 +47,8 @@ class Chosen extends AbstractChosen
     else
       @container.html this.get_single_html()
 
-    @form_field_jq.hide().after @container
+    @form_field_jq.hide()
+    @form_field_jq.after @container
     @dropdown = @container.find('div.chosen-drop').first()
 
     @search_field = @container.find('input').first()


### PR DESCRIPTION
jQuery "3.3.1" throws TypeError: this.form_field_jq.hide(...).after is not a function
the issue is fixed by splitting the lines.

<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->

### Summary

Provide a general description of the code changes in your pull request.

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [x] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [x] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.
