### PR TITLE
Change composer package type to npm-asset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "input",
     "ui"
   ],
-  "type": "library",
+  "type": "npm-asset",
   "license": "MIT",
   "minimum-stability": "stable",
   "homepage": "https://harvesthq.github.io/chosen/",


### PR DESCRIPTION
None of the action items in the summary below are relevant because this is a change only in composer.json. If you think otherwise, please let me know.

This PR changes the type of this project in the composer.json file. The current value of `"library"` is not a very good fit because that is the default for PHP libraries which are usually placed in a non-web-accessible `vendor` directory. Since Chosen is a JavaScript library, it needs to be accessible via web.

Now, composer doesn't support any type that indicates web asset but there is a community project called [asset-packagist](https://asset-packagist.org) which utilises a type of `"npm-asset"`. This type of project is placed in web accessible directories using other packages such as `oomphinc/composer-installers-extender`. Now, this is not really relevant to this change but I am adding additional context to support my case.

The above might seem convoluted but is actually regular workflow at least for Drupal projects. I believe changing the composer type makes it very straight-forward for not just Drupal but various other projects as well to use chosen. The current type presents an additional unnecessary hurdle in setting up chosen for use with PHP projects.

<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->

### Summary

Provide a general description of the code changes in your pull request.

Please double-check that:

  - [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [ ] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.
