### PR TITLE
Add support for chosen:search_updated event

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -255,6 +255,9 @@ class Chosen extends AbstractChosen
   update_results_content: (content) ->
     @search_results.html content
 
+  fire_search_updated: (search_term) ->
+    @form_field_jq.trigger("chosen:search_updated", {chosen: this, search_term: search_term})
+
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()

--- a/coffee/chosen.proto.coffee
+++ b/coffee/chosen.proto.coffee
@@ -247,6 +247,9 @@ class @Chosen extends AbstractChosen
   update_results_content: (content) ->
     @search_results.update content
 
+  fire_search_updated: (search_term) ->
+    @form_field.fire("chosen:search_updated", {chosen: this, search_term: search_term})
+
   results_hide: ->
     if @results_showing
       this.result_clear_highlight()

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -211,9 +211,11 @@ class AbstractChosen
 
     if results < 1 and query.length
       this.update_results_content ""
+      this.fire_search_updated query
       this.no_results query
     else
       this.update_results_content this.results_option_build()
+      this.fire_search_updated query
       this.winnow_results_set_highlight() unless options?.skip_highlight
 
   get_search_regex: (escaped_search_string) ->

--- a/public/options.html
+++ b/public/options.html
@@ -245,6 +245,11 @@
           <td>Triggered if <code class="language-javascript">max_selected_options</code> is set and that total is broken.</td>
         </tr>
         <tr>
+          <td>chosen:search_updated</td>
+          <td>Triggered when Chosen’s search results are updated after typing search term.
+            The event includes a corresponding <code class="language-javascript">search_term</code> parameter.</td>
+        </tr>
+        <tr>
           <td>chosen:showing_dropdown</td>
           <td>Triggered when Chosen’s dropdown is opened.</td>
         </tr>

--- a/sass/chosen.scss
+++ b/sass/chosen.scss
@@ -108,7 +108,7 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
       display: block;
       width: 100%;
       height: 100%;
-      background: $chosen-sprite no-repeat 0px 2px;
+      background: $chosen-sprite no-repeat 0 0;
     }
   }
   .chosen-search {
@@ -420,6 +420,10 @@ $chosen-sprite-retina: url('chosen-sprite@2x.png') !default;
     background-image: $chosen-sprite-retina !important;
     background-size: 52px 37px !important;
     background-repeat: no-repeat !important;
+  }
+
+  .chosen-container-single .chosen-single div b {
+    background-position: 0 2px;
   }
 }
 /* @end */


### PR DESCRIPTION
The event is fired on the original selector when Chosen’s search results are updated after typing the search term.

The event also includes a corresponding `search_term` parameter.