### PR TITLE
support options with labels only

### DIFF
--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -24,15 +24,16 @@ class SelectParser
 
   add_option: (option, group_position, group_disabled) ->
     if option.nodeName.toUpperCase() is "OPTION"
-      if option.text != ""
+      option_text = if option.text != "" then option.text else option.label
+      if option_text != ""
         if group_position?
           @parsed[group_position].children += 1
         @parsed.push
           array_index: @parsed.length
           options_index: @options_index
           value: option.value
-          text: option.text
-          html: option.innerHTML
+          text: option_text
+          html: if option.innerHTML != "" then option.innerHTML else option_text
           title: option.title if option.title
           selected: option.selected
           disabled: if group_disabled is true then group_disabled else option.disabled


### PR DESCRIPTION
### Summary

Add support of options without `text`, but with `label`

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.
