### PR TITLE
show options list when search input receive focus event.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -62,6 +62,9 @@ class AbstractChosen
     if @is_multiple
       setTimeout (=> this.container_mousedown()), 50 unless @active_field
     else
+      if !@results_showing
+        @results_show()
+
       @activate_field() unless @active_field
 
   input_blur: (evt) ->


### PR DESCRIPTION
hello,

I'm currently working on a legacy project that relies on this amazing component. However the system has many forms and most of the fields are to choose an option. Users want to navigate the fields using the keyboard, but when they find a select, everything goes "water down."
This PR is intended to correct this problem. It causes the options to appear when the search field receives the focus event.