### PR TITLE
Issue #3133: Use placeholder attribute for placeholder text.

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -347,7 +347,7 @@ class AbstractChosen
     """
       <ul class="chosen-choices">
         <li class="search-field">
-          <input class="chosen-search-input" type="text" autocomplete="off" value="#{@default_text}" />
+          <input class="chosen-search-input" type="text" autocomplete="off" placeholder="#{@default_text}" />
         </li>
       </ul>
       <div class="chosen-drop">


### PR DESCRIPTION
Fixes https://github.com/harvesthq/chosen/issues/3133

### Summary

* Switched placeholder text from `value` attribute to `placeholder` attribute on `input` element.

Please double-check that:

  - [x] All changes were made in CoffeeScript files, **not** JavaScript files.
  - [ ] You used [Grunt](https://github.com/harvesthq/chosen/blob/master/contributing.md#grunt) to build the JavaScript files and tested them locally.
  - [ ] You've updated both the jQuery *and* Prototype versions.
  - [x] You haven't manually updated the version number in `package.json`.
  - [x] N/A If necessary, you've updated [the documentation](https://github.com/harvesthq/chosen/blob/master/public/options.html).

See the [Pull Requests section of our Contributing Guidelines](https://github.com/harvesthq/chosen/blob/master/contributing.md#pull-requests) for more details.

### References

If your pull request is in reference to one or more open GitHub issues, please mention them here to keep the conversations linked together:
- https://github.com/harvesthq/chosen/issues/3133