### PR TITLE
Speed up rendering when there are lot of select choen

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -396,7 +396,7 @@ class Chosen extends AbstractChosen
       this.single_deselect_control_build()
       @selected_item.removeClass("chosen-default")
 
-    @selected_item.find("span").html(text)
+    @selected_item.find("span").text(text)
 
   result_deselect: (pos) ->
     result_data = @results_data[pos]


### PR DESCRIPTION
A simple change to speed up rendering when there are lots of select drop down to conver to select-chosen

<!---
Good pull requests — patches, improvements, new features — are a fantastic help.  They should remain focused in scope and avoid containing unrelated commits.

Please review the Pull Requests section of our Contributing Guidelines before submitting your work: https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests
-->

### Summary

Provide a general description of the code changes in your pull request.

Please double-check that:

  - [ ] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [ ] You haven't manually updated the version number in `package.json`.
  - [ ] If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together.
